### PR TITLE
Chat names from tokens

### DIFF
--- a/locale/de/config.json
+++ b/locale/de/config.json
@@ -524,6 +524,8 @@
   "SETTINGS.DisplayDefaultRollCardDescription": "Soll die Standard Würfelkarte zusammen mit der Shadowrun Würfelkarte angezeigt werden",
   "SETTINGS.ShowGlitchAnimationName": "Zeige Patzeranimation",
   "SETTINGS.ShowGlitchAnimationDescription": "Soll die Patzeranimation als Teil des Textes der Würfelkarte angezeigt werden",
+  "SETTINGS.ShowTokenNameForChatOutputName": "Token Namen für Würfelkarte",
+  "SETTINGS.ShowTokenNameForChatOutputDescription": "Soll der Namen des Tokens für die Würfelkarte angezeigt werden anstelle dem Namen des Actors, wenn ein Token verfügbar ist",
 
   "SR5.MIGRATION.WarningTitle": "Alarm",
   "SR5.MIGRATION.WarningHeader": "Migrationswarnung",

--- a/locale/en/config.json
+++ b/locale/en/config.json
@@ -536,6 +536,8 @@
     "SETTINGS.DisplayDefaultRollCardDescription": "Should the default roll-card be displayed along with the shadowrun roll-card",
     "SETTINGS.ShowGlitchAnimationName": "Display Glitch Animation",
     "SETTINGS.ShowGlitchAnimationDescription": "Should display the animation as part of the glitch text on the roll card",
+    "SETTINGS.ShowTokenNameForChatOutputName": "Use Token Name for Roll Card",
+    "SETTINGS.ShowTokenNameForChatOutputDescription": "Should the token name be used for roll card output instead of the actor name when available",
 
     "SR5.MIGRATION.WarningTitle": "Alert",
     "SR5.MIGRATION.WarningHeader": "Migration Warning",

--- a/src/module/chat.ts
+++ b/src/module/chat.ts
@@ -55,7 +55,7 @@ export const createChatData = async (templateData: TemplateData, roll?: Roll) =>
         speaker: {
             actor: actor?._id,
             token: actor?.token,
-            alias: actor?.name,
+            alias: templateData.header.name,
         },
         flags: {
             shadowrun5e: {

--- a/src/module/constants.ts
+++ b/src/module/constants.ts
@@ -1,4 +1,5 @@
 export const SYSTEM_NAME = 'shadowrun5e';
 export const FLAGS = {
     ShowGlitchAnimation: 'showGlitchAnimation',
+    ShowTokenNameForChatOutput: 'showTokenNameInsteadOfActor'
 };

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -258,6 +258,7 @@ export class SR5Item extends Item {
                 const attack = this.getAttackData(0);
                 // don't include any hits
                 delete attack?.hits;
+                console.error('SR5Item Roll');
                 // generate chat data
                 createChatData({
                     header: {

--- a/src/module/rolls/ShadowrunRoller.ts
+++ b/src/module/rolls/ShadowrunRoller.ts
@@ -8,7 +8,7 @@ import { Helpers } from '../helpers';
 import { SR5Actor } from '../actor/SR5Actor';
 import { SR5Item } from '../item/SR5Item';
 import { createChatData, TemplateData } from '../chat';
-import { SYSTEM_NAME } from '../constants';
+import {FLAGS, SYSTEM_NAME} from '../constants';
 import { PartsList } from '../parts/PartsList';
 
 export interface BasicRollProps {
@@ -177,6 +177,13 @@ export class ShadowrunRoller {
             });
             glitch = oneCount > Math.floor(parts.total / 2);
         }
+
+        const useTokenNameForChatOutput = game.settings.get(SYSTEM_NAME, FLAGS.ShowTokenNameForChatOutput);
+        if (useTokenNameForChatOutput && token) {
+            img = token?.data.img;
+            name = token?.data.name;
+        }
+
 
         const templateData = {
             actor: actor,

--- a/src/module/rolls/ShadowrunRoller.ts
+++ b/src/module/rolls/ShadowrunRoller.ts
@@ -178,12 +178,7 @@ export class ShadowrunRoller {
             glitch = oneCount > Math.floor(parts.total / 2);
         }
 
-        const useTokenNameForChatOutput = game.settings.get(SYSTEM_NAME, FLAGS.ShowTokenNameForChatOutput);
-        if (useTokenNameForChatOutput && token) {
-            img = token?.data.img;
-            name = token?.data.name;
-        }
-
+        [name, img] = ShadowrunRoller.getPreferedNameAndImageSource(name, img, actor, token);
 
         const templateData = {
             actor: actor,
@@ -355,5 +350,22 @@ export class ShadowrunRoller {
                 }).render(true);
             });
         });
+    }
+
+    /** Use either the actor or the tokens name and image, depending on system settings.
+     *
+     * However don't change anything if a custom name or image has been given.
+     */
+    static getPreferedNameAndImageSource(name?: string, img?: string, actor?: SR5Actor, token?: Token): [string|undefined, string|undefined] {
+
+        const namedAndImageMatchActor = name === actor?.name && img === actor?.img;
+        const useTokenNameForChatOutput = game.settings.get(SYSTEM_NAME, FLAGS.ShowTokenNameForChatOutput);
+
+        if (namedAndImageMatchActor && useTokenNameForChatOutput && token) {
+            img = token?.data.img;
+            name = token?.data.name;
+        }
+
+        return [name, img];
     }
 }

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -61,5 +61,14 @@ export const registerSystemSettings = () => {
         config: true,
         type: Boolean,
         default: true,
-    })
+    });
+
+    game.settings.register(SYSTEM_NAME, FLAGS.ShowTokenNameForChatOutput, {
+        name: 'SETTINGS.ShowTokenNameForChatOutputName',
+        hint: 'SETTINGS.ShowTokenNameForChatOutputDescription',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true
+    });
 };


### PR DESCRIPTION
Allow gamemasters to choose wether they want to use the token or the actor name / img for roll chat messages using a system setting.

Should a roll be initiated from within the actorsheet without a token placed on map, the actor name / img will be used, even if otherwise stated in the settings.

Should a custom name / img be used, that doesn't match the actor name / img, this will be used instead, allow item rolls to still function unaffected.