### PR TITLE
Fix critter stun track

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -1,0 +1,38 @@
+# Local development environment
+
+## Linux
+
+On Linux you can use `docker` (or another container runtime like `podman`) to
+quickly setup a local instance of `foundry`:
+
+This will use `docker-compose` (or `podman-compose`) to manage the containers.
+
+It requires some manual setup to make the `foundryvtt.zip` avaiable for
+installation:
+
+1. Create a `data` and a `data/cache` directory - this will host all files of
+   the installation: `mkdir -p data/cache`
+2. Download the desired version of foundry from your account as `zip` and place
+   it inside the `data/cache` folder (this version has to match the version of
+   the container-image in `docker-compose.yml`):
+
+``` sh
+wget -O data/cache/foundryvtt-$SOME_VERSION.zip $URL_TO_DOWNLOAD_LINK
+```
+3. Spin up `foundryvtt` using `docker-compose`:
+
+``` sh
+# This command must be run inside the root directory of this repository
+# It will automatically symlink this system into data/Data/systems
+docker-compose up
+```
+
+Now an instance of `foundryvtt` will be running on http://localhost:30000
+
+If you need to restart the instance:
+
+``` sh
+docker-compose down
+docker-compose up
+```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.8"
+
+services:
+  foundry:
+    image: felddy/foundryvtt:release
+    hostname: my_foundry_host
+    init: true
+    restart: "unless-stopped"
+    volumes:
+      - type: bind
+        source: ./data
+        target: /data
+        bind:
+          propagation: 'Z'
+      - type: bind
+        source: ./data/cache/
+        target: /cache/
+        bind:
+          propagation: 'Z'
+      - type: bind
+        source: .
+        target: /data/Data/systems/shadowrun5e/
+        bind:
+          propagation: 'Z'
+    environment:
+      - CONTAINER_CACHE=/cache/
+      - FOUNDRY_ADMIN_KEY=123456789
+      - FOUNDRY_LICENSE_KEY=''
+      - FOUNDRY_UID=0
+      - FOUNDRY_GID=0
+    ports:
+      - "30000:30000/tcp"

--- a/src/module/actor/prep/CritterPrep.ts
+++ b/src/module/actor/prep/CritterPrep.ts
@@ -49,7 +49,7 @@ export class CritterPrep extends BaseActorPrep<SR5CritterType, CritterActorData>
         const {track, modifiers} = data;
 
         track.stun.max = Number(modifiers['stun_track']);
-        track.stun.label = CONFIG.SR5.damageTypes.physical;
+        track.stun.label = CONFIG.SR5.damageTypes.stun;
         track.stun.disabled = false;
 
         track.physical.max = Number(modifiers['physical_track']);


### PR DESCRIPTION
This should fix #289 to correctly show `Stun`.

I also added `docker-compose.yml` file that I used to run a local instance for testing with `podman`.

Not sure if you want this - if not I can quickly rebase that commit out of this MR.