### PR TITLE
Allow french

### DIFF
--- a/system.json
+++ b/system.json
@@ -24,6 +24,11 @@
             "lang": "pt-BR",
             "name": "Português (Brasil)",
             "path": "dist/locale/pt-BR/config.json"
+        },
+        {
+            "lang": "fr",
+            "name": "Français",
+            "path": "dist/locale/fr/config.json"
         }
     ],
     "packs": [


### PR DESCRIPTION
Following the addition of the config.json file of the french translation, here comes the change in the system file to allow the use of french.

Quentin