### PR TITLE
Removed trailing comma

### DIFF
--- a/locale/de/config.json
+++ b/locale/de/config.json
@@ -542,5 +542,5 @@
 
   "CONTROLS.SR5.OverwatchScoreTracker": "Overwatch Wert Übersicht",
 
-  "SR5.DIALOG.MissingModuleContent": "Um das Quell-PDF anzuzeigen, muss das Modul PDFoundry installiert sein und ein PDF mit passendem Code erstellt werden.",
+  "SR5.DIALOG.MissingModuleContent": "Um das Quell-PDF anzuzeigen, muss das Modul PDFoundry installiert sein und ein PDF mit passendem Code erstellt werden."
 }


### PR DESCRIPTION
JSON parser beeing very correct with it's handling of a trailing comma.