### PR TITLE
Fixed embeddedItems ActiveEffects datatype after setFlag/getFlag flow.

### DIFF
--- a/src/module/constants.ts
+++ b/src/module/constants.ts
@@ -2,7 +2,8 @@ export const SYSTEM_NAME = 'shadowrun5e';
 export const FLAGS = {
     ShowGlitchAnimation: 'showGlitchAnimation',
     ShowTokenNameForChatOutput: 'showTokenNameInsteadOfActor',
-    MessageCustomRoll: 'customRoll'
+    MessageCustomRoll: 'customRoll',
+    EmbeddedItems: 'embeddedItems'
 };
 export const GLITCH_DIE = 1;
 export const METATYPEMODIFIER = 'SR5.Character.Modifiers.NPCMetatypeAttribute';

--- a/src/module/helpers.ts
+++ b/src/module/helpers.ts
@@ -215,4 +215,13 @@ export class Helpers {
 
         return name.slice(0, length).toUpperCase();
     }
+
+    static convertIndexedObjectToArray(indexedObject: object): object[] {
+        return Object.keys(indexedObject).map(index => {
+            if (Number.isNaN(index)) {
+                console.warn('An object with no numerical index was given, which is likely a bug.', indexedObject);
+            }
+            return indexedObject[index];
+        })
+    }
 }

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -14,7 +14,7 @@ import BlastData = Shadowrun.BlastData;
 import { ChatData } from './ChatData';
 import { AdvancedRollProps, ShadowrunRoll, ShadowrunRoller } from '../rolls/ShadowrunRoller';
 import { createChatData } from '../chat';
-import { SYSTEM_NAME } from '../constants';
+import {FLAGS, SYSTEM_NAME} from '../constants';
 import ConditionData = Shadowrun.ConditionData;
 import { SR5ItemDataWrapper } from './SR5ItemDataWrapper';
 import SR5ItemType = Shadowrun.SR5ItemType;
@@ -61,21 +61,26 @@ export class SR5Item extends Item {
      * TODO properly types this
      */
     getEmbeddedItems(): any[] {
-        let items = this.getFlag(SYSTEM_NAME, 'embeddedItems');
-        if (items) {
-            // moved this "hotfix" to here so that everywhere that accesses the flag just gets an array -- Shawn
-            //TODO: This is a hotfix. Items should either always be
-            // stored as an array or always be stored as a object.
-            if (!Array.isArray(items)) {
-                let newItems: any[] = [];
-                for (const key of Object.keys(items)) {
-                    newItems.push(items[key]);
-                }
-                return newItems;
-            }
-            return items;
+        let items = this.getFlag(SYSTEM_NAME, FLAGS.EmbeddedItems);
+
+        items = items ? items : [];
+
+        // moved this "hotfix" to here so that everywhere that accesses the flag just gets an array -- Shawn
+        //TODO: This is a hotfix. Items should either always be
+        // stored as an array or always be stored as a object.
+        if (items && !Array.isArray(items)) {
+            items = Helpers.convertIndexedObjectToArray(items);
         }
-        return [];
+
+        // Manually map wrongly converted array fields...
+        items = items.map(item => {
+            if (item.effects && !Array.isArray(item.effects)) {
+                item.effects = Helpers.convertIndexedObjectToArray(item.effects);
+            }
+            return item;
+        });
+
+        return items;
     }
 
     /**
@@ -85,11 +90,11 @@ export class SR5Item extends Item {
     async setEmbeddedItems(items: any[]) {
         // clear the flag first to remove the previous items - if we don't do this then it doesn't actually "delete" any items
         // await this.unsetFlag(SYSTEM_NAME, 'embeddedItems');
-        await this.setFlag(SYSTEM_NAME, 'embeddedItems', items);
+        await this.setFlag(SYSTEM_NAME, FLAGS.EmbeddedItems, items);
     }
 
     async clearEmbeddedItems() {
-        await this.unsetFlag(SYSTEM_NAME, 'embeddedItems');
+        await this.unsetFlag(SYSTEM_NAME, FLAGS.EmbeddedItems);
     }
 
     getLastAttack(): AttackData | undefined {
@@ -682,6 +687,7 @@ export class SR5Item extends Item {
         await this.prepareEmbeddedEntities();
         await this.prepareData();
         await this.render(false);
+
         return true;
     }
 


### PR DESCRIPTION
Didn't find the actual conversion of arrays into index objects, so I rebuild getEmbeddedItems a bit and used the same kind of solution.
Also: System / Module Active Effects are stored as an array in the Entity.data field, however Foundry converts that into a Collection in Entity.effects. The actual item data fits that and it's only after the setFlag/getFlag flow that it Entity.data.effects breaks.