### PR TITLE
Reported issue with overwriting skills and reopening item app windows

### DIFF
--- a/src/module/apps/skills/KnowledgeSkillEditForm.ts
+++ b/src/module/apps/skills/KnowledgeSkillEditForm.ts
@@ -3,12 +3,11 @@ import KnowledgeSkillCategory = Shadowrun.KnowledgeSkillCategory;
 
 export class KnowledgeSkillEditForm extends LanguageSkillEditForm {
     category: KnowledgeSkillCategory;
+    constructor(actor, options, skillId, category) {
+        super(actor, options, skillId);
+        this.category = category;
+    }
     _updateString() {
         return `data.skills.knowledge.${this.category}.value.${this.skillId}`;
-    }
-
-    constructor(actor, skillId, category, options) {
-        super(actor, skillId, options);
-        this.category = category;
     }
 }

--- a/src/module/apps/skills/SkillEditForm.ts
+++ b/src/module/apps/skills/SkillEditForm.ts
@@ -3,7 +3,7 @@ import SkillEditFormData = Shadowrun.SkillEditFormData;
 export class SkillEditForm extends BaseEntitySheet {
     skillId: string;
 
-    constructor(actor, skillId, options) {
+    constructor(actor, options, skillId) {
         super(actor, options);
         this.skillId = skillId;
     }

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -265,10 +265,28 @@ export class SR5ItemSheet extends ItemSheet {
         return $(this.element).find('.tab.active .scroll-area');
     }
 
+    /** This is needed to circumvent Application.close setting closed state early, due to it's async animation
+     * - The length of the closing animation can't be longer then any await time in the closing cycle
+     * - FormApplication._onSubmit will otherwise set ._state to RENDERED even if the Application window has closed already
+     * - Subsequent render calls then will show the window again, due to it's state
+     *
+     * @private
+     */
+    private fixStaleRenderedState() {
+        if (this._state === Application.RENDER_STATES.RENDERED && ui.windows[this.appId] === undefined) {
+            console.warn(`SR5ItemSheet app for ${this.entity.name} is set as RENDERED but has no window registered. Fixing app internal render state. This is a known bug.`);
+            // Hotfixing instead of this.close() since FormApplication.close() expects form elements, which don't exist anymore.
+            this._state = Application.RENDER_STATES.CLOSED;
+        }
+    }
+
     /**
      * @private
      */
     async _render(force = false, options = {}) {
+        // NOTE: This is for a timing bug. See function doc for code removal. Good luck, there be dragons here. - taM
+        this.fixStaleRenderedState();
+
         this._saveScrollPositions();
         await super._render(force, options);
         this._restoreScrollPositions();


### PR DESCRIPTION
- Fix overwriting skills by only allowing one skill app to open.
- Fix reopening ItemSheets due to update latency above closing animation length