### PR TITLE
Better `gulp link` output

### DIFF
--- a/gulp.tasks.js
+++ b/gulp.tasks.js
@@ -121,9 +121,12 @@ async function linkUserData() {
             throw Error('No User Data path defined in foundryconfig.json');
         }
 
-        if (!fs.existsSync(linkDir)) {
+        if (fs.existsSync(linkDir)) {
+            if (!fs.statSync(linkDir).isSymbolicLink())
+                throw Error(`${chalk.blueBright(linkDir)} is not a link. Please delete or rename folder then run ${chalk.greenBright('link')} command again`);
+        } else {
             console.log(
-                chalk.green(`Copying build to ${chalk.blueBright(linkDir)}`)
+                chalk.green(`Linking build to ${chalk.blueBright(linkDir)}`)
             );
             await fs.symlink(path.resolve('./'), linkDir);
         }


### PR DESCRIPTION
Make an error when running link command and the system folder is not ready for linking.