### PR TITLE
Changes the german translation of "SR5.Target" form a verb to a noun.

### DIFF
--- a/locale/de/config.json
+++ b/locale/de/config.json
@@ -82,7 +82,7 @@
     "SR5.RunningSilent": "Auf Schleichfahrt",
     "SR5.ConditionMonitor": "Monitor",
     "SR5.ComplexForms": "Komplexe Formen",
-    "SR5.Target": "Zielen",
+    "SR5.Target": "Ziel",
     "SR5.Fade": "Schwund",
 
     "SR5.Duration": "Dauer",


### PR DESCRIPTION
The "SR5.Target" localization string is currently only used in the context of Complex Forms, which have a "Target" attribute describing the type of icon that can be targeted by that Complex Form. The German translation of the noun "Target" is "Ziel" not the currently used translation "Zielen", which is the verb. The German source book also uses the word "Ziel" when talking about the target properties of Complex Forms.