### PR TITLE
Added missing item type back to action creation

### DIFF
--- a/src/templates/actor/parts/ActionList.html
+++ b/src/templates/actor/parts/ActionList.html
@@ -3,6 +3,7 @@
             name=(localize 'SR5.Actions')
             icons=(ItemHeaderIcons 'action')
             rightSide=(ItemHeaderRightSide 'action')
+            itemId='action'
     }}
     {{#each actions as |item iid|}}
         {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'


### PR DESCRIPTION
Creating a new actor action didn't work, due to actor/sheet rework:
![grafik](https://user-images.githubusercontent.com/146255/92617570-b5bd9f80-f2bf-11ea-874b-134f3473a563.png)
