### PR TITLE
Small bugfixes and improvements in the chummer import

### DIFF
--- a/dist/templates/apps/import.html
+++ b/dist/templates/apps/import.html
@@ -18,6 +18,8 @@
             Qualities<input type="checkbox" class="qualities" checked />
             Powers<input type="checkbox" class="powers" checked />
             Spells<input type="checkbox" class="spells" checked />
+            Contacts<input type="checkbox" class="contacts" checked />
+            Lifestyles<input type="checkbox" class="lifestyles" checked />
         </div>
         <textarea class="chummer-text" rows="20" cols="50"> </textarea>
         <button type="button" class="submit-chummer-import">Submit</button>

--- a/src/module/actor/prep/functions/SkillsPrep.ts
+++ b/src/module/actor/prep/functions/SkillsPrep.ts
@@ -10,7 +10,17 @@ export class SkillsPrep {
     static prepareSkills(data: SR5ActorData) {
         const { language, active, knowledge } = data.skills;
         if (language) {
-            if (!language.value) language.value = {};
+            if (!language.value) {
+                language.value = {};
+            }
+
+            // language.value is defined as an array in template.json 
+            // However what we actually want here is an object, so we set it manually
+            // The same is done for the other knowledge skillgroups 'value' properties below
+            if (Array.isArray(language.value) && language.value.length == 0) {
+                language.value = {};
+            }
+
             language.attribute = 'intuition';
         }
 
@@ -35,7 +45,7 @@ export class SkillsPrep {
                 prepareSkill(skill);
             }
         }
-
+  
         const entries = Object.entries(data.skills.language.value);
         // remove entries which are deleted TODO figure out how to delete these from the data
         entries.forEach(([key, val]: [string, { _delete?: boolean }]) => val._delete && delete data.skills.language.value[key]);

--- a/src/module/apps/characterImport/gearImport/AmmoParser.ts
+++ b/src/module/apps/characterImport/gearImport/AmmoParser.ts
@@ -1,0 +1,34 @@
+import { BaseGearParser } from "./BaseGearParser"
+
+/**
+ * Parses ammunition
+ */
+export class AmmoParser extends BaseGearParser {
+   
+    parse(chummerGear : any) : any {
+        const parsedGear =  super.parse(chummerGear);
+        parsedGear.type = 'ammo';
+        parsedGear.data.technology.rating = chummerGear.devicerating;
+
+        if (chummerGear.weaponbonusap) {
+            parsedGear.data.ap = parseInt(chummerGear.weaponbonusap);
+        }
+
+        if (chummerGear.weaponbonusdamage) {
+            parsedGear.data.damage = parseInt(chummerGear.weaponbonusdamage);
+
+            if (chummerGear.weaponbonusdamage.includes('P')) {
+                parsedGear.data.damageType = 'physical';
+            } else if (chummerGear.weaponbonusdamage.includes('S')) {
+                parsedGear.data.damageType = 'stun';
+            } else if (chummerGear.weaponbonusdamage.includes('M')) {
+                parsedGear.data.damageType = 'matrix';
+            }
+            else {
+                parsedGear.data.damageType = 'physical';
+            }
+        }
+
+        return parsedGear;
+    }
+}

--- a/src/module/apps/characterImport/gearImport/BaseGearParser.ts
+++ b/src/module/apps/characterImport/gearImport/BaseGearParser.ts
@@ -23,12 +23,18 @@ export class BaseGearParser implements GearParser {
 
         parsedGear.data.technology.rating = chummerGear.rating;
         parsedGear.data.technology.quantity = chummerGear.qty;
+        parsedGear.data.technology.availability = chummerGear.avail;
         parsedGear.data.description =
         {
             value: '',
             chat: '',
-            source: `${chummerGear.source} ${chummerGear.page}`
+            source: ''
         };
+
+        if (chummerGear.source && chummerGear.page)
+        {
+            parsedGear.data.description.source = `${chummerGear.source} ${chummerGear.page}`;
+        }
 
         return parsedGear;
     }

--- a/src/module/apps/characterImport/gearImport/GearsParser.ts
+++ b/src/module/apps/characterImport/gearImport/GearsParser.ts
@@ -14,6 +14,11 @@ export class GearsParser {
 
         chummerGears.forEach((chummerGear) => {
             try {
+                // First filter out gear entries, that we do not want to handle.
+                if (!this.gearShouldBeParsed(chummerGear)) {
+                    return;
+                }
+
                 const itemsData = this.parseGearEntry(chummerGear);
                 items.push(itemsData);
             }
@@ -30,5 +35,18 @@ export class GearsParser {
         const parserSelector = new ParserSelector();
         const parser = parserSelector.select(chummerGear);
         return parser.parse(chummerGear);
+    }
+
+    private gearShouldBeParsed(chummerGear : any) : boolean {
+        // We do not handle grenades and rockets here since they are also in the weapons section with more info.
+        const englishGearName = (chummerGear.name_english as string).toLowerCase();
+        if (englishGearName.startsWith('grenade') || 
+            englishGearName.startsWith('minigrenade') || 
+            englishGearName.startsWith('rocket'))
+        {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/module/apps/characterImport/gearImport/ParserSelector.ts
+++ b/src/module/apps/characterImport/gearImport/ParserSelector.ts
@@ -2,6 +2,7 @@ import { GearParser, BaseGearParser } from "./BaseGearParser";
 import { SinParser } from "./SinParser";
 import { DeviceParser } from "./DeviceParser";
 import { ProgramParser } from "./ProgramParser";
+import { AmmoParser } from "./AmmoParser";
 
 /**
  * Responsible for selecting the correct GearParser depending on the gear.
@@ -22,6 +23,11 @@ export class ParserSelector {
         if (chummerGear.iscommlink === 'True')
         {
             return new DeviceParser();
+        }
+
+        if (chummerGear.isammo === 'True')
+        {
+            return new AmmoParser();
         }
 
         if (chummerGear.category === 'Common Programs' || 

--- a/src/module/apps/chummer-import-form.js
+++ b/src/module/apps/chummer-import-form.js
@@ -29,7 +29,9 @@ export class ChummerImportForm extends FormApplication {
                 equipment: $('.gear').is(':checked'),
                 qualities: $('.qualities').is(':checked'),
                 powers: $('.powers').is(':checked'),
-                spells: $('.spells').is(':checked')
+                spells: $('.spells').is(':checked'),
+                contacts: $('.contacts').is(':checked'),
+                lifestyles: $('.lifestyles').is(':checked'),
             }
 
             const importer = new CharacterImporter();

--- a/src/templates/apps/import.html
+++ b/src/templates/apps/import.html
@@ -18,6 +18,8 @@
             Qualities<input type="checkbox" class="qualities" checked />
             Powers<input type="checkbox" class="powers" checked />
             Spells<input type="checkbox" class="spells" checked />
+            Contacts<input type="checkbox" class="contacts" checked />
+            Lifestyles<input type="checkbox" class="lifestyles" checked />
         </div>
         <textarea class="chummer-text" rows="20" cols="50"> </textarea>
         <button type="button" class="submit-chummer-import">Submit</button>


### PR DESCRIPTION
Import: Added support for description, background, concept and notes (closes #300)
Import: Added support for contacts (group contacts are handled as normal contacts for now) (closes #301)
Import: Added support for lifestyles (closes #310)
Import: Fixed adept power points import (fixes #308)
Import: Languages were not correctly imported because language.value was setup as an array instead of an object (fixes #316)
Import: Ammunition is now marked as ammo and the stats are imported - however it cannot yet be equipped into a weapon :( (fixes #309)
Import: Fixed pilot watercraft skill import 

Import: Added skill name to adept power "Improved skill"
Import: Grenades & rockets are no longer imported twice (previously they were in weapons and gear section)
Import: Added rating for gear items, still missing on the other items
Import: Display nothing instead of "null" in the item sheet when there is no source / page specified on the item