### PR TITLE
Overwatch score tracker

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -454,6 +454,9 @@ button.display {
 button.display:hover {
   cursor: pointer;
 }
+button.display.short {
+  line-height: 1.3em;
+}
 
 input[type=checkbox].hidden {
   display: none;
@@ -658,11 +661,11 @@ select.display > option {
   padding-right: 0.25em;
   max-width: 50px;
 }
-.sr5 .inventory .item .item-img:hover {
+.sr5 .inventory .item .item-img.item-roll:hover {
   text-shadow: -1px -1px 0 darkblue, 1px -1px 0 darkblue, -1px 1px 0 darkblue, 1px 1px 0 darkblue;
   cursor: pointer;
 }
-.sr5 .inventory .item .item-img:hover > img {
+.sr5 .inventory .item .item-img.item-roll:hover > img {
   content: url("../ui/dice-solid.svg");
   filter: invert(1);
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -365,6 +365,10 @@
 
   "SR5.RollOneDie": "You can't roll less than 1 die, chummer",
 
+  "SR5.OverwatchScoreTrackerTitle": "Mr. Johnson's Baby Monitor",
+  "SR5.PlusFifteenMinutes": "+15min",
+  "SR5.Character": "Character",
+
   "SETTINGS.DiagonalMovementName": "Diagonal Movement",
   "SETTINGS.DiagonalMovementDescription": "How should diagonal movement be handled when using a grid",
   "SETTINGS.IgnoreDiagonal": "Ignore Diagonal Movement (1-1-1)",

--- a/lang/en.json
+++ b/lang/en.json
@@ -368,6 +368,11 @@
   "SR5.OverwatchScoreTrackerTitle": "Mr. Johnson's Baby Monitor",
   "SR5.PlusFifteenMinutes": "+15min",
   "SR5.Character": "Character",
+  "SR5.AddOneToOverwatch": "+1 to OS",
+  "SR5.AddFiveToOverwatch": "+5 to OS",
+  "SR5.AddFifteenMinutesToOverwatch": "Roll 2d6 for 15 minutes in the matrix",
+  "SR5.ResetOverwatchScore": "Reset Overwatch Score",
+
 
   "SETTINGS.DiagonalMovementName": "Diagonal Movement",
   "SETTINGS.DiagonalMovementDescription": "How should diagonal movement be handled when using a grid",

--- a/module/actor/entity.js
+++ b/module/actor/entity.js
@@ -17,6 +17,18 @@ export class SR5Actor extends Actor {
         return this;
     }
 
+    getOverwatchScore() {
+        const os = this.getFlag('shadowrun5e', 'overwatchScore');
+        return os !== undefined ? os : 0;
+    }
+
+    async setOverwatchScore(value) {
+        const num = parseInt(value);
+        if (!isNaN(num)) {
+            return this.setFlag('shadowrun5e', 'overwatchScore', num);
+        }
+    }
+
     prepareData() {
         super.prepareData();
 

--- a/module/apps/gmtools/OverwatchScoreTracker.js
+++ b/module/apps/gmtools/OverwatchScoreTracker.js
@@ -1,0 +1,48 @@
+/**
+ * A GM-Tool to keep track of all players overwatch scores
+ */
+export class OverwatchScoreTracker extends Application {
+    static get defaultOptions() {
+        const options = super.defaultOptions;
+        options.id = 'overwatch-score-tracker';
+        options.classes = ['sr5'];
+        options.title = game.i18n.localize('SR5.OverwatchScoreTrackerTitle');
+        options.template = 'systems/shadowrun5e/templates/apps/gmtools/overwatch-score-tracker.html';
+        options.width = 600;
+        options.height = 'auto';
+        return options;
+    }
+
+    getData() {
+        const actors = game.users.reduce((acc, user) => {
+            if (!user.isGM && user.character) {
+                acc.push(user.character.data);
+            }
+            return acc;
+        }, [])
+
+        console.log(actors);
+
+        return {
+            actors,
+        }
+    }
+
+    activateListeners(html) {
+        console.log(html);
+
+        html.find('.overwatch-score-reset').on('click', this._resetOverwatchScore.bind(this));
+    }
+
+    _getActorFromEvent(event) {
+        const id = event.currentTarget.closest('.item').dataset.actorId;
+        if (id) return game.actors.find(a => a._id === id);
+    }
+
+    _resetOverwatchScore(event) {
+        event.preventDefault();
+        const actor = this._getActorFromEvent(event);
+        console.log(actor);
+        console.log('reset ');
+    }
+}

--- a/module/apps/gmtools/OverwatchScoreTracker.js
+++ b/module/apps/gmtools/OverwatchScoreTracker.js
@@ -80,9 +80,9 @@ export class OverwatchScoreTracker extends Application {
             roll.roll();
 
             // use GM Roll Mode so players don't see
-            const rollMode = CONFIG.Dice.rollModes.gmroll;
+            // const rollMode = CONFIG.Dice.rollModes.gmroll;
+            // roll.toMessage({ rollMode });
 
-            roll.toMessage({ rollMode });
             if (roll.total) {
                 const os = actor.getOverwatchScore();
                 actor.setOverwatchScore(os + roll.total).then(() => this.render());

--- a/module/apps/gmtools/OverwatchScoreTracker.js
+++ b/module/apps/gmtools/OverwatchScoreTracker.js
@@ -9,8 +9,9 @@ export class OverwatchScoreTracker extends Application {
         options.title = game.i18n.localize('SR5.OverwatchScoreTrackerTitle');
         options.template =
             'systems/shadowrun5e/templates/apps/gmtools/overwatch-score-tracker.html';
-        options.width = 600;
+        options.width = 450;
         options.height = 'auto';
+        options.resizable = true;
         return options;
     }
 

--- a/module/apps/gmtools/OverwatchScoreTracker.js
+++ b/module/apps/gmtools/OverwatchScoreTracker.js
@@ -7,7 +7,8 @@ export class OverwatchScoreTracker extends Application {
         options.id = 'overwatch-score-tracker';
         options.classes = ['sr5'];
         options.title = game.i18n.localize('SR5.OverwatchScoreTrackerTitle');
-        options.template = 'systems/shadowrun5e/templates/apps/gmtools/overwatch-score-tracker.html';
+        options.template =
+            'systems/shadowrun5e/templates/apps/gmtools/overwatch-score-tracker.html';
         options.width = 600;
         options.height = 'auto';
         return options;
@@ -19,30 +20,65 @@ export class OverwatchScoreTracker extends Application {
                 acc.push(user.character.data);
             }
             return acc;
-        }, [])
-
-        console.log(actors);
+        }, []);
 
         return {
             actors,
-        }
+        };
     }
 
     activateListeners(html) {
-        console.log(html);
-
         html.find('.overwatch-score-reset').on('click', this._resetOverwatchScore.bind(this));
+        html.find('.overwatch-score-add').on('click', this._addOverwatchScore.bind(this));
+        html.find('.overwatch-score-input').on('change', this._setOverwatchScore.bind(this));
+        html.find('.overwatch-score-roll-15-minutes').on(
+            'click',
+            this._rollFor15Minutes.bind(this)
+        );
     }
 
     _getActorFromEvent(event) {
         const id = event.currentTarget.closest('.item').dataset.actorId;
-        if (id) return game.actors.find(a => a._id === id);
+        if (id) return game.actors.find((a) => a._id === id);
+    }
+
+    _setOverwatchScore(event) {
+        const actor = this._getActorFromEvent(event);
+        const amount = event.currentTarget.value;
+        if (amount && actor) {
+            actor.setOverwatchScore(amount).then(() => this.render());
+        }
+    }
+
+    _addOverwatchScore(event) {
+        const actor = this._getActorFromEvent(event);
+        const amount = parseInt(event.currentTarget.dataset.amount);
+        if (amount && actor) {
+            const os = actor.getOverwatchScore();
+            actor.setOverwatchScore(os + amount).then(() => this.render());
+        }
     }
 
     _resetOverwatchScore(event) {
         event.preventDefault();
         const actor = this._getActorFromEvent(event);
-        console.log(actor);
-        console.log('reset ');
+        if (actor) {
+            actor.setOverwatchScore(0).then(() => this.render());
+        }
+    }
+
+    _rollFor15Minutes(event) {
+        event.preventDefault();
+        const actor = this._getActorFromEvent(event);
+        if (actor) {
+            const roll = new Roll('2d6');
+            roll.toMessage({
+                rollMode: 'gmroll',
+            });
+            if (roll.total) {
+                const os = actor.getOverwatchScore();
+                actor.setOverwatchScore(os + roll.total).then(() => this.render());
+            }
+        }
     }
 }

--- a/module/apps/gmtools/OverwatchScoreTracker.js
+++ b/module/apps/gmtools/OverwatchScoreTracker.js
@@ -2,6 +2,7 @@
  * A GM-Tool to keep track of all players overwatch scores
  */
 export class OverwatchScoreTracker extends Application {
+    static MatrixOverwatchDiceCount = '2d6';
     static get defaultOptions() {
         const options = super.defaultOptions;
         options.id = 'overwatch-score-tracker';
@@ -16,6 +17,7 @@ export class OverwatchScoreTracker extends Application {
     }
 
     getData() {
+        // get list of actors that belong to users
         const actors = game.users.reduce((acc, user) => {
             if (!user.isGM && user.character) {
                 acc.push(user.character.data);
@@ -38,6 +40,7 @@ export class OverwatchScoreTracker extends Application {
         );
     }
 
+    // returns the actor that this event is acting on
     _getActorFromEvent(event) {
         const id = event.currentTarget.closest('.item').dataset.actorId;
         if (id) return game.actors.find((a) => a._id === id);
@@ -72,10 +75,14 @@ export class OverwatchScoreTracker extends Application {
         event.preventDefault();
         const actor = this._getActorFromEvent(event);
         if (actor) {
-            const roll = new Roll('2d6');
-            roll.toMessage({
-                rollMode: 'gmroll',
-            });
+            //  use static value so it can be modified in modules
+            const roll = new Roll(OverwatchScoreTracker.MatrixOverwatchDiceCount);
+            roll.roll();
+
+            // use GM Roll Mode so players don't see
+            const rollMode = CONFIG.Dice.rollModes.gmroll;
+
+            roll.toMessage({ rollMode });
             if (roll.total) {
                 const os = actor.getOverwatchScore();
                 actor.setOverwatchScore(os + roll.total).then(() => this.render());

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -137,6 +137,9 @@ button.display {
     &:hover {
         cursor: pointer;
     }
+    &.short {
+        line-height: 1.3em;
+    }
 }
 
 input[type='checkbox'].hidden {
@@ -339,11 +342,13 @@ select.display {
             .item-img {
                 padding-right: 0.25em;
                 max-width: 50px;
-                @include rollable;
-                &:hover {
-                    > img {
-                        content: url('../ui/dice-solid.svg');
-                        filter: invert(1);
+                &.item-roll {
+                    @include rollable;
+                    &:hover {
+                        > img {
+                            content: url('../ui/dice-solid.svg');
+                            filter: invert(1);
+                        }
                     }
                 }
                 > img {

--- a/shadowrun5e.js
+++ b/shadowrun5e.js
@@ -12,6 +12,7 @@ import { preCombatUpdate, shadowrunCombatUpdate } from './module/combat.js';
 import { measureDistance } from './module/canvas.js';
 import * as chat from './module/chat.js';
 import * as migrations from './module/migration.js';
+import { OverwatchScoreTracker } from './module/apps/gmtools/OverwatchScoreTracker.js';
 
 /* -------------------------------------------- */
 /*  Foundry VTT Initialization                  */
@@ -89,6 +90,22 @@ Hooks.on('hotbarDrop', (bar, data, slot) => {
     if (data.type !== 'Item') return;
     createItemMacro(data.data, slot);
     return false;
+});
+
+Hooks.on('renderSceneControls', (controls, html) => {
+    html.find('[data-tool="overwatch-score-tracker"]').on('click', (event) => {
+        event.preventDefault();
+        new OverwatchScoreTracker().render(true);
+    });
+});
+
+Hooks.on('getSceneControlButtons', (controls) => {
+    const tokenControls = controls.find(c => c.name === 'token');
+    tokenControls.tools.push({
+        name: 'overwatch-score-tracker',
+        title: 'CONTROLS.SR5.OverwatchScoreTracker',
+        icon: 'fas fa-network-wired',
+    });
 });
 
 // found at: https://helloacm.com/the-javascript-function-to-compare-version-number-strings/

--- a/shadowrun5e.js
+++ b/shadowrun5e.js
@@ -100,12 +100,14 @@ Hooks.on('renderSceneControls', (controls, html) => {
 });
 
 Hooks.on('getSceneControlButtons', (controls) => {
-    const tokenControls = controls.find(c => c.name === 'token');
-    tokenControls.tools.push({
-        name: 'overwatch-score-tracker',
-        title: 'CONTROLS.SR5.OverwatchScoreTracker',
-        icon: 'fas fa-network-wired',
-    });
+    if (game.user.isGM) {
+        const tokenControls = controls.find(c => c.name === 'token');
+        tokenControls.tools.push({
+            name: 'overwatch-score-tracker',
+            title: 'CONTROLS.SR5.OverwatchScoreTracker',
+            icon: 'fas fa-network-wired',
+        });
+    }
 });
 
 // found at: https://helloacm.com/the-javascript-function-to-compare-version-number-strings/

--- a/templates/apps/gmtools/overwatch-score-tracker.html
+++ b/templates/apps/gmtools/overwatch-score-tracker.html
@@ -36,9 +36,9 @@
                     </div>
                     <div class="item-text rtg"></div>
                     <div class="item-text" style="white-space: nowrap">
-                        <span class="overwatch-score-add-1 roll" title="{{localize 'SR5.AddOneToOverwatch'}}">+1</span>
+                        <span class="overwatch-score-add roll" title="{{localize 'SR5.AddOneToOverwatch'}}" data-amount="1">+1</span>
                         <span> / </span>
-                        <span class="overwatch-scorre-add-5 roll" title="{{localize 'SR5.AddFiveToOverwatch'}}">+5</span>
+                        <span class="overwatch-score-add roll" title="{{localize 'SR5.AddFiveToOverwatch'}}" data-amount="5">+5</span>
                         <span> / </span>
                         <span class="roll overwatch-score-roll-15-minutes" title="{{localize 'SR5.AddFifteenMinutesToOverwatch'}}">
                             {{localize "SR5.PlusFifteenMinutes"}}

--- a/templates/apps/gmtools/overwatch-score-tracker.html
+++ b/templates/apps/gmtools/overwatch-score-tracker.html
@@ -1,0 +1,59 @@
+<form class="{{cssClass}}" autocomplete="off">
+    <div class="inventory">
+        <div class="scroll-area">
+            <div class="item item-section">
+                <div class="item-left">
+                    <div class="item-text item-name">
+                        {{localize "SR5.Character"}}
+                    </div>
+                </div>
+            </div>
+            {{#each actors as |actor index|}}
+            <div class="item" data-actor-id="{{actor._id}}">
+                <div class="item-left">
+                    <div class="item-img">
+                        <img
+                            src="{{actor.img}}"
+                            title="{{actor.name}}"
+                            height="24px"
+                            width="24px"
+                        />
+                    </div>
+                    <div class="item-text item-name">
+                        {{actor.name}}
+                    </div>
+                </div>
+                <div class="item-right">
+                    <div class="item-text">
+                        <input
+                            class="display overwatch-score-input"
+                            size="3"
+                            type="text"
+                            value="{{actor.flags.shadowrun5e.overwatchScore}}"
+                            data-dtype="Number"
+                            placeholder="0"
+                        />
+                    </div>
+                    <div class="item-text rtg"></div>
+                    <div class="item-text" style="white-space: nowrap">
+                        <span class="overwatch-score-add-1 roll" title="{{localize 'SR5.AddOneToOverwatch'}}">+1</span>
+                        <span> / </span>
+                        <span class="overwatch-scorre-add-5 roll" title="{{localize 'SR5.AddFiveToOverwatch'}}">+5</span>
+                        <span> / </span>
+                        <span class="roll overwatch-score-roll-15-minutes" title="{{localize 'SR5.AddFifteenMinutesToOverwatch'}}">
+                            {{localize "SR5.PlusFifteenMinutes"}}
+                        </span>
+                    </div>
+                    <div class="item-text rtg"></div>
+                    <div class="item-text item-icons">
+                        <i
+                            class="roll fas fa-power-off overwatch-score-reset"
+                            title="{{localize 'SR5.ResetOverwatchScore'}}"
+                        ></i>
+                    </div>
+                </div>
+            </div>
+            {{/each}}
+        </div>
+    </div>
+</form>


### PR DESCRIPTION
Adds an Overwatch Score Tracker to the system, available in the Basic Tools Menu.

There's an issue with rollMode in the current versions of Foundry it seems so I'm not outputting the roll card for the moment.

Version number in system.json will need to be updated, I wasn't sure if that was something you can do as part of the PR or how we want to handle that.