### PR TITLE
Renames and readability

### DIFF
--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -132,7 +132,7 @@ export class SR5Actor extends Actor {
      * Check base, embeddedEntities and derived methods (see super.prepareData implementation for order)
      * Only implement data preparation here that doesn't fall into the other three categories.
      */
-    prepareData() {
+    override prepareData() {
         super.prepareData();
     }
 
@@ -143,7 +143,7 @@ export class SR5Actor extends Actor {
      *  Shadowrun data preparation is separate from the actor entity see the different <>Prep classes like
      *  CharacterPrep
      */
-    prepareBaseData() {
+    override prepareBaseData() {
         super.prepareBaseData();
 
         switch (this.type) {
@@ -177,7 +177,7 @@ export class SR5Actor extends Actor {
     /**
      * prepare embedded entities. Check ClientDocumentMixin.prepareData for order of data prep.
      */
-    prepareEmbeddedDocuments() {
+    override prepareEmbeddedDocuments() {
         // This will apply ActiveEffects, which is okay for modify (custom) effects, however add/multiply on .value will be
         // overwritten.
         super.prepareEmbeddedDocuments();
@@ -192,7 +192,7 @@ export class SR5Actor extends Actor {
      * Should some ActiveEffects need to be excluded from the general application, do so here.
      * @override
      */
-    applyActiveEffects() {
+    override applyActiveEffects() {
         // Shadowrun uses prepareDerivedData to calculate lot's of things that don't exist on the data model in full.
         // Errors during change application will stop that process and cause a broken sheet.
         try {
@@ -210,7 +210,7 @@ export class SR5Actor extends Actor {
      * At the moment general actor data preparation has been moved to derived data preparation, due it's dependence
      * on prepareEmbeddedEntities and prepareEmbeddedItems for items modifying attribute values and more.
      */
-    prepareDerivedData() {
+    override prepareDerivedData() {
         super.prepareDerivedData();
 
         // General actor data preparation has been moved to derived data, as it depends on prepared item data.

--- a/src/module/actor/flows/ModifierFlow.ts
+++ b/src/module/actor/flows/ModifierFlow.ts
@@ -23,10 +23,10 @@ export interface ModifierFlowOptions {
  */
 export class ModifierFlow {
     // The actor document to retrieve modifiers for.
-    document: SR5Actor;
+    actor: SR5Actor;
 
-    constructor(document: SR5Actor) {
-        this.document = document;
+    constructor(actor: SR5Actor) {
+        this.actor = actor;
     }
 
     /**
@@ -41,18 +41,18 @@ export class ModifierFlow {
         if (this[name] !== undefined) return this[name];
 
         // Get global modifiers that can come from the general modifier system.
-        const modifiers = this.document.getSituationModifiers(options);
+        const modifiers = this.actor.getSituationModifiers(options);
         //@ts-ignore
         if (modifiers.handlesTotalFor(name)) return modifiers.getTotalFor(name, options);
 
         // Get global modifiers that come from the legacy actor modifier system.
-        return Number(this.document.system.modifiers[name] ?? 0);
+        return Number(this.actor.system.modifiers[name] ?? 0);
     }
 
     /**
      * Translate simple modifier type string to the differently named actor / document method.
      */
     get wounds(): number {
-        return this.document.getWoundModifier();
+        return this.actor.getWoundModifier();
     }
 }

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -97,13 +97,12 @@ export class SR5BaseActorSheet extends ActorSheet {
     // Store the currently selected inventory.
     selectedInventory: string;
 
-
     constructor(...args) {
         // @ts-ignore // Since we don't need any actual data, don't define args to avoid breaking changes.
         super(...args);
 
         // Preselect default inventory.
-        this.selectedInventory = this.document.defaultInventory.name;
+        this.selectedInventory = this.actor.defaultInventory.name;
     }
 
     /**
@@ -206,7 +205,7 @@ export class SR5BaseActorSheet extends ActorSheet {
         this._prepareSkillsWithFilters(data);
 
         data.itemType = this._prepareItemTypes(data);
-        data.effects = prepareActiveEffectCategories(this.document.effects);  // All actor types have effects.
+        data.effects = prepareActiveEffectCategories(this.actor.effects);  // All actor types have effects.
         data.inventories = this._prepareItemsInventory();
         data.inventory = this._prepareSelectedInventory(data.inventories);
         data.hasInventory = this._prepareHasInventory(data.inventories);
@@ -233,7 +232,7 @@ export class SR5BaseActorSheet extends ActorSheet {
         Helpers.setupCustomCheckbox(this, html)
 
         // Active Effect management
-        html.find(".effect-control").on('click',event => onManageActiveEffect(event, this.document));
+        html.find(".effect-control").on('click',event => onManageActiveEffect(event, this.actor));
 
         // General item CRUD management...
         html.find('.item-create').on('click', this._onItemCreate.bind(this));
@@ -430,7 +429,7 @@ export class SR5BaseActorSheet extends ActorSheet {
         // Add any created items to the selected inventory.
         if (Array.isArray(documents)) {
             const items = documents.filter(document => document instanceof SR5Item);
-            await this.document.inventory.addItems(this.selectedInventory, items);
+            await this.actor.inventory.addItems(this.selectedInventory, items);
         }
 
         return documents;
@@ -523,8 +522,8 @@ export class SR5BaseActorSheet extends ActorSheet {
         if (!items) return;
 
         // Add the item to the selected inventory.
-        if (this.selectedInventory !== this.document.defaultInventory.name)
-            await this.document.inventory.addItems(this.selectedInventory, items);
+        if (this.selectedInventory !== this.actor.defaultInventory.name)
+            await this.actor.inventory.addItems(this.selectedInventory, items);
     }
 
     async _onItemEdit(event) {
@@ -781,23 +780,23 @@ export class SR5BaseActorSheet extends ActorSheet {
 
         // All inventories for showing all items, but not as default
         // Add first, for it to appear on top.
-        inventoriesSheet[this.document.allInventories.name] = {
-            name: this.document.allInventories.name,
-            label: this.document.allInventories.label,
+        inventoriesSheet[this.actor.allInventories.name] = {
+            name: this.actor.allInventories.name,
+            label: this.actor.allInventories.label,
             types: {}
         };
-        this._addInventoryTypes(inventoriesSheet[this.document.allInventories.name]);
+        this._addInventoryTypes(inventoriesSheet[this.actor.allInventories.name]);
 
         // Default inventory for items without a defined one.
         // Add first for display purposes on sheet.
-        inventoriesSheet[this.document.defaultInventory.name] = {
-            name: this.document.defaultInventory.name,
-            label: this.document.defaultInventory.label,
+        inventoriesSheet[this.actor.defaultInventory.name] = {
+            name: this.actor.defaultInventory.name,
+            label: this.actor.defaultInventory.label,
             types: {}
         };
-        this._addInventoryTypes(inventoriesSheet[this.document.defaultInventory.name]);
+        this._addInventoryTypes(inventoriesSheet[this.actor.defaultInventory.name]);
 
-        Object.values(this.document.system.inventories).forEach(inventory => {
+        Object.values(this.actor.system.inventories).forEach(inventory => {
             const {name, label, itemIds} = inventory
 
             // Avoid re-adding default inventories.
@@ -821,7 +820,7 @@ export class SR5BaseActorSheet extends ActorSheet {
         const handledTypes = this.getHandledItemTypes();
 
         // Check all items and using the item to inventory mapping add them to that inventory.
-        this.document.items.forEach((item) => {
+        this.actor.items.forEach((item) => {
             if (!item.id) return;
 
             // Handled types are on the sheet outside the inventory.
@@ -830,7 +829,7 @@ export class SR5BaseActorSheet extends ActorSheet {
             const sheetItem = this._prepareSheetItem(item);
 
             // Determine what inventory the item sits in.
-            const inventory = itemIdInventory[item.id] || this.document.defaultInventory;
+            const inventory = itemIdInventory[item.id] || this.actor.defaultInventory;
             // Build inventory list this item should be shown an.
             const addTo: string[] = inventory.showAll ? Object.keys(inventoriesSheet) : [inventory.name];
 
@@ -918,7 +917,7 @@ export class SR5BaseActorSheet extends ActorSheet {
         });
 
         // Add existing items to their types as sheet items
-        this.document.items.forEach((item: SR5Item) => {
+        this.actor.items.forEach((item: SR5Item) => {
             const sheetItem = this._prepareSheetItem(item);
             itemType[sheetItem.type].push(sheetItem);
         });
@@ -956,7 +955,7 @@ export class SR5BaseActorSheet extends ActorSheet {
     async _onMarksQuantityChange(event) {
         event.stopPropagation();
 
-        if (this.object.isIC() && this.object.hasHost()) {
+        if (this.actor.isIC() && this.actor.hasHost()) {
             return ui.notifications?.info(game.i18n.localize('SR5.Infos.CantModifyHostContent'));
         }
 
@@ -969,13 +968,13 @@ export class SR5BaseActorSheet extends ActorSheet {
         if (!scene || !target) return; // item can be undefined.
 
         const marks = parseInt(event.currentTarget.value);
-        await this.object.setMarks(target, marks, {scene, item, overwrite: true});
+        await this.actor.setMarks(target, marks, {scene, item, overwrite: true});
     }
 
     async _onMarksQuantityChangeBy(event, by: number) {
         event.stopPropagation();
 
-        if (this.object.isIC() && this.object.hasHost()) {
+        if (this.actor.isIC() && this.actor.hasHost()) {
             return ui.notifications?.info(game.i18n.localize('SR5.Infos.CantModifyHostContent'));
         }
 
@@ -987,13 +986,13 @@ export class SR5BaseActorSheet extends ActorSheet {
         const {scene, target, item} = markedDocuments;
         if (!scene || !target) return; // item can be undefined.
 
-        await this.object.setMarks(target, by, {scene, item});
+        await this.actor.setMarks(target, by, {scene, item});
     }
 
     async _onMarksDelete(event) {
         event.stopPropagation();
 
-        if (this.object.isIC() && this.object.hasHost()) {
+        if (this.actor.isIC() && this.actor.hasHost()) {
             return ui.notifications?.info(game.i18n.localize('SR5.Infos.CantModifyHostContent'));
         }
 
@@ -1003,20 +1002,20 @@ export class SR5BaseActorSheet extends ActorSheet {
         const userConsented = await Helpers.confirmDeletion();
         if (!userConsented) return;
 
-        await this.object.clearMark(markId);
+        await this.actor.clearMark(markId);
     }
 
     async _onMarksClearAll(event) {
         event.stopPropagation();
 
-        if (this.object.isIC() && this.object.hasHost()) {
+        if (this.actor.isIC() && this.actor.hasHost()) {
             return ui.notifications?.info(game.i18n.localize('SR5.Infos.CantModifyHostContent'));
         }
 
         const userConsented = await Helpers.confirmDeletion();
         if (!userConsented) return;
 
-        await this.object.clearMarks();
+        await this.actor.clearMarks();
     }
 
     _prepareSkillsWithFilters(data: SR5ActorSheetData) {
@@ -1457,10 +1456,10 @@ export class SR5BaseActorSheet extends ActorSheet {
         const userConsented = await Helpers.confirmDeletion();
         if (!userConsented) return;
 
-        await this.document.inventory.remove(this.selectedInventory);
+        await this.actor.inventory.remove(this.selectedInventory);
 
         // Preselect default instead of none.
-        this.selectedInventory = this.document.defaultInventory.name;
+        this.selectedInventory = this.actor.defaultInventory.name;
         this.render();
     }
 
@@ -1474,7 +1473,7 @@ export class SR5BaseActorSheet extends ActorSheet {
         event.preventDefault();
 
         // Disallow editing of default inventory.
-        if (action === 'edit' && this.document.inventory.disallowRename(this.selectedInventory))
+        if (action === 'edit' && this.actor.inventory.disallowRename(this.selectedInventory))
             return ui.notifications?.warn(game.i18n.localize('SR5.Warnings.CantEditDefaultInventory'));
 
 
@@ -1525,10 +1524,10 @@ export class SR5BaseActorSheet extends ActorSheet {
 
         switch (action) {
             case 'edit':
-                inventory = await this.document.inventory.rename(this.selectedInventory, inventory);
+                inventory = await this.actor.inventory.rename(this.selectedInventory, inventory);
                 break;
             case 'create':
-                inventory = await this.document.inventory.create(inventory);
+                inventory = await this.actor.inventory.create(inventory);
                 break;
         }
 
@@ -1565,15 +1564,15 @@ export class SR5BaseActorSheet extends ActorSheet {
         event.preventDefault();
 
         const itemId = Helpers.listItemId(event);
-        const item = this.document.items.get(itemId);
+        const item = this.actor.items.get(itemId);
         if (!item) return;
 
         // Ask user about what inventory to move the item to.
-        const dialog = new MoveInventoryDialog(this.document, this.selectedInventory);
+        const dialog = new MoveInventoryDialog(this.actor, this.selectedInventory);
         const inventory = await dialog.select();
         if (dialog.canceled) return;
 
-        await this.document.inventory.addItems(inventory, item);
+        await this.actor.inventory.addItems(inventory, item);
     }
 
     /**
@@ -1688,7 +1687,7 @@ export class SR5BaseActorSheet extends ActorSheet {
      * @returns List of prepare sit. mod data
      */
     _prepareSituationModifiers(): {category: string, label: string, value: number, hidden: boolean}[] {
-        const modifiers = this.document.getSituationModifiers();
+        const modifiers = this.actor.getSituationModifiers();
         if (!modifiers) return [];
 
         return Object.entries(modifiers._modifiers).map(([category, modifier]: [Shadowrun.SituationModifierType, SituationModifier]) => {
@@ -1708,14 +1707,14 @@ export class SR5BaseActorSheet extends ActorSheet {
     _hideSituationModifier(category: Shadowrun.SituationModifierType): boolean {
         switch (category) {
             case 'background_count':
-                return !this.document.isAwakened;
+                return !this.actor.isAwakened;
             case 'environmental':
-                return this.document.isSprite();
+                return this.actor.isSprite();
             // Defense modifier is already shown in general modifier section.
             case 'defense':
                 return true;
             case 'recoil':
-                return !this.document.hasPhysicalBody
+                return !this.actor.hasPhysicalBody
             default:
                 return false;
         }
@@ -1727,7 +1726,7 @@ export class SR5BaseActorSheet extends ActorSheet {
      * @param event 
      */
     _onShowSituationModifiersApplication(event) {
-        new SituationModifiersApplication(this.document).render(true);
+        new SituationModifiersApplication(this.actor).render(true);
     }
 
     /**

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -143,7 +143,7 @@ export class SR5BaseActorSheet extends ActorSheet {
      * Extend and override the default options used by the 5e Actor Sheet
      * @returns {Object}
      */
-    static get defaultOptions() {
+    static override get defaultOptions() {
         return mergeObject(super.defaultOptions, {
             classes: ['sr5', 'sheet', 'actor'],
             width: 905,
@@ -167,7 +167,7 @@ export class SR5BaseActorSheet extends ActorSheet {
      *
      * @override
      */
-    get template() {
+    override get template() {
         const path = 'systems/shadowrun5e/dist/templates';
 
         if (this.actor.limited) {
@@ -178,7 +178,7 @@ export class SR5BaseActorSheet extends ActorSheet {
     }
 
     /** SheetData used by _all_ actor types! */
-    async getData(options) {
+    override async getData(options) {
         // Remap Foundry default v8/v10 mappings to better match systems legacy foundry versions mapping accross it's templates.
         // NOTE: If this is changed, you'll have to match changes on all actor sheets.
         let data = super.getData() as any;
@@ -226,7 +226,7 @@ export class SR5BaseActorSheet extends ActorSheet {
     }
 
     /** Listeners used by _all_ actor types! */
-    activateListeners(html) {
+    override activateListeners(html) {
         super.activateListeners(html);
 
         Helpers.setupCustomCheckbox(this, html)
@@ -359,7 +359,7 @@ export class SR5BaseActorSheet extends ActorSheet {
      * @override Default drag start handler to add Skill support
      * @param event
      */
-    async _onDragStart(event) {
+    override async _onDragStart(event) {
         // Create drag data
         const dragData = {
             actorId: this.actor.id,
@@ -439,7 +439,7 @@ export class SR5BaseActorSheet extends ActorSheet {
      * Enhance Foundry state restore on rerender by more user interaction state.
      * @override
      */
-    async _render(...args) {
+    override async _render(...args) {
         const focus = this._saveInputCursorPosition();
         this._saveScrollPositions();
 
@@ -483,7 +483,7 @@ export class SR5BaseActorSheet extends ActorSheet {
      * Used together with _restoreScrollPositions during render calls.
      * @private
      */
-    _saveScrollPositions() {
+    override _saveScrollPositions() {
         const activeList = this._findActiveList();
         if (activeList.length) {
             this._scroll = activeList.prop('scrollTop');
@@ -494,7 +494,7 @@ export class SR5BaseActorSheet extends ActorSheet {
      * Used together with _storeScrollPositions during render calls.
      * @private
      */
-    _restoreScrollPositions() {
+    override _restoreScrollPositions() {
         const activeList = this._findActiveList();
         if (activeList.length && this._scroll != null) {
             activeList.prop('scrollTop', this._scroll);

--- a/src/module/actor/sheets/SR5CharacterSheet.ts
+++ b/src/module/actor/sheets/SR5CharacterSheet.ts
@@ -66,7 +66,7 @@ export class SR5CharacterSheet extends SR5BaseActorSheet {
 
         // Character actor types are matrix actors.
         super._prepareMatrixAttributes(data);
-        data['markedDocuments'] = this.object.getAllMarkedDocuments();
+        data['markedDocuments'] = this.actor.getAllMarkedDocuments();
 
         return data;
     }

--- a/src/module/actor/sheets/SR5CharacterSheet.ts
+++ b/src/module/actor/sheets/SR5CharacterSheet.ts
@@ -21,7 +21,7 @@ export class SR5CharacterSheet extends SR5BaseActorSheet {
      *
      * @returns An array of item types from the template.json Item section.
      */
-    getHandledItemTypes(): string[] {
+    override getHandledItemTypes(): string[] {
         let itemTypes = super.getHandledItemTypes();
 
         return [
@@ -45,7 +45,7 @@ export class SR5CharacterSheet extends SR5BaseActorSheet {
      *
      * @returns An array of item types from the template.json Item section.
      */
-    getInventoryItemTypes(): string[] {
+    override getInventoryItemTypes(): string[] {
         const itemTypes = super.getInventoryItemTypes();
 
         return [
@@ -61,7 +61,7 @@ export class SR5CharacterSheet extends SR5BaseActorSheet {
         ];
     }
 
-    async getData(options) {
+    override async getData(options) {
         const data = await super.getData(options) as CharacterSheetData;
 
         // Character actor types are matrix actors.

--- a/src/module/actor/sheets/SR5ICActorSheet.ts
+++ b/src/module/actor/sheets/SR5ICActorSheet.ts
@@ -17,12 +17,11 @@ export class SR5ICActorSheet extends SR5BaseActorSheet {
      *
      * @returns An array of item types from the template.json Item section.
      */
-    getHandledItemTypes(): string[] {
+    override getHandledItemTypes(): string[] {
         return super.getHandledItemTypes();
     }
 
-
-    async getData(options) {
+    override async getData(options) {
         const data = await super.getData(options) as ICActorSheetData;
 
         // Fetch a connected host.
@@ -35,7 +34,7 @@ export class SR5ICActorSheet extends SR5BaseActorSheet {
         return data;
     }
 
-    activateListeners(html) {
+    override activateListeners(html) {
         super.activateListeners(html);
 
         html.find('.entity-remove').on('click', this._removeHost.bind(this));
@@ -50,7 +49,7 @@ export class SR5ICActorSheet extends SR5BaseActorSheet {
         await this.actor.removeICHost();
     }
 
-    async _onDrop(event: DragEvent) {
+    override async _onDrop(event: DragEvent) {
         event.preventDefault();
         event.stopPropagation();
 

--- a/src/module/actor/sheets/SR5ICActorSheet.ts
+++ b/src/module/actor/sheets/SR5ICActorSheet.ts
@@ -26,11 +26,11 @@ export class SR5ICActorSheet extends SR5BaseActorSheet {
         const data = await super.getData(options) as ICActorSheetData;
 
         // Fetch a connected host.
-        data.host = this.object.getICHost();
+        data.host = this.actor.getICHost();
 
         // Display Matrix Marks
-        data.markedDocuments = this.object.getAllMarkedDocuments();
-        data.disableMarksEdit = this.object.hasHost();
+        data.markedDocuments = this.actor.getAllMarkedDocuments();
+        data.disableMarksEdit = this.actor.hasHost();
 
         return data;
     }
@@ -47,7 +47,7 @@ export class SR5ICActorSheet extends SR5BaseActorSheet {
      */
     async _removeHost(event) {
         event.stopPropagation();
-        await this.object.removeICHost();
+        await this.actor.removeICHost();
     }
 
     async _onDrop(event: DragEvent) {
@@ -63,7 +63,7 @@ export class SR5ICActorSheet extends SR5BaseActorSheet {
         switch(dropData.type) {
             case 'Item':
                 // We don't have to narrow down type here, the SR5Actor will handle this for us.
-                return await this.object.addICHost(dropData.uuid);
+                return await this.actor.addICHost(dropData.uuid);
         }
 
         // Let Foundry handle default cases.

--- a/src/module/actor/sheets/SR5SpiritActorSheet.ts
+++ b/src/module/actor/sheets/SR5SpiritActorSheet.ts
@@ -9,7 +9,7 @@ export class SR5SpiritActorSheet extends SR5BaseActorSheet {
      *
      * @returns An array of item types from the template.json Item section.
      */
-    getHandledItemTypes(): string[] {
+    override getHandledItemTypes(): string[] {
         let itemTypes = super.getHandledItemTypes();
 
         return [

--- a/src/module/actor/sheets/SR5SpriteActorSheet.ts
+++ b/src/module/actor/sheets/SR5SpriteActorSheet.ts
@@ -9,7 +9,7 @@ export class SR5SpriteActorSheet extends SR5BaseActorSheet {
      *
      * @returns An array of item types from the template.json Item section.
      */
-    getHandledItemTypes(): string[] {
+    override getHandledItemTypes(): string[] {
         let itemTypes = super.getHandledItemTypes();
 
         return [

--- a/src/module/actor/sheets/SR5VehicleActorSheet.ts
+++ b/src/module/actor/sheets/SR5VehicleActorSheet.ts
@@ -19,7 +19,7 @@ export class SR5VehicleActorSheet extends SR5BaseActorSheet {
      *
      * @returns An array of item types from the template.json Item section.
      */
-    getHandledItemTypes(): string[] {
+    override getHandledItemTypes(): string[] {
         let itemTypes = super.getHandledItemTypes();
 
         return [
@@ -35,7 +35,7 @@ export class SR5VehicleActorSheet extends SR5BaseActorSheet {
      *
      * @returns An array of item types from the template.json Item section.
      */
-    getInventoryItemTypes(): string[] {
+    override getInventoryItemTypes(): string[] {
         const itemTypes = super.getInventoryItemTypes();
 
         return [
@@ -51,7 +51,7 @@ export class SR5VehicleActorSheet extends SR5BaseActorSheet {
         ];
     }
 
-    async getData(options) {
+    override async getData(options) {
         const data = await super.getData(options);
 
         // Vehicle actor type specific fields.
@@ -60,7 +60,7 @@ export class SR5VehicleActorSheet extends SR5BaseActorSheet {
         return data;
     }
 
-    activateListeners(html: JQuery) {
+    override activateListeners(html: JQuery) {
         super.activateListeners(html);
 
         // Vehicle Sheet related handlers...
@@ -71,7 +71,7 @@ export class SR5VehicleActorSheet extends SR5BaseActorSheet {
      * Vehicle specific drop events
      * @param event A DataTransferEvent containing some form of FoundryVTT Document / Data
      */
-    async _onDrop(event) {
+    override async _onDrop(event) {
         event.preventDefault();
         event.stopPropagation();
 

--- a/src/module/apps/ChangelogApplication.ts
+++ b/src/module/apps/ChangelogApplication.ts
@@ -1,11 +1,11 @@
 import {FLAGS, SYSTEM_NAME} from "../constants";
 
 export class ChangelogApplication extends Application {
-    get template(): string {
+    override get template(): string {
         return 'systems/shadowrun5e/dist/templates/apps/changelog.html';
     }
 
-    static get defaultOptions() {
+    static override get defaultOptions() {
         const options = super.defaultOptions;
         options.classes = ['shadowrun5e'];
         options.title = game.i18n.localize('SR5.ChangelogApplication.Title');
@@ -14,7 +14,7 @@ export class ChangelogApplication extends Application {
         return options;
     }
 
-    render(force?: boolean, options?: Application.RenderOptions) {
+    override render(force?: boolean, options?: Application.RenderOptions) {
         ChangelogApplication.setRenderForCurrentVersion();
         return super.render(force, options);
     }

--- a/src/module/apps/SituationModifiersApplication.ts
+++ b/src/module/apps/SituationModifiersApplication.ts
@@ -51,12 +51,12 @@ class ModifiersHandler {
  */
 class EnvironmentalModifiersHandler extends ModifiersHandler {
 
-    activateListeners(html: JQuery<HTMLElement>) {
+    override activateListeners(html: JQuery<HTMLElement>) {
         console.log(`Shadowrun5e | Registering modifier handler ${this.constructor.name} listeners`);
         $(html).find('button.env-modifier').on('click', this._handleModifierChange.bind(this));
     }
 
-    static addTokenHUDElements(modifierColumn: JQuery<HTMLElement>, tokenId: string, actor: SR5Actor, modifiers: DocumentSituationModifiers): void {
+    static override addTokenHUDElements(modifierColumn: JQuery<HTMLElement>, tokenId: string, actor: SR5Actor, modifiers: DocumentSituationModifiers): void {
         console.log(`${SYSTEM_NAME} | Environmental modifier HUD on renderTokenHUD`);
 
         // Setup and connect tokenHUD elements.
@@ -104,14 +104,14 @@ class EnvironmentalModifiersHandler extends ModifiersHandler {
 
 
 class MatrixModifiersHandler extends ModifiersHandler {
-    getData(options?: object | undefined) {
+    override getData(options?: object | undefined) {
         return {}
     }
 
-    activateListeners(html: JQuery<HTMLElement>) {
+    override activateListeners(html: JQuery<HTMLElement>) {
     }
 
-    static addTokenHUDElements(modifierColumn: JQuery<HTMLElement>, tokenId: string, actor: SR5Actor, modifiers: DocumentSituationModifiers): void {
+    static override addTokenHUDElements(modifierColumn: JQuery<HTMLElement>, tokenId: string, actor: SR5Actor, modifiers: DocumentSituationModifiers): void {
         console.log(`${SYSTEM_NAME} | Matrix modifier HUD on renderTokenHUD`);
 
         // Setup and connect tokenHUD elements.
@@ -127,15 +127,15 @@ class MatrixModifiersHandler extends ModifiersHandler {
 }
 
 class MagicModifiersHandler extends ModifiersHandler {
-    getData(options?: object | undefined) {
+    override getData(options?: object | undefined) {
         return {}
     }
 
-    activateListeners(html: JQuery<HTMLElement>) {
+    override activateListeners(html: JQuery<HTMLElement>) {
         html.find('.remove-magical-from-target').on('click', this.handleClearMagicModifiers.bind(this));
     }
 
-    static addTokenHUDElements(modifierColumn: JQuery<HTMLElement>, tokenId: string, actor: SR5Actor, modifiers: DocumentSituationModifiers): void {
+    static override addTokenHUDElements(modifierColumn: JQuery<HTMLElement>, tokenId: string, actor: SR5Actor, modifiers: DocumentSituationModifiers): void {
         console.log(`${SYSTEM_NAME} | Magic modifier HUD on renderTokenHUD`);
 
         // Don't add awakend modifiers to token hud for mundane actors.
@@ -166,11 +166,11 @@ class MagicModifiersHandler extends ModifiersHandler {
  * 
  */
 class RecoilModifiersHandler extends ModifiersHandler {
-    getData(options?: object | undefined) {
+    override getData(options?: object | undefined) {
         return {}
     }
 
-    activateListeners(html: JQuery<HTMLElement>): void {
+    override activateListeners(html: JQuery<HTMLElement>): void {
         html.find('.recoil-delta button').on('click', this.applyRecoilDelta.bind(this));
         html.find('button#modifiers-recoil-total').on('click', async event => {
             if (this.app.modifiers.documentIsScene) return;
@@ -257,11 +257,11 @@ export class SituationModifiersApplication extends FormApplication {
         return SituationModifiersApplication._staticHandlers.map(staticHandler => new staticHandler(this));
     }
 
-    get template() {
+    override get template() {
         return 'systems/shadowrun5e/dist/templates/apps/situational-modifiers.hbs';
     }
 
-    static get defaultOptions() {
+    static override get defaultOptions() {
         const options = super.defaultOptions;
 
         options.classes = ['sr5'];
@@ -287,7 +287,7 @@ export class SituationModifiersApplication extends FormApplication {
         return options;
     }
 
-    async getData(options?: any): Promise<SituationalModifiersTemplateData> {
+    override async getData(options?: any): Promise<SituationalModifiersTemplateData> {
         // Update all modifiers before displaying.
         this.modifiers.applyAll();
 
@@ -302,7 +302,7 @@ export class SituationModifiersApplication extends FormApplication {
         }
     }
 
-    activateListeners(html: JQuery<HTMLElement>): void {
+    override activateListeners(html: JQuery<HTMLElement>): void {
         super.activateListeners(html);
 
         this.handlers.forEach(handler => handler.activateListeners(html));
@@ -383,7 +383,7 @@ export class SituationModifiersApplication extends FormApplication {
     /**
      * Override _onChangeInput to include a render on changing modifier values.
      */
-    async _onChangeInput(event) {
+    override async _onChangeInput(event) {
         await super._onChangeInput(event);
         this.render(true);
     }

--- a/src/module/apps/characterImport/gearImport/AmmoParser.ts
+++ b/src/module/apps/characterImport/gearImport/AmmoParser.ts
@@ -5,7 +5,7 @@ import { BaseGearParser } from "./BaseGearParser"
  */
 export class AmmoParser extends BaseGearParser {
    
-    parse(chummerGear : any) : any {
+    override parse(chummerGear : any) : any {
         const parsedGear =  super.parse(chummerGear);
         parsedGear.type = 'ammo';
 

--- a/src/module/apps/characterImport/gearImport/DeviceParser.ts
+++ b/src/module/apps/characterImport/gearImport/DeviceParser.ts
@@ -5,7 +5,7 @@ import { BaseGearParser } from "./BaseGearParser"
  */
 export class DeviceParser extends BaseGearParser {
    
-    parse(chummerGear : any) : any {
+    override parse(chummerGear : any) : any {
         const parsedGear =  super.parse(chummerGear);
         parsedGear.type = 'device';
         parsedGear.system.technology.rating = chummerGear.devicerating;

--- a/src/module/apps/characterImport/gearImport/ProgramParser.ts
+++ b/src/module/apps/characterImport/gearImport/ProgramParser.ts
@@ -4,7 +4,7 @@ import { BaseGearParser } from "./BaseGearParser"
  * Parses common, hacking and agent programs.
  */
 export class ProgramParser extends BaseGearParser {
-    parse(chummerGear : any) : any {
+    override parse(chummerGear : any) : any {
         const parsedGear =  super.parse(chummerGear);
         parsedGear.type = 'program';
 

--- a/src/module/apps/characterImport/gearImport/SinParser.ts
+++ b/src/module/apps/characterImport/gearImport/SinParser.ts
@@ -5,7 +5,7 @@ import { BaseGearParser } from "./BaseGearParser"
  * Licenses that are not attached to a SIN are not handled.
  */
 export class SinParser extends BaseGearParser {
-    parse(chummerGear : any) : any {
+    override parse(chummerGear : any) : any {
         const parsedGear =  super.parse(chummerGear);
         parsedGear.type = 'sin';
 

--- a/src/module/apps/dialogs/DamageApplicationDialog.ts
+++ b/src/module/apps/dialogs/DamageApplicationDialog.ts
@@ -9,7 +9,7 @@ export class DamageApplicationDialog extends FormDialog {
         super(dialogData, options);
     }
 
-    static get defaultOptions() {
+    static override get defaultOptions() {
         const options = super.defaultOptions;
         options.id = 'damage-application';
         // TODO: Class Dialog here is needed for dialog button styling.

--- a/src/module/apps/dialogs/DeleteConfirmationDialog.ts
+++ b/src/module/apps/dialogs/DeleteConfirmationDialog.ts
@@ -24,7 +24,7 @@ export class DeleteConfirmationDialog extends FormDialog {
         }
     }
 
-    static get defaultOptions() {
+    static override get defaultOptions() {
         const options = super.defaultOptions;
         options.id = 'delete-confirmation-application';
         // Class Dialog here is needed for dialog button styling.

--- a/src/module/apps/dialogs/FormDialog.ts
+++ b/src/module/apps/dialogs/FormDialog.ts
@@ -46,7 +46,7 @@ export class FormDialog extends Dialog<FormDialogOptions> {
         });
     }
 
-    async close() {
+    override async close() {
         await super.close();
 
         if (this.canceled) {
@@ -55,14 +55,14 @@ export class FormDialog extends Dialog<FormDialogOptions> {
         }
     }
 
-    activateListeners(html: JQuery) {
+    override activateListeners(html: JQuery) {
         super.activateListeners(html);
 
         html.on("change", "input,select,textarea", this._onChangeInput.bind(this));
     }
 
 
-    async submit(button) {
+    override async submit(button) {
         this.selectedButton = button.name ?? button.label;
 
         this.applyFormData();
@@ -174,7 +174,7 @@ export class FormDialog extends Dialog<FormDialogOptions> {
     /**
      * See FormApplication._renderInner
      */
-    async _renderInner(data): Promise<JQuery<HTMLElement>> {
+    override async _renderInner(data): Promise<JQuery<HTMLElement>> {
         const templatePath = data.templatePath || this.templateContent;
         if (templatePath)
             data.content = await renderTemplate(data.templatePath || this.templateContent,

--- a/src/module/apps/dialogs/MoveInventoryDialog.ts
+++ b/src/module/apps/dialogs/MoveInventoryDialog.ts
@@ -18,7 +18,7 @@ export class MoveInventoryDialog extends FormDialog {
         super(dialogData, options);
     }
 
-    static get defaultOptions() {
+    static override get defaultOptions() {
         const options = super.defaultOptions;
         options.id = 'move-inventory-application';
         options.classes = ['sr5', 'form-dialog'];

--- a/src/module/apps/dialogs/TestDialog.ts
+++ b/src/module/apps/dialogs/TestDialog.ts
@@ -25,7 +25,7 @@ export interface TestDialogListener {
  * TODO: Add TestDialog JSDoc
  */
 export class TestDialog extends FormDialog {
-    data: TestDialogData
+    override data: TestDialogData
     // Listeners as given by the dialogs creator.
     listeners: TestDialogListener[]
 
@@ -38,7 +38,7 @@ export class TestDialog extends FormDialog {
         this.listeners = listeners;
     }
 
-    static get defaultOptions() {
+    static override get defaultOptions() {
         const options = super.defaultOptions;
         options.id = 'test-dialog';
         // TODO: Class Dialog here is needed for dialog button styling.
@@ -50,7 +50,7 @@ export class TestDialog extends FormDialog {
         return options;
     }
 
-    activateListeners(html: JQuery) {
+    override activateListeners(html: JQuery) {
         super.activateListeners(html);
 
         // Handle in-dialog entity links to render the respective sheets.
@@ -74,7 +74,7 @@ export class TestDialog extends FormDialog {
      *
      * data.templatePath work's the same and can be used as well.
      */
-    get templateContent(): string {
+    override get templateContent(): string {
         return 'systems/shadowrun5e/dist/templates/apps/dialogs/success-test-dialog.html';
     }
 
@@ -96,7 +96,7 @@ export class TestDialog extends FormDialog {
     /**
      * Overwrite this method to provide the dialog application title.
      */
-    get title() {
+    override get title() {
         const data = this.data as unknown as TestDialogData;
         return game.i18n.localize(data.test.title);
     }
@@ -104,7 +104,7 @@ export class TestDialog extends FormDialog {
     /**
      * Overwrite this method to provide dialog buttons.
      */
-    get buttons() {
+    override get buttons() {
         return {
             roll: {
                 label: game.i18n.localize('SR5.Roll'),
@@ -120,7 +120,7 @@ export class TestDialog extends FormDialog {
      * Callback for after the dialoge has closed.
      * @param html
      */
-    onAfterClose(html: JQuery<HTMLElement>): SuccessTestData {
+    override onAfterClose(html: JQuery<HTMLElement>): SuccessTestData {
         return this.data.test.data;
     }
 
@@ -130,7 +130,7 @@ export class TestDialog extends FormDialog {
      *
      * @param data An object with keys in Foundry UpdateData style {'key.key.key': value}
      */
-    _updateData(data) {
+    override _updateData(data) {
         // The user canceled their interaction by cancenling, don't apply form changes.
         if (this.selectedButton === 'cancel') return;
 

--- a/src/module/apps/skills/KnowledgeSkillEditSheet.ts
+++ b/src/module/apps/skills/KnowledgeSkillEditSheet.ts
@@ -7,7 +7,7 @@ export class KnowledgeSkillEditSheet extends LanguageSkillEditSheet {
         super(actor, options, skillId);
         this.category = category;
     }
-    _updateString() {
+    override _updateString() {
         return `system.skills.knowledge.${this.category}.value.${this.skillId}`;
     }
 }

--- a/src/module/apps/skills/LanguageSkillEditSheet.ts
+++ b/src/module/apps/skills/LanguageSkillEditSheet.ts
@@ -2,11 +2,11 @@ import { SkillEditSheet } from './SkillEditSheet';
 import SkillEditFormData = Shadowrun.SkillEditFormData;
 
 export class LanguageSkillEditSheet extends SkillEditSheet {
-    _updateString() {
+    override _updateString() {
         return `system.skills.language.value.${this.skillId}`;
     }
 
-    getData() {
+    override getData() {
         return mergeObject(super.getData(), {
             editable_name: true,
             editable_canDefault: false,
@@ -15,7 +15,7 @@ export class LanguageSkillEditSheet extends SkillEditSheet {
     }
 
     /** @override */
-    _onUpdateObject(event, formData, updateData) {
+    override _onUpdateObject(event, formData, updateData) {
         super._onUpdateObject(event, formData, updateData);
         const name = formData['skill.name'];
         const currentData = updateData[this._updateString()] || {};

--- a/src/module/apps/skills/SkillEditSheet.ts
+++ b/src/module/apps/skills/SkillEditSheet.ts
@@ -5,7 +5,7 @@ import {SR5} from "../../config";
 export class SkillEditSheet extends DocumentSheet {
     skillId: string;
 
-    get document(): SR5Actor {
+    override get document(): SR5Actor {
         return super.document as SR5Actor;
     }
 
@@ -18,7 +18,7 @@ export class SkillEditSheet extends DocumentSheet {
         return `system.skills.active.${this.skillId}`;
     }
 
-    static get defaultOptions() {
+    static override get defaultOptions() {
         const options = super.defaultOptions;
         // @ts-ignore
         return mergeObject(options, {
@@ -34,7 +34,7 @@ export class SkillEditSheet extends DocumentSheet {
         });
     }
 
-    get title(): string {
+    override get title(): string {
         const label = this.document.getSkillLabel(this.skillId);
         return `${game.i18n.localize('SR5.EditSkill')} - ${game.i18n.localize(label)}`;
     }
@@ -108,7 +108,7 @@ export class SkillEditSheet extends DocumentSheet {
         }
     }
 
-    activateListeners(html) {
+    override activateListeners(html) {
         super.activateListeners(html);
         $(html).find('.add-spec').on('click', this._addNewSpec.bind(this));
         $(html).find('.remove-spec').on('click', this._removeSpec.bind(this));

--- a/src/module/combat/SR5Combat.ts
+++ b/src/module/combat/SR5Combat.ts
@@ -14,7 +14,7 @@ import SocketMessageData = Shadowrun.SocketMessageData;
  */
 export class SR5Combat extends Combat {
     // Overwrite foundry-vtt-types v9 combatTrackerSettings type definitions.
-    get settings() {
+    override get settings() {
         return super.settings as {resource: string, skipDefeated: boolean};
     }
 
@@ -190,7 +190,7 @@ export class SR5Combat extends Combat {
     /**
      * Make sure Shadowrun initiative order is applied.
      */
-    setupTurns(): any[] {
+    override setupTurns(): any[] {
         const turns = super.setupTurns();
         return turns.sort(SR5Combat.sortByRERIC);
     }
@@ -305,7 +305,7 @@ export class SR5Combat extends Combat {
      *
      * * @Override
      */
-    async nextTurn(): Promise<this | undefined> {
+    override async nextTurn(): Promise<this | undefined> {
         // Maybe advance to the next round/init pass
         let nextRound = this.round;
         let initiativePass = this.initiativePass;
@@ -345,7 +345,7 @@ export class SR5Combat extends Combat {
         return this.nextRound();
     }
 
-    async startCombat() {
+    override async startCombat() {
         // By default, no actor starts. Pre-selet top.
         const turn = 0;
         const round = SR.combat.INITIAL_INI_ROUND;
@@ -368,7 +368,7 @@ export class SR5Combat extends Combat {
         return this;
     }
 
-    async nextRound(): Promise<any> {
+    override async nextRound(): Promise<any> {
         // Let Foundry handle time and some other things.
         await super.nextRound();
 
@@ -466,7 +466,7 @@ export class SR5Combat extends Combat {
         await SocketMessage.emitForGM(FLAGS.DoNewActionPhase, {id: this.id});
     }
 
-    delete(...args): Promise<this | undefined> {
+    override delete(...args): Promise<this | undefined> {
         // Remove all combat related modifiers.
         this.combatants.contents.forEach(combatant => combatant.actor?.removeDefenseMultiModifier());
         return super.delete(...args);

--- a/src/module/effect/SR5ActiveEffectConfig.ts
+++ b/src/module/effect/SR5ActiveEffectConfig.ts
@@ -1,9 +1,9 @@
 export class SR5ActiveEffectConfig extends ActiveEffectConfig {
-    get template(): string {
+    override get template(): string {
         return 'systems/shadowrun5e/dist/templates/effect/active-effect-config.html';
     }
 
-    getData(options?: Application.RenderOptions): Promise<ActiveEffectConfig.Data> | ActiveEffectConfig.Data {
+    override getData(options?: Application.RenderOptions): Promise<ActiveEffectConfig.Data> | ActiveEffectConfig.Data {
         const data = super.getData(options) as any;
         data.modes = {...data.modes, 0: game.i18n.localize('SR5.ActiveEffect.Modes.Modify')};
         return data;

--- a/src/module/importer/apps/import-form.ts
+++ b/src/module/importer/apps/import-form.ts
@@ -29,7 +29,7 @@ export class Import extends Application {
         this.collectDataImporterFileSupport();
     }
 
-    static get defaultOptions() {
+    static override get defaultOptions() {
         const options = super.defaultOptions;
         options.id = 'chummer-data-import';
         options.classes = ['app', 'window-app', 'filepicker'];
@@ -40,7 +40,7 @@ export class Import extends Application {
         return options;
     }
 
-    getData(options?: any) {
+    override getData(options?: any) {
         const data = super.getData(options) as any;
 
         data.dataFiles = {};
@@ -126,7 +126,7 @@ export class Import extends Application {
         return file.name.match(pattern) !== null;
     };
 
-    activateListeners(html) {
+    override activateListeners(html) {
         html.find("button[type='submit']").on('click', async (event) => {
             event.preventDefault();
 

--- a/src/module/importer/importer/ArmorImporter.ts
+++ b/src/module/importer/importer/ArmorImporter.ts
@@ -6,7 +6,7 @@ import {Helpers} from "../../helpers";
 
 export class ArmorImporter extends DataImporter<ArmorItemData, Shadowrun.ArmorData> {
     public armorTranslations: any;
-    public categoryTranslations: any;
+    public override categoryTranslations: any;
     public files = ['armor.xml'];
 
     CanParse(jsonObject: object): boolean {

--- a/src/module/importer/importer/ComplexFormImporter.ts
+++ b/src/module/importer/importer/ComplexFormImporter.ts
@@ -6,7 +6,7 @@ import {Helpers} from "../../helpers";
 import { DataDefaults } from '../../data/DataDefaults';
 
 export class ComplexFormImporter extends DataImporter<Shadowrun.ComplexFormItemData, Shadowrun.ComplexFormData> {
-    public categoryTranslations: any;
+    public override categoryTranslations: any;
     public nameTranslations: any;
     public files = ['complexforms.xml'];
 
@@ -14,7 +14,7 @@ export class ComplexFormImporter extends DataImporter<Shadowrun.ComplexFormItemD
         return jsonObject.hasOwnProperty('complexforms') && jsonObject['complexforms'].hasOwnProperty('complexform');
     }
 
-    public GetDefaultData({ type }: { type: any; }): Shadowrun.ComplexFormItemData {
+    public override GetDefaultData({ type }: { type: any; }): Shadowrun.ComplexFormItemData {
         const systemData = {action: {type: 'complex', attribute: 'resonance', skill: 'compiling'}} as Shadowrun.ComplexFormData;
         return DataDefaults.baseItemData<Shadowrun.ComplexFormItemData, Shadowrun.ComplexFormData>({type}, systemData);
     }

--- a/src/module/importer/importer/CritterPowerImporter.ts
+++ b/src/module/importer/importer/CritterPowerImporter.ts
@@ -7,7 +7,7 @@ import {Helpers} from "../../helpers";
 export class CritterPowerImporter extends DataImporter<Shadowrun.CritterPowerItemData, Shadowrun.CritterPowerData> {
     public files = ['critterpowers.xml'];
 
-    public unsupportedCategories = [
+    public override unsupportedCategories = [
         'Emergent',
     ];
     

--- a/src/module/importer/importer/DeviceImporter.ts
+++ b/src/module/importer/importer/DeviceImporter.ts
@@ -121,7 +121,7 @@ export class DeviceImporter extends DataImporter<DeviceItemData, Shadowrun.Devic
 
     /* List of unsupported Commlinks, due to dynamics value calculations.
      */
-    static unsupportedEntry(jsonData): boolean {
+    static override unsupportedEntry(jsonData): boolean {
         if (DataImporter.unsupportedEntry(jsonData)) {
             return true;
         }

--- a/src/module/importer/importer/EquipmentImporter.ts
+++ b/src/module/importer/importer/EquipmentImporter.ts
@@ -6,7 +6,7 @@ import {Helpers} from "../../helpers";
 
 export class EquipmentImporter extends DataImporter<EquipmentItemData, Shadowrun.EquipmentData> {
     files = ['gear.xml'];
-    unsupportedCategories = [
+    override unsupportedCategories = [
         'Ammunition',
         'Commlinks',
         'Cyberdecks',

--- a/src/module/importer/importer/ModImporter.ts
+++ b/src/module/importer/importer/ModImporter.ts
@@ -6,7 +6,7 @@ import ModificationItemData = Shadowrun.ModificationItemData;
 import {Helpers} from "../../helpers";
 
 export class ModImporter extends DataImporter<ModificationItemData, Shadowrun.ModificationData> {
-    public categoryTranslations: any;
+    public override categoryTranslations: any;
     public accessoryTranslations: any;
     public files = ['weapons.xml'];
 

--- a/src/module/importer/importer/QualityImporter.ts
+++ b/src/module/importer/importer/QualityImporter.ts
@@ -5,8 +5,8 @@ import QualityItemData = Shadowrun.QualityItemData;
 import {Helpers} from "../../helpers";
 
 export class QualityImporter extends DataImporter<QualityItemData, Shadowrun.QualityData> {
-    public categoryTranslations: any;
-    public itemTranslations: any;
+    public override categoryTranslations: any;
+    public override itemTranslations: any;
     public files = ['qualities.xml'];
 
     CanParse(jsonObject: object): boolean {

--- a/src/module/importer/importer/SpellImporter.ts
+++ b/src/module/importer/importer/SpellImporter.ts
@@ -10,15 +10,15 @@ import {Helpers} from "../../helpers";
 import { DataDefaults } from '../../data/DataDefaults';
 
 export class SpellImporter extends DataImporter<Shadowrun.SpellItemData, Shadowrun.SpellData> {
-    public categoryTranslations: any;
-    public itemTranslations: any;
+    public override categoryTranslations: any;
+    public override itemTranslations: any;
     public files = ['spells.xml'];
 
     CanParse(jsonObject: object): boolean {
         return jsonObject.hasOwnProperty('spells') && jsonObject['spells'].hasOwnProperty('spell');
     }
 
-    public GetDefaultData({ type }: { type: any; }): Shadowrun.SpellItemData {
+    public override GetDefaultData({ type }: { type: any; }): Shadowrun.SpellItemData {
         const systemData = {action: {type: 'varies', attribute: 'magic', skill: 'spellcasting'}} as Shadowrun.SpellData;
         return DataDefaults.baseItemData<Shadowrun.SpellItemData, Shadowrun.SpellData>({type}, systemData);
     }

--- a/src/module/importer/importer/SpritePowerImporter.ts
+++ b/src/module/importer/importer/SpritePowerImporter.ts
@@ -10,7 +10,7 @@ import { DataImporter } from "./DataImporter";
  */
 export class SpritePowerImporter extends DataImporter<Shadowrun.SpritePowerItemData, Shadowrun.SpritePowerData> {
     public files = ['critterpowers.xml'];
-    public unsupportedCategories = [
+    public override unsupportedCategories = [
         'Drake',
         'Echoes',
         'Free Spirit',

--- a/src/module/importer/importer/WareImporter.ts
+++ b/src/module/importer/importer/WareImporter.ts
@@ -7,8 +7,8 @@ import CyberwareItemData = Shadowrun.CyberwareItemData;
 import BiowareItemData = Shadowrun.BiowareItemData;
 
 export class WareImporter extends DataImporter<Ware, Shadowrun.WareData> {
-    public categoryTranslations: any;
-    public itemTranslations: any;
+    public override categoryTranslations: any;
+    public override itemTranslations: any;
     public files = ['cyberware.xml', 'bioware.xml'];
 
     CanParse(jsonObject: object): boolean {

--- a/src/module/importer/importer/WeaponImporter.ts
+++ b/src/module/importer/importer/WeaponImporter.ts
@@ -11,15 +11,15 @@ import {Helpers} from "../../helpers";
 import { DataDefaults } from '../../data/DataDefaults';
 
 export class WeaponImporter extends DataImporter<WeaponItemData, Shadowrun.WeaponData> {
-    public categoryTranslations: any;
-    public itemTranslations: any;
+    public override categoryTranslations: any;
+    public override itemTranslations: any;
     public files = ['weapons.xml'];
 
     CanParse(jsonObject: object): boolean {
         return jsonObject.hasOwnProperty('weapons') && jsonObject['weapons'].hasOwnProperty('weapon');
     }
 
-    public GetDefaultData({ type }: { type: any; }): WeaponItemData {
+    public override GetDefaultData({ type }: { type: any; }): WeaponItemData {
         const systemData = {action: {type: 'varies', attribute: 'agility'}} as Shadowrun.WeaponData;
         return DataDefaults.baseItemData<Shadowrun.WeaponItemData, Shadowrun.WeaponData>({type}, systemData);
     }

--- a/src/module/importer/parser/armor/ArmorParserBase.ts
+++ b/src/module/importer/parser/armor/ArmorParserBase.ts
@@ -3,7 +3,7 @@ import { TechnologyItemParserBase } from '../item/TechnologyItemParserBase';
 import ArmorItemData = Shadowrun.ArmorItemData;
 
 export class ArmorParserBase extends TechnologyItemParserBase<ArmorItemData> {
-    Parse(jsonData: object, item: ArmorItemData): ArmorItemData {
+    override Parse(jsonData: object, item: ArmorItemData): ArmorItemData {
         item = super.Parse(jsonData, item);
 
         item.system.armor.value = ImportHelper.IntValue(jsonData, 'armor', 0);

--- a/src/module/importer/parser/complex-form/ComplexFormParserBase.ts
+++ b/src/module/importer/parser/complex-form/ComplexFormParserBase.ts
@@ -4,7 +4,7 @@ import ComplexFormTarget = Shadowrun.ComplexFormTarget;
 import ComplexFormItemData = Shadowrun.ComplexFormItemData;
 
 export class ComplexFormParserBase extends ItemParserBase<ComplexFormItemData> {
-    Parse(jsonData: object, item: ComplexFormItemData, jsonTranslation?: object): ComplexFormItemData {
+    override Parse(jsonData: object, item: ComplexFormItemData, jsonTranslation?: object): ComplexFormItemData {
         // @ts-ignore // TODO: Foundry Where is my foundry base data?
         item.name = ImportHelper.StringValue(jsonData, 'name');
 

--- a/src/module/importer/parser/critter-power/CritterPowerParserBase.ts
+++ b/src/module/importer/parser/critter-power/CritterPowerParserBase.ts
@@ -4,7 +4,7 @@ import { ItemParserBase } from '../item/ItemParserBase';
 import CritterPowerItemData = Shadowrun.CritterPowerItemData;
 
 export class CritterPowerParserBase extends ItemParserBase<CritterPowerItemData> {
-    public Parse(jsonData: object, item: CritterPowerItemData, jsonTranslation?: object): CritterPowerItemData {
+    public override Parse(jsonData: object, item: CritterPowerItemData, jsonTranslation?: object): CritterPowerItemData {
         // @ts-ignore // TODO: Foundry Where is my foundry base data?
         item.name = ImportHelper.StringValue(jsonData, 'name');
 

--- a/src/module/importer/parser/critter-power/SpritePowerParser.ts
+++ b/src/module/importer/parser/critter-power/SpritePowerParser.ts
@@ -14,7 +14,7 @@ export class SpritePowerParser extends ItemParserBase<Shadowrun.SpritePowerItemD
         else return '';
     }
 
-    public Parse(chummerData: object, itemData: Shadowrun.SpritePowerItemData, dataTranslation?: object): Shadowrun.SpritePowerItemData {
+    public override Parse(chummerData: object, itemData: Shadowrun.SpritePowerItemData, dataTranslation?: object): Shadowrun.SpritePowerItemData {
         itemData = super.Parse(chummerData, itemData, dataTranslation);
 
         // Chummer has camel case for action, system uses lowercase for type. ('Complex' => 'complex', ...)

--- a/src/module/importer/parser/item/TechnologyItemParserBase.ts
+++ b/src/module/importer/parser/item/TechnologyItemParserBase.ts
@@ -3,7 +3,7 @@ import { ImportHelper } from '../../helper/ImportHelper';
 import ShadowrunTechnologyItemData = Shadowrun.ShadowrunTechnologyItemData;
 
 export abstract class TechnologyItemParserBase<TResult extends ShadowrunTechnologyItemData> extends ItemParserBase<TResult> {
-    Parse(jsonData: object, item: TResult, jsonTranslation?: object): TResult {
+    override Parse(jsonData: object, item: TResult, jsonTranslation?: object): TResult {
         item = super.Parse(jsonData, item, jsonTranslation);
 
         item.system.technology.availability = ImportHelper.StringValue(jsonData, 'avail', '0');

--- a/src/module/importer/parser/mod/ModParserBase.ts
+++ b/src/module/importer/parser/mod/ModParserBase.ts
@@ -4,7 +4,7 @@ import { TechnologyItemParserBase } from '../item/TechnologyItemParserBase';
 import ModificationItemData = Shadowrun.ModificationItemData;
 
 export class ModParserBase extends TechnologyItemParserBase<ModificationItemData> {
-    Parse(jsonData: object, item: ModificationItemData): ModificationItemData {
+    override Parse(jsonData: object, item: ModificationItemData): ModificationItemData {
         item = super.Parse(jsonData, item);
 
         item.system.type = 'weapon';

--- a/src/module/importer/parser/quality/QualityParserBase.ts
+++ b/src/module/importer/parser/quality/QualityParserBase.ts
@@ -3,7 +3,7 @@ import { ItemParserBase } from '../item/ItemParserBase';
 import QualityItemData = Shadowrun.QualityItemData;
 
 export class QualityParserBase extends ItemParserBase<QualityItemData> {
-    public Parse(jsonData: object, item: QualityItemData, jsonTranslation?): QualityItemData {
+    public override Parse(jsonData: object, item: QualityItemData, jsonTranslation?): QualityItemData {
         // @ts-ignore // TODO: Foundry Where is my foundry base data?
         item.name = ImportHelper.StringValue(jsonData, 'name');
 

--- a/src/module/importer/parser/spell/CombatSpellParser.ts
+++ b/src/module/importer/parser/spell/CombatSpellParser.ts
@@ -3,7 +3,7 @@ import { ImportHelper } from '../../helper/ImportHelper';
 import SpellItemData = Shadowrun.SpellItemData;
 
 export class CombatSpellParser extends SpellParserBase {
-    Parse(jsonData: object, item: SpellItemData, jsonTranslation?: object): SpellItemData {
+    override Parse(jsonData: object, item: SpellItemData, jsonTranslation?: object): SpellItemData {
         item = super.Parse(jsonData, item, jsonTranslation);
 
         let descriptor = ImportHelper.StringValue(jsonData, 'descriptor');

--- a/src/module/importer/parser/spell/DetectionSpellImporter.ts
+++ b/src/module/importer/parser/spell/DetectionSpellImporter.ts
@@ -3,7 +3,7 @@ import { ImportHelper } from '../../helper/ImportHelper';
 import SpellItemData = Shadowrun.SpellItemData;
 
 export class DetectionSpellImporter extends SpellParserBase {
-    Parse(jsonData: object, item: SpellItemData, jsonTranslation?: object): SpellItemData {
+    override Parse(jsonData: object, item: SpellItemData, jsonTranslation?: object): SpellItemData {
         item = super.Parse(jsonData, item, jsonTranslation);
 
         let descriptor = ImportHelper.StringValue(jsonData, 'descriptor');

--- a/src/module/importer/parser/spell/IllusionSpellParser.ts
+++ b/src/module/importer/parser/spell/IllusionSpellParser.ts
@@ -3,7 +3,7 @@ import { ImportHelper } from '../../helper/ImportHelper';
 import SpellItemData = Shadowrun.SpellItemData;
 
 export class IllusionSpellParser extends SpellParserBase {
-    Parse(jsonData: object, item: SpellItemData, jsonTranslation?: object): SpellItemData {
+    override Parse(jsonData: object, item: SpellItemData, jsonTranslation?: object): SpellItemData {
         item = super.Parse(jsonData, item, jsonTranslation);
 
         let descriptor = ImportHelper.StringValue(jsonData, 'descriptor');

--- a/src/module/importer/parser/spell/ManipulationSpellParser.ts
+++ b/src/module/importer/parser/spell/ManipulationSpellParser.ts
@@ -3,7 +3,7 @@ import { ImportHelper } from '../../helper/ImportHelper';
 import SpellItemData = Shadowrun.SpellItemData;
 
 export class ManipulationSpellParser extends SpellParserBase {
-    Parse(jsonData: object, item: SpellItemData, jsonTranslation?: object): SpellItemData {
+    override Parse(jsonData: object, item: SpellItemData, jsonTranslation?: object): SpellItemData {
         item = super.Parse(jsonData, item, jsonTranslation);
 
         // A few spells have a missing descriptor instead of an empty string.

--- a/src/module/importer/parser/spell/SpellParserBase.ts
+++ b/src/module/importer/parser/spell/SpellParserBase.ts
@@ -4,7 +4,7 @@ import { ItemParserBase } from '../item/ItemParserBase';
 import SpellItemData = Shadowrun.SpellItemData;
 
 export class SpellParserBase extends ItemParserBase<SpellItemData> {
-    public Parse(jsonData: object, item: SpellItemData, jsonTranslation?: object): SpellItemData {
+    public override Parse(jsonData: object, item: SpellItemData, jsonTranslation?: object): SpellItemData {
         item.name = ImportHelper.StringValue(jsonData, 'name');
 
         item.system.description.source = `${ImportHelper.StringValue(jsonData, 'source')} ${ImportHelper.StringValue(jsonData, 'page')}`;

--- a/src/module/importer/parser/ware/CyberwareParser.ts
+++ b/src/module/importer/parser/ware/CyberwareParser.ts
@@ -3,7 +3,7 @@ import { TechnologyItemParserBase } from '../item/TechnologyItemParserBase';
 import Ware = Shadowrun.WareItemData;
 
 export class CyberwareParser extends TechnologyItemParserBase<Ware> {
-    Parse(jsonData: object, item: Ware, jsonTranslation?: object): Ware {
+    override Parse(jsonData: object, item: Ware, jsonTranslation?: object): Ware {
         item = super.Parse(jsonData, item, jsonTranslation);
 
         const essence = ImportHelper.StringValue(jsonData, 'ess', '0').match(/[0-9]\.?[0-9]*/g);

--- a/src/module/importer/parser/weapon/MeleeParser.ts
+++ b/src/module/importer/parser/weapon/MeleeParser.ts
@@ -44,7 +44,7 @@ export class MeleeParser extends WeaponParserBase {
         return DataDefaults.damageData(partialDamageData);
     }
 
-    Parse(jsonData: object, item: WeaponItemData, jsonTranslation?: object): WeaponItemData {
+    override Parse(jsonData: object, item: WeaponItemData, jsonTranslation?: object): WeaponItemData {
         item = super.Parse(jsonData, item, jsonTranslation);
 
         item.system.melee.reach = ImportHelper.IntValue(jsonData, 'reach');

--- a/src/module/importer/parser/weapon/RangedParser.ts
+++ b/src/module/importer/parser/weapon/RangedParser.ts
@@ -41,7 +41,7 @@ export class RangedParser extends WeaponParserBase {
         return match !== undefined ? parseInt(match) : 0;
     }
 
-    Parse(jsonData: object, item: WeaponItemData, jsonTranslation?: object): WeaponItemData {
+    override Parse(jsonData: object, item: WeaponItemData, jsonTranslation?: object): WeaponItemData {
         item = super.Parse(jsonData, item, jsonTranslation);
 
         // Some new weapons don't have any rc defined in XML.

--- a/src/module/importer/parser/weapon/ThrownParser.ts
+++ b/src/module/importer/parser/weapon/ThrownParser.ts
@@ -95,7 +95,7 @@ export class ThrownParser extends WeaponParserBase {
         return blastData;
     }
 
-    Parse(jsonData: object, item: WeaponItemData, jsonTranslation?: object): WeaponItemData {
+    override Parse(jsonData: object, item: WeaponItemData, jsonTranslation?: object): WeaponItemData {
         item = super.Parse(jsonData, item, jsonTranslation);
 
         if (jsonData.hasOwnProperty('range')) {

--- a/src/module/importer/parser/weapon/WeaponParserBase.ts
+++ b/src/module/importer/parser/weapon/WeaponParserBase.ts
@@ -47,7 +47,7 @@ export abstract class WeaponParserBase extends TechnologyItemParserBase<WeaponIt
         }
     }
 
-    public Parse(jsonData: object, item: WeaponItemData, jsonTranslation?: object): WeaponItemData {
+    public override Parse(jsonData: object, item: WeaponItemData, jsonTranslation?: object): WeaponItemData {
         item = super.Parse(jsonData, item, jsonTranslation);
 
         let category = ImportHelper.StringValue(jsonData, 'category');

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -104,7 +104,7 @@ export class SR5Item extends Item {
      *
      * If you need the actual actor owner, no matter how deep into item embedding, this current item is use SR5item.actorOwner
      */
-    get actor(): SR5Actor {
+    override get actor(): SR5Actor {
         return super.actor as unknown as SR5Actor;
     }
 
@@ -227,7 +227,7 @@ export class SR5Item extends Item {
      * - as of foundry v0.7.4, actor data isn't prepared by the time we prepare items
      * - this caused issues with Actions that have a Limit or Damage attribute and so those were moved
      */
-    prepareData() {
+    override prepareData() {
         super.prepareData();
         this.prepareNestedItems();
 
@@ -1501,7 +1501,7 @@ export class SR5Item extends Item {
         return this;
     }
 
-    async update(data, options?): Promise<this> {
+    override async update(data, options?): Promise<this> {
         // Item.item => Embedded item into another item!
         if (this._isNestedItem) {
             return this.updateNestedItem(data);
@@ -1718,7 +1718,7 @@ export class SR5Item extends Item {
         if (this.canBeNetworkDevice) await NetworkDeviceFlow.removeDeviceFromController(this);
     }
 
-    async _onCreate(changed, options, user) {
+    override async _onCreate(changed, options, user) {
         const applyData = {};
         //@ts-ignore
         Helpers.injectActionTestsIntoChangeData(this.type, changed, applyData);
@@ -1734,7 +1734,7 @@ export class SR5Item extends Item {
      *
      * This is preferred to altering data on the fly in the prepareData methods flow.
      */
-    async _preUpdate(changed, options: DocumentModificationOptions, user: User) {
+    override async _preUpdate(changed, options: DocumentModificationOptions, user: User) {
         // Some Foundry core updates will no diff and just replace everything. This doesn't match with the
         // differential approach of action test injection. (NOTE: Changing ownership of a document)
         if (options.diff !== false && options.recursive !== false) {

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -63,7 +63,7 @@ export class SR5ItemSheet extends ItemSheet {
      * Extend and override the default options used by the Simple Item Sheet
      * @returns {Object}
      */
-    static get defaultOptions() {
+    static override get defaultOptions() {
         // @ts-ignore // mergeObject breaks TypeScript typing. Should be fine.
         return mergeObject(super.defaultOptions, {
             classes: ['sr5', 'sheet', 'item'],
@@ -73,7 +73,7 @@ export class SR5ItemSheet extends ItemSheet {
         });
     }
 
-    get template() {
+    override get template() {
         const path = 'systems/shadowrun5e/dist/templates/item/';
         return `${path}${this.item.type}.html`;
     }
@@ -84,7 +84,7 @@ export class SR5ItemSheet extends ItemSheet {
      * Prepare data for rendering the Item sheet
      * The prepared data object contains both the actor data as well as additional sheet options
      */
-    async getData(options): Promise<any> {
+    override async getData(options): Promise<any> {
         const data = super.getData(options) as unknown as SR5ItemSheetData;
 
         // Rework v9 style data mapping to v10 style, while waiting for foundry-vtt-types to be update to v10.
@@ -246,7 +246,7 @@ export class SR5ItemSheet extends ItemSheet {
      * Activate event listeners using the prepared sheet HTML
      * @param html -  The prepared HTML object ready to be rendered into the DOM
      */
-    activateListeners(html) {
+    override activateListeners(html) {
         super.activateListeners(html);
 
         Helpers.setupCustomCheckbox(this, html);
@@ -314,13 +314,13 @@ export class SR5ItemSheet extends ItemSheet {
         html.find('.controller-remove').on('click', this._onControllerRemove.bind(this));
 
         // Prepare listeners only applied to item type action
-        if (this.document.isAction()) {
+        if (this.item.isAction()) {
             this._createActionModifierTagify(html);
             
         }
     }
 
-    async _onDrop(event) {
+    override async _onDrop(event) {
         if (!game.items || !game.actors || !game.scenes) return;
 
         event.preventDefault();
@@ -562,7 +562,7 @@ export class SR5ItemSheet extends ItemSheet {
     /**
      * @private
      */
-    async _render(force = false, options = {}) {
+    override async _render(force = false, options = {}) {
         // NOTE: This is for a timing bug. See function doc for code removal. Good luck, there be dragons here. - taM
         // this.fixStaleRenderedState();
 
@@ -574,7 +574,7 @@ export class SR5ItemSheet extends ItemSheet {
     /**
      * @private
      */
-    _restoreScrollPositions() {
+    override _restoreScrollPositions() {
         const activeList = this._findActiveList();
         if (activeList.length && this._scroll != null) {
             activeList.prop('scrollTop', this._scroll);
@@ -584,7 +584,7 @@ export class SR5ItemSheet extends ItemSheet {
     /**
      * @private
      */
-    _saveScrollPositions() {
+    override _saveScrollPositions() {
         const activeList = this._findActiveList();
         if (activeList.length) {
             this._scroll = activeList.prop('scrollTop');

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -95,7 +95,7 @@ export class SR5ItemSheet extends ItemSheet {
         data.system = data.item.system;
         //@ts-ignore // TODO: remove TODO: foundry-vtt-types v10
         data.data = data.item.system;
-        const itemData = this.document.system;
+        const itemData = this.item.system;
 
         if (itemData.action) {
             try {
@@ -155,7 +155,7 @@ export class SR5ItemSheet extends ItemSheet {
         data['limits'] = this._getSortedLimitsForSelect();
 
         // Active Effects data.
-        data['effects'] = prepareActiveEffectCategories(this.document.effects);
+        data['effects'] = prepareActiveEffectCategories(this.item.effects);
 
         if (this.item.isHost) {
             data['markedDocuments'] = this.item.getAllMarkedDocuments();
@@ -236,7 +236,7 @@ export class SR5ItemSheet extends ItemSheet {
     }
 
     _getNetworkDevices(): SR5Item[] {
-        // return NetworkDeviceFlow.getNetworkDevices(this.document);
+        // return NetworkDeviceFlow.getNetworkDevices(this.item);
         return [];
     }
 
@@ -260,7 +260,7 @@ export class SR5ItemSheet extends ItemSheet {
         this.form.ondrop = (event) => this._onDrop(event);
 
         // Active Effect management
-        html.find(".effect-control").click(event => onManageActiveEffect(event, this.document));
+        html.find(".effect-control").click(event => onManageActiveEffect(event, this.item));
 
         /**
          * General item handling
@@ -529,7 +529,7 @@ export class SR5ItemSheet extends ItemSheet {
         const maxItems = Object.keys(SR5.modifierTypes).length;
 
         // Use localized label as value, and modifier as the later to be extracted value 
-        const modifiers = this.document.system.action?.modifiers ?? []; 
+        const modifiers = this.item.system.action?.modifiers ?? []; 
         const tags = modifiers.map(modifier => ({
             value: game.i18n.localize(SR5.modifierTypes[modifier]),
             id: modifier
@@ -540,7 +540,7 @@ export class SR5ItemSheet extends ItemSheet {
         html.find('input#action-modifier').on('change', async (event) => {
             const modifiers = tagify.value.map(tag => tag.id);
             // render would loose tagify input focus. submit on close will save.
-            await this.document.update({'system.action.modifiers': modifiers}, {render:false});
+            await this.item.update({'system.action.modifiers': modifiers}, {render:false});
         });
     }
 
@@ -553,7 +553,7 @@ export class SR5ItemSheet extends ItemSheet {
      */
     private fixStaleRenderedState() {
         if (this._state === Application.RENDER_STATES.RENDERED && ui.windows[this.appId] === undefined) {
-            console.warn(`SR5ItemSheet app for ${this.document.name} is set as RENDERED but has no window registered. Fixing app internal render state. This is a known bug.`);
+            console.warn(`SR5ItemSheet app for ${this.item.name} is set as RENDERED but has no window registered. Fixing app internal render state. This is a known bug.`);
             // Hotfixing instead of this.close() since FormApplication.close() expects form elements, which don't exist anymore.
             this._state = Application.RENDER_STATES.CLOSED;
         }
@@ -594,7 +594,7 @@ export class SR5ItemSheet extends ItemSheet {
     async _onMarksQuantityChange(event) {
         event.stopPropagation();
 
-        if (!this.object.isHost) return;
+        if (!this.item.isHost) return;
 
         const markId = event.currentTarget.dataset.markId;
         if (!markId) return;
@@ -605,13 +605,13 @@ export class SR5ItemSheet extends ItemSheet {
         if (!scene || !target) return; // item can be undefined.
 
         const marks = parseInt(event.currentTarget.value);
-        await this.object.setMarks(target, marks, {scene, item, overwrite: true});
+        await this.item.setMarks(target, marks, {scene, item, overwrite: true});
     }
 
     async _onMarksQuantityChangeBy(event, by: number) {
         event.stopPropagation();
 
-        if (!this.object.isHost) return;
+        if (!this.item.isHost) return;
 
         const markId = event.currentTarget.dataset.markId;
         if (!markId) return;
@@ -621,13 +621,13 @@ export class SR5ItemSheet extends ItemSheet {
         const {scene, target, item} = markedIdDocuments;
         if (!scene || !target) return; // item can be undefined.
 
-        await this.object.setMarks(target, by, {scene, item});
+        await this.item.setMarks(target, by, {scene, item});
     }
 
     async _onMarksDelete(event) {
         event.stopPropagation();
 
-        if (!this.object.isHost) return;
+        if (!this.item.isHost) return;
 
         const markId = event.currentTarget.dataset.markId;
         if (!markId) return;
@@ -635,18 +635,18 @@ export class SR5ItemSheet extends ItemSheet {
         const userConsented = await Helpers.confirmDeletion();
         if (!userConsented) return;
 
-        await this.object.clearMark(markId);
+        await this.item.clearMark(markId);
     }
 
     async _onMarksClearAll(event) {
         event.stopPropagation();
 
-        if (!this.object.isHost) return;
+        if (!this.item.isHost) return;
 
         const userConsented = await Helpers.confirmDeletion();
         if (!userConsented) return;
 
-        await this.object.clearMarks();
+        await this.item.clearMarks();
     }
 
     async _onOpenOriginLink(event) {

--- a/src/module/migrator/versions/Version0_8_0.ts
+++ b/src/module/migrator/versions/Version0_8_0.ts
@@ -23,7 +23,7 @@ export class Version0_8_0 extends VersionMigration {
         return "0.8.0";
     }
 
-    protected async ShouldMigrateItemData(data: ShadowrunItemData) {
+    protected override async ShouldMigrateItemData(data: ShadowrunItemData) {
         return this._ShouldMigrateItemData(data);
     }
 
@@ -31,16 +31,16 @@ export class Version0_8_0 extends VersionMigration {
         return ['weapon', 'spell'].includes(data.type);
     }
 
-    protected async ShouldMigrateSceneData(scene: Scene) {
+    protected override async ShouldMigrateSceneData(scene: Scene) {
         return scene.tokens.size > 0;
     }
 
-    protected async ShouldMigrateActorData(data: ShadowrunActorData) {
+    protected override async ShouldMigrateActorData(data: ShadowrunActorData) {
         // @ts-ignore
         return data.items.contents.filter(i => this._ShouldMigrateItemData(i.data)).length > 0;
     }
 
-    protected async MigrateItemData(data: ShadowrunItemData) {
+    protected override async MigrateItemData(data: ShadowrunItemData) {
         const updateData: {
             data?: object
         } = {};
@@ -50,7 +50,7 @@ export class Version0_8_0 extends VersionMigration {
         return updateData;
     }
 
-    protected async MigrateActorData(data: ShadowrunActorData) {
+    protected override async MigrateActorData(data: ShadowrunActorData) {
         let updateData: {
             data?: object,
             items?: object[]

--- a/src/module/rolls/SR5Roll.ts
+++ b/src/module/rolls/SR5Roll.ts
@@ -26,7 +26,7 @@ interface ShadowrunChatMessageData {
  * TODO: A chat message should contain all data needed to cast resulting actions.
  */
 export class SR5Roll extends Roll {
-    data: ShadowrunRollData
+    override data: ShadowrunRollData
 
     // toJSON(): any {
     //     // TODO: Check if data includes custom ShadowrunRollData
@@ -113,7 +113,7 @@ export class SR5Roll extends Roll {
         return this.glitches > Math.floor(this.pool / 2);
     }
 
-    get total(): number {
+    override get total(): number {
         return this.hits;
     }
 }

--- a/src/module/rules/modifiers/BackgroundCountModifier.ts
+++ b/src/module/rules/modifiers/BackgroundCountModifier.ts
@@ -6,7 +6,7 @@ import BackgroundCountModifiersData = Shadowrun.BackgroundCountModifiersData;
  * Rules application of situation modifieres for magic.
  */
 export class BackgroundCountModifier extends SituationModifier {
-    source: BackgroundCountModifiersSourceData
-    applied: BackgroundCountModifiersData
-    type: Shadowrun.SituationModifierType = 'background_count';
+    override source: BackgroundCountModifiersSourceData
+    override applied: BackgroundCountModifiersData
+    override type: Shadowrun.SituationModifierType = 'background_count';
 }

--- a/src/module/rules/modifiers/DefenseModifier.ts
+++ b/src/module/rules/modifiers/DefenseModifier.ts
@@ -11,7 +11,7 @@ export class DefenseModifier extends SituationModifier {
     /**
      * Defense modifier is a legacy modifier but can differ based set actor modifiers
      */
-    static get hasSourceData() {
+    static override get hasSourceData() {
         return false;
     }
 
@@ -19,7 +19,7 @@ export class DefenseModifier extends SituationModifier {
      * Depending on the test context additional defense modifiers might apply
      * 
      */
-    _calcActiveTotal(options:SituationalModifierApplyOptions): number {
+    override _calcActiveTotal(options:SituationalModifierApplyOptions): number {
         if (!this.modifiers || !this.modifiers.documentIsActor) return 0;
         
         const actor = this.modifiers.document as SR5Actor;

--- a/src/module/rules/modifiers/EnvironmentalModifier.ts
+++ b/src/module/rules/modifiers/EnvironmentalModifier.ts
@@ -8,9 +8,9 @@ import EnvironmentalModifiersData = Shadowrun.EnvironmentalModifiersData;
   * Rules application of situation modifieres for matrix.
  */
 export class EnvironmentalModifier extends SituationModifier {
-    source: EnvironmentalModifiersSourceData
-    applied: EnvironmentalModifiersData
-    type: Shadowrun.SituationModifierType = 'environmental';
+    override source: EnvironmentalModifiersSourceData
+    override applied: EnvironmentalModifiersData
+    override type: Shadowrun.SituationModifierType = 'environmental';
 
     
     get levels(): EnvironmentalModifierLevels {
@@ -39,7 +39,7 @@ export class EnvironmentalModifier extends SituationModifier {
      * 
      * SR5#173 'Environmental Modifiers'
      */
-    _calcActiveTotal(): number {
+    override _calcActiveTotal(): number {
         // A fixed value selection overrides other selections.
         if (this.applied.active.value)
             return this.applied.active.value;
@@ -67,7 +67,7 @@ export class EnvironmentalModifier extends SituationModifier {
         return this.levels.good;
     }
 
-    setInactive(modifier: string): void {
+    override setInactive(modifier: string): void {
         if (this.source.active[modifier] !== this.applied.active[modifier]) this.setActive(modifier, 0);
         else delete this.source.active[modifier];
     }

--- a/src/module/rules/modifiers/NoiseModifier.ts
+++ b/src/module/rules/modifiers/NoiseModifier.ts
@@ -6,7 +6,7 @@ import NoiseModifiersData = Shadowrun.NoiseModifiersData;
  * Rules application of situation modifieres for matrix.
  */
 export class NoiseModifier extends SituationModifier {
-    source: NoiseModifiersSourceData
-    applied: NoiseModifiersData
-    type: Shadowrun.SituationModifierType = 'noise'
+    override source: NoiseModifiersSourceData
+    override applied: NoiseModifiersData
+    override type: Shadowrun.SituationModifierType = 'noise'
 }

--- a/src/module/rules/modifiers/RecoilModifier.ts
+++ b/src/module/rules/modifiers/RecoilModifier.ts
@@ -12,11 +12,11 @@ export class RecoilModifier extends SituationModifier  {
     /**
      * Recoil modifiers don't allow for any selection.
      */
-    static get hasSourceData() {
+    static override get hasSourceData() {
         return false;
     }
 
-    _calcActiveTotal(options: SituationalModifierApplyOptions): number {
+    override _calcActiveTotal(options: SituationalModifierApplyOptions): number {
         if (!this.modifiers || !this.modifiers.documentIsActor) return 0;
 
         if (!options.test || options.test.type !== 'RangedAttackTest') return (this.modifiers.document as SR5Actor)?.recoil ?? 0;

--- a/src/module/template.ts
+++ b/src/module/template.ts
@@ -1,8 +1,8 @@
 import { SR5Item } from './item/SR5Item';
 
 export default class Template extends MeasuredTemplate {
-    x: number;
-    y: number;
+    override x: number;
+    override y: number;
     item?: SR5Item;
     onComplete?: () => void;
 

--- a/src/module/tests/AttributeOnlyTest.ts
+++ b/src/module/tests/AttributeOnlyTest.ts
@@ -15,12 +15,12 @@ export interface AttributeOnlyTestData extends SuccessTestData {
  * Main difference is the user ability to change attributes before rolling dice.
  */
 export class AttributeOnlyTest extends SuccessTest {
-    data: AttributeOnlyTestData
+    override data: AttributeOnlyTestData
 
-    get _dialogTemplate() {
+    override get _dialogTemplate() {
         return 'systems/shadowrun5e/dist/templates/apps/dialogs/attribute-only-test-dialog.html';
     }
-    _prepareData(data, options): any {
+    override _prepareData(data, options): any {
         data = super._prepareData(data, options);
 
         // Preset attribute selection with action attributes.
@@ -30,7 +30,7 @@ export class AttributeOnlyTest extends SuccessTest {
         return data;
     }
 
-    prepareBaseValues() {
+    override prepareBaseValues() {
         this.prepareAttributeSelection();
 
         super.prepareBaseValues();

--- a/src/module/tests/CombatSpellDefenseTest.ts
+++ b/src/module/tests/CombatSpellDefenseTest.ts
@@ -13,8 +13,8 @@ export interface CombatSpellDefenseTestData extends DefenseTestData {
 }
 
 export class CombatSpellDefenseTest extends DefenseTest {
-    data: CombatSpellDefenseTestData
-    against: SpellCastingTest
+    override data: CombatSpellDefenseTestData
+    override against: SpellCastingTest
 
     /**
      * A combat spell defense test changes it's behaviour based on the spell it's defending against.
@@ -22,7 +22,7 @@ export class CombatSpellDefenseTest extends DefenseTest {
      * @param item A spell item.
      * @param actor The actor to defend with.
      */
-    static async _getDocumentTestAction(item: SR5Item, actor: SR5Actor): Promise<MinimalActionData> {
+    static override async _getDocumentTestAction(item: SR5Item, actor: SR5Actor): Promise<MinimalActionData> {
         const action = DataDefaults.minimalActionData(await super._getDocumentTestAction(item, actor));
 
         const spellData = item.asSpell
@@ -32,12 +32,12 @@ export class CombatSpellDefenseTest extends DefenseTest {
         return TestCreator._mergeMinimalActionDataInOrder(action, itemAction);
     }
 
-    prepareBaseValues() {
+    override prepareBaseValues() {
         super.prepareBaseValues();
         this.calculateCombatSpellDamage();
     }
 
-    get testModifiers(): ModifierTypes[] {
+    override get testModifiers(): ModifierTypes[] {
         const spell = this.item?.asSpell;
         if (!spell) return ['global'];
 
@@ -64,7 +64,7 @@ export class CombatSpellDefenseTest extends DefenseTest {
         this.data.incomingDamage = CombatSpellRules.calculateBaseDamage(spell.system.combat.type, this.data.incomingDamage, this.data.against.force);
     }
 
-    async processResults() {
+    override async processResults() {
         await super.processResults();
 
         await this.applyActorEffectsForDefense();
@@ -74,7 +74,7 @@ export class CombatSpellDefenseTest extends DefenseTest {
     /**
      * A success on a defense test is a MISS on the initial attack.
      */
-    async processSuccess() {
+    override async processSuccess() {
         this.data.modifiedDamage = CombatSpellRules.modifyDamageAfterMiss(this.data.incomingDamage);
 
         await super.processSuccess();
@@ -83,7 +83,7 @@ export class CombatSpellDefenseTest extends DefenseTest {
     /**
      * A failure on a defense test is a HIT on the initial attack.
      */
-    async processFailure() {
+    override async processFailure() {
         const spell = this.item?.asSpell;
         if (!spell) return;
         if (!this.actor) return;
@@ -97,7 +97,7 @@ export class CombatSpellDefenseTest extends DefenseTest {
     /**
      * Combat Spell Defense allows a resist test for the defending actor.
      */
-    async afterFailure() {
+    override async afterFailure() {
         const spell = this.item?.asSpell;
         if (!spell) return;
 

--- a/src/module/tests/ComplexFormTest.ts
+++ b/src/module/tests/ComplexFormTest.ts
@@ -17,9 +17,9 @@ export interface ComplexFormTestData extends SuccessTestData {
  * Handles threading complex forms as described on SR5#251.
  */
 export class ComplexFormTest extends SuccessTest {
-    data: ComplexFormTestData
+    override data: ComplexFormTestData
 
-    _prepareData(data, options): any {
+    override _prepareData(data, options): any {
         data = super._prepareData(data, options);
 
         data.level =  data.level || 0;
@@ -29,22 +29,22 @@ export class ComplexFormTest extends SuccessTest {
         return data;
     }
 
-    get _dialogTemplate()  {
+    override get _dialogTemplate()  {
         return 'systems/shadowrun5e/dist/templates/apps/dialogs/complexform-test-dialog.html';
     }
 
-    get _chatMessageTemplate(): string {
+    override get _chatMessageTemplate(): string {
         return 'systems/shadowrun5e/dist/templates/rolls/complexform-test-message.html';
     }
 
     /**
      * This test type can't be extended.
      */
-    get canBeExtended() {
+    override get canBeExtended() {
         return false;
     }
 
-    static _getDefaultTestAction(): Partial<MinimalActionData> {
+    static override _getDefaultTestAction(): Partial<MinimalActionData> {
         return {
             skill: 'software',
             attribute: 'resonance'
@@ -52,11 +52,11 @@ export class ComplexFormTest extends SuccessTest {
     }
 
     // TODO: Add missing modifiers (gitter) // SR5#251
-    get testModifiers(): ModifierTypes[] {
+    override get testModifiers(): ModifierTypes[] {
         return ['global', 'wounds', 'noise'];
     }
 
-    async prepareDocumentData() {
+    override async prepareDocumentData() {
         this.prepareInitialLevelValue();
         await super.prepareDocumentData();
     }
@@ -72,7 +72,7 @@ export class ComplexFormTest extends SuccessTest {
         this.data.level = lastUsedLevel.value || suggestedLevel;
     }
 
-    prepareBaseValues() {
+    override prepareBaseValues() {
         super.prepareBaseValues();
         this.prepareLevelValue();
         this.prepareLimitValue();
@@ -97,7 +97,7 @@ export class ComplexFormTest extends SuccessTest {
         )
     }
 
-    calculateBaseValues() {
+    override calculateBaseValues() {
         super.calculateBaseValues();
         this.calculateFadeValue();
     }
@@ -117,13 +117,13 @@ export class ComplexFormTest extends SuccessTest {
         this.data.fadeDamage = FadeRules.calcFadeDamage(fade, this.hits.value, resonance);
     }
 
-    async processResults() {
+    override async processResults() {
         this.calculateFadeDamage();
 
         await super.processResults();
     }
 
-    async afterTestComplete() {
+    override async afterTestComplete() {
         await this.saveLastUsedLevel();
 
         await super.afterTestComplete();

--- a/src/module/tests/DefenseTest.ts
+++ b/src/module/tests/DefenseTest.ts
@@ -22,9 +22,9 @@ export interface DefenseTestData extends OpposedTestData {
  * Handle general damage data as well as general defense rules.
  */
 export class DefenseTest extends OpposedTest {
-    data: DefenseTestData
+    override data: DefenseTestData
 
-    _prepareData(data, options?) {
+    override _prepareData(data, options?) {
         data = super._prepareData(data, options);
 
         const damage = data.against ? data.against.damage : DataDefaults.damageData();
@@ -35,15 +35,15 @@ export class DefenseTest extends OpposedTest {
         return data;
     }
 
-    get _chatMessageTemplate() {
+    override get _chatMessageTemplate() {
         return 'systems/shadowrun5e/dist/templates/rolls/defense-test-message.html'
     }
 
-    get successLabel() {
+    override get successLabel() {
         return 'SR5.AttackDodged';
     }
 
-    get failureLabel() {
+    override get failureLabel() {
         return 'SR5.AttackHits';
     }
 

--- a/src/module/tests/DrainTest.ts
+++ b/src/module/tests/DrainTest.ts
@@ -22,9 +22,9 @@ export interface DrainTestData extends SuccessTestData {
  * both of which the user can apply.
  */
 export class DrainTest extends SuccessTest {
-    data: DrainTestData
+    override data: DrainTestData
 
-    _prepareData(data, options): any {
+    override _prepareData(data, options): any {
         data = super._prepareData(data, options);
 
         data.against = data.against || new SpellCastingTest({}, {}, options).data;
@@ -35,15 +35,15 @@ export class DrainTest extends SuccessTest {
         return data;
     }
 
-    get _dialogTemplate(): string {
+    override get _dialogTemplate(): string {
         return 'systems/shadowrun5e/dist/templates/apps/dialogs/drain-test-dialog.html';
     }
 
-    get _chatMessageTemplate(): string {
+    override get _chatMessageTemplate(): string {
         return 'systems/shadowrun5e/dist/templates/rolls/drain-test-message.html';
     }
 
-    static _getDefaultTestAction(): Partial<MinimalActionData> {
+    static override _getDefaultTestAction(): Partial<MinimalActionData> {
         return {
             'attribute2': 'willpower'
         };
@@ -52,15 +52,15 @@ export class DrainTest extends SuccessTest {
     /**
      * This test type can't be extended.
      */
-    get canBeExtended() {
+    override get canBeExtended() {
         return false;
     }
 
-    get testModifiers(): ModifierTypes[] {
+    override get testModifiers(): ModifierTypes[] {
         return ['global', 'drain']
     }
 
-    static async _getDocumentTestAction(item, actor) {
+    static override async _getDocumentTestAction(item, actor) {
         const documentAction = await super._getDocumentTestAction(item, actor);
 
         if (!actor.isAwakened) {
@@ -79,7 +79,7 @@ export class DrainTest extends SuccessTest {
     /**
      * Re-calculate incomingDrain in case of user input
      */
-    calculateBaseValues() {
+    override calculateBaseValues() {
         super.calculateBaseValues();
 
         Helpers.calcValue<typeof this.data.incomingDrain.type.base>(this.data.incomingDrain.type as GenericValueField);
@@ -93,19 +93,19 @@ export class DrainTest extends SuccessTest {
     /**
      * A drain test is successful whenever it has more hits than drain damage
      */
-    get success(): boolean {
+    override get success(): boolean {
         return this.data.modifiedDrain.value <= 0;
     }
 
-    get successLabel(): string {
+    override get successLabel(): string {
         return 'SR5.ResistedAllDamage';
     }
 
-    get failureLabel(): string {
+    override get failureLabel(): string {
         return 'SR5.ResistedSomeDamage'
     }
 
-    async processResults() {
+    override async processResults() {
         // Don't use incomingDrain as it might have a user value override applied.
         this.data.modifiedDrain = DrainRules.modifyDrainDamage(this.data.modifiedDrain, this.hits.value);
 

--- a/src/module/tests/DroneInfiltrationTest.ts
+++ b/src/module/tests/DroneInfiltrationTest.ts
@@ -1,7 +1,7 @@
 import {SuccessTest} from "./SuccessTest";
 
 export class DroneInfiltrationTest extends SuccessTest {
-    static async _getDocumentTestAction(item, actor) {
+    static override async _getDocumentTestAction(item, actor) {
         // Both item and actor are needed to determine what to roll.
         if (!item || !actor) return {};
 

--- a/src/module/tests/DronePerceptionTest.ts
+++ b/src/module/tests/DronePerceptionTest.ts
@@ -1,7 +1,7 @@
 import {SuccessTest} from "./SuccessTest";
 
 export class DronePerceptionTest extends SuccessTest {
-    static async _getDocumentTestAction(item, actor) {
+    static override async _getDocumentTestAction(item, actor) {
         // Both item and actor are needed to determine what to roll.
         if (!item || !actor) return {};
 

--- a/src/module/tests/FadeTest.ts
+++ b/src/module/tests/FadeTest.ts
@@ -14,10 +14,10 @@ export interface FadeTestData extends SuccessTestData {
 }
 
 export class FadeTest extends SuccessTest {
-    data: FadeTestData
+    override data: FadeTestData
     against: ComplexFormTest
 
-    _prepareData(data, options): any {
+    override _prepareData(data, options): any {
         data = super._prepareData(data, options);
 
         data.against = data.against || new ComplexFormTest({}, {}, options).data;
@@ -28,55 +28,55 @@ export class FadeTest extends SuccessTest {
         return data;
     }
 
-    get _dialogTemplate() {
+    override get _dialogTemplate() {
         return 'systems/shadowrun5e/dist/templates/apps/dialogs/fade-test-dialog.html';
     }
 
-    get _chatMessageTemplate(): string {
+    override get _chatMessageTemplate(): string {
         return 'systems/shadowrun5e/dist/templates/rolls/fade-test-message.html';
     }
 
-    static _getDefaultTestAction(): Partial<MinimalActionData> {
+    static override _getDefaultTestAction(): Partial<MinimalActionData> {
         return {
             'attribute': 'resonance',
             'attribute2': 'willpower'
         };
     }
 
-    get testModifiers(): ModifierTypes[] {
+    override get testModifiers(): ModifierTypes[] {
         return ['global', 'fade']
     }
 
-     get canBeExtended() {
+     override get canBeExtended() {
         return false;
     }
 
     /**
      * A drain test is successful whenever it has more hits than drain damage
      */
-    get success(): boolean {
+    override get success(): boolean {
         return this.data.modifiedFade.value <= 0;
     }
 
-    get successLabel(): string {
+    override get successLabel(): string {
         return 'SR5.ResistedAllDamage';
     }
 
-    get failureLabel(): string {
+    override get failureLabel(): string {
         return 'SR5.ResistedSomeDamage'
     }
 
     /**
      * Re-calculate incomingFade in case of user input
      */
-    calculateBaseValues() {
+    override calculateBaseValues() {
         super.calculateBaseValues();
 
         // Avoid using a user defined value override.
         this.data.modifiedFade.base = Helpers.calcTotal(this.data.incomingFade, {min: 0});
     }
 
-    async processResults() {
+    override async processResults() {
         // Don't use incomingDrain as it might have a user value override applied.
         this.data.modifiedFade = FadeRules.modifyFadeDamage(this.data.modifiedFade, this.hits.value);
 

--- a/src/module/tests/MeleeAttackTest.ts
+++ b/src/module/tests/MeleeAttackTest.ts
@@ -10,9 +10,9 @@ export interface MeleeAttackData extends SuccessTestData {
 }
 
 export class MeleeAttackTest extends SuccessTest {
-    data: MeleeAttackData;
+    override data: MeleeAttackData;
 
-    _prepareData(data, options): any {
+    override _prepareData(data, options): any {
         data = super._prepareData(data, options);
 
         data.damage = data.damage || DataDefaults.damageData();
@@ -23,23 +23,23 @@ export class MeleeAttackTest extends SuccessTest {
     /**
      * This test type can't be extended.
      */
-    get canBeExtended() {
+    override get canBeExtended() {
         return false;
     }
 
-     get testModifiers(): ModifierTypes[] {
+     override get testModifiers(): ModifierTypes[] {
         return ['global', 'wounds', 'environmental'];
     }
 
-     get _dialogTemplate(): string {
+     override get _dialogTemplate(): string {
         return 'systems/shadowrun5e/dist/templates/apps/dialogs/melee-attack-test-dialog.html';
     }
 
-    get showSuccessLabel(): boolean {
+    override get showSuccessLabel(): boolean {
         return this.success;
     }
 
-    async prepareDocumentData() {
+    override async prepareDocumentData() {
         if (!this.item || !this.item.isMeleeWeapon) return;
 
         this.data.reach = this.item.getReach();
@@ -55,7 +55,7 @@ export class MeleeAttackTest extends SuccessTest {
      * @param actor 
      * @param type 
      */
-    prepareActorModifier(actor: SR5Actor, type: ModifierTypes): { name: string; value: number; } {
+    override prepareActorModifier(actor: SR5Actor, type: ModifierTypes): { name: string; value: number; } {
         if (type !== 'environmental') return super.prepareActorModifier(actor, type);
 
         // Only light and visibility apply.

--- a/src/module/tests/NaturalRecoveryPhysicalTest.ts
+++ b/src/module/tests/NaturalRecoveryPhysicalTest.ts
@@ -2,7 +2,7 @@ import {SuccessTest} from "./SuccessTest";
 import {PartsList} from "../parts/PartsList";
 
 export class NaturalRecoveryPhysicalTest extends SuccessTest {
-    async execute(): Promise<this> {
+    override async execute(): Promise<this> {
         if (!this.actor) return this;
         if (!this.actor.canRecoverPhysicalDamage) {
             ui.notifications?.warn(game.i18n.localize('SR5.Warnings.CantRecoverPhysicalWithStunDamage'));
@@ -12,7 +12,7 @@ export class NaturalRecoveryPhysicalTest extends SuccessTest {
         return super.execute();
     }
 
-    prepareBaseValues() {
+    override prepareBaseValues() {
         super.prepareBaseValues();
         this.prepareThreshold();
     }
@@ -33,7 +33,7 @@ export class NaturalRecoveryPhysicalTest extends SuccessTest {
     /**
      * A recovery test will heal on each test iteration
      */
-    async processResults() {
+    override async processResults() {
         await super.processResults();
 
         // Don't bother healing if the actor can't.

--- a/src/module/tests/NaturalRecoveryStunTest.ts
+++ b/src/module/tests/NaturalRecoveryStunTest.ts
@@ -2,7 +2,7 @@ import {SuccessTest} from "./SuccessTest";
 import {PartsList} from "../parts/PartsList";
 
 export class NaturalRecoveryStunTest extends SuccessTest {
-    prepareBaseValues() {
+    override prepareBaseValues() {
         super.prepareBaseValues();
         this.prepareThreshold();
     }
@@ -23,7 +23,7 @@ export class NaturalRecoveryStunTest extends SuccessTest {
     /**
      * A recovery test will heal on each test iteration
      */
-    async processResults() {
+    override async processResults() {
         await super.processResults();
 
         // Don't bother healing if the actor can't.

--- a/src/module/tests/OpposedTest.ts
+++ b/src/module/tests/OpposedTest.ts
@@ -23,7 +23,7 @@ export interface OpposedTestData extends
  * An opposed test results from a normal success test as an opposed action.
  */
 export class OpposedTest extends SuccessTest {
-    public data: OpposedTestData;
+    public override data: OpposedTestData;
     public against: SuccessTest;
 
     constructor(data, documents?: TestDocuments, options?: TestOptions) {
@@ -36,7 +36,7 @@ export class OpposedTest extends SuccessTest {
         this.against = new AgainstCls(data.against || {});
     }
 
-    _prepareData(data, options?): any {
+    override _prepareData(data, options?): any {
         data = super._prepareData(data, options);
 
         // TODO: this isn't needed if opposed is always taken from data.action.opposed
@@ -46,12 +46,12 @@ export class OpposedTest extends SuccessTest {
         return data;
     }
 
-    async populateDocuments() {
+    override async populateDocuments() {
         await super.populateDocuments();
         await this.against.populateDocuments();
     }
 
-    static async _getOpposedActionTestData(againstData: SuccessTestData, actor, previousMessageId: string): Promise<OpposedTestData | undefined> {
+    static override async _getOpposedActionTestData(againstData: SuccessTestData, actor, previousMessageId: string): Promise<OpposedTestData | undefined> {
         if (!againstData.opposed) {
             console.error(`Shadowrun 5e | Supplied test data doesn't contain an opposed action`, againstData, this);
             return;
@@ -113,42 +113,42 @@ export class OpposedTest extends SuccessTest {
     /**
      * Overwrite SuccessTest#opposed behavior as an OpposedTest can't have another opposed test.
      */
-    get opposed() {
+    override get opposed() {
         return false;
     }
 
     /**
      * Overwrite SuccessTest#opposing behavior as an OpposedTest is opposing another test.
      */
-    get opposing() {
+    override get opposing() {
         return true;
     }
 
     /**
      * This test type can't be extended.
      */
-    get canBeExtended() {
+    override get canBeExtended() {
         return false;
     }
 
     /**
      * Opposed tests shouldn't show item description from the active tests source item.
      */
-    get _canShowDescription(): boolean {
+    override get _canShowDescription(): boolean {
         return false;
     }
 
     /**
      * Opposed tests can't cause any blast template.
      */
-    get _canPlaceBlastTemplate(): boolean {
+    override get _canPlaceBlastTemplate(): boolean {
         return false;
     }
 
     /**
      * Apply opposed test modifiers based on the item implementation
      */
-    async prepareItemModifiers() {
+    override async prepareItemModifiers() {
         if (!this.item) return;
 
         // NOTE: This is a legacy method for applying item data based modifiers, but it will do.
@@ -179,7 +179,7 @@ export class OpposedTest extends SuccessTest {
         await TestCreator.fromMessageAction(messageId, opposedActionTest, {showDialog});
     }
 
-    static async chatMessageListeners(message: ChatMessage, html, data) {
+    static override async chatMessageListeners(message: ChatMessage, html, data) {
         html.find('.opposed-action').on('click', OpposedTest._castOpposedAction);
     }
 }

--- a/src/module/tests/PhysicalDefenseTest.ts
+++ b/src/module/tests/PhysicalDefenseTest.ts
@@ -23,9 +23,9 @@ export interface PhysicalDefenseTestData extends DefenseTestData {
 
 
 export class PhysicalDefenseTest extends DefenseTest {
-    public data: PhysicalDefenseTestData;
+    public override data: PhysicalDefenseTestData;
 
-    _prepareData(data, options?): any {
+    override _prepareData(data, options?): any {
         data = super._prepareData(data, options);
 
         data.cover = 0;
@@ -37,22 +37,22 @@ export class PhysicalDefenseTest extends DefenseTest {
         return data;
     }
 
-    get _dialogTemplate(): string {
+    override get _dialogTemplate(): string {
         return 'systems/shadowrun5e/dist/templates/apps/dialogs/physical-defense-test-dialog.html';
     }
 
-    static _getDefaultTestAction(): Partial<MinimalActionData> {
+    static override _getDefaultTestAction(): Partial<MinimalActionData> {
         return {
             'attribute': 'reaction',
             'attribute2': 'intuition'
         };
     }
 
-    get testModifiers(): ModifierTypes[] {
+    override get testModifiers(): ModifierTypes[] {
         return ['global', 'wounds', 'defense', 'multi_defense'];
     }
 
-    async prepareDocumentData() {
+    override async prepareDocumentData() {
         this.prepareActiveDefense();
         this.prepareMeleeReach();
         await super.prepareDocumentData();
@@ -119,12 +119,12 @@ export class PhysicalDefenseTest extends DefenseTest {
         this.data.defenseReach = MeleeRules.defenseReachModifier(incomingReach, defenseReach);
     }
 
-    calculateBaseValues() {
+    override calculateBaseValues() {
         super.calculateBaseValues();
         this.applyIniModFromActiveDefense();
     }
 
-    applyPoolModifiers() {
+    override applyPoolModifiers() {
         this.applyPoolCoverModifier();
         this.applyPoolActiveDefenseModifier();
         this.applyPoolMeleeReachModifier();
@@ -169,27 +169,27 @@ export class PhysicalDefenseTest extends DefenseTest {
         PartsList.AddUniquePart(this.data.modifiers.mod, fireMode.label, Number(fireMode.defense));
     }
 
-    get success() {
+    override get success() {
         return CombatRules.attackMisses(this.against.hits.value, this.hits.value);
     }
 
-    get failure() {
+    override get failure() {
         return CombatRules.attackHits(this.against.hits.value, this.hits.value)
     }
 
-    async processResults() {
+    override async processResults() {
         await super.processResults();
 
         await this.applyActorEffectsForDefense();
     }
 
-    async processSuccess() {
+    override async processSuccess() {
         this.data.modifiedDamage = CombatRules.modifyDamageAfterMiss(this.data.incomingDamage);
 
         await super.processSuccess();
     }
 
-    async processFailure() {
+    override async processFailure() {
         if (!this.actor) return;
 
         this.data.modifiedDamage = CombatRules.modifyDamageAfterHit(this.actor, this.against.hits.value, this.hits.value, this.data.incomingDamage);
@@ -197,13 +197,13 @@ export class PhysicalDefenseTest extends DefenseTest {
         await super.processFailure();
     }
 
-    async afterFailure() {
+    override async afterFailure() {
         const test = await TestCreator.fromOpposedTestResistTest(this, this.data.options);
         if (!test) return;
         await test.execute();
     }
 
-    canConsumeDocumentRessources() {
+    override canConsumeDocumentRessources() {
         // Check if the actor is in active combat situation and has enough initiative score left.
         if (this.actor && this.data.iniMod && game.combat) {
             const combat: SR5Combat = game.combat as unknown as SR5Combat;
@@ -233,7 +233,7 @@ export class PhysicalDefenseTest extends DefenseTest {
         this.data.iniMod = activeDefense.initMod;
     }
 
-    _prepareResultActionsTemplateData() {
+    override _prepareResultActionsTemplateData() {
         const actions = super._prepareResultActionsTemplateData();
 
         // Don't add an action if no active defense was selected.

--- a/src/module/tests/PhysicalResistTest.ts
+++ b/src/module/tests/PhysicalResistTest.ts
@@ -28,9 +28,9 @@ export interface PhysicalResistTestData extends SuccessTestData {
  * Physical resist specifically handles physical damage dealt by ranged, melee and physical spell attacks.
  */
 export class PhysicalResistTest extends SuccessTest {
-    data: PhysicalResistTestData
+    override data: PhysicalResistTestData
 
-    _prepareData(data, options): any {
+    override _prepareData(data, options): any {
         data = super._prepareData(data, options);
 
         // Get incoming damage from test before or default.
@@ -40,33 +40,33 @@ export class PhysicalResistTest extends SuccessTest {
         return data;
     }
 
-    get _chatMessageTemplate() {
+    override get _chatMessageTemplate() {
         return 'systems/shadowrun5e/dist/templates/rolls/defense-test-message.html';
     }
 
-    get _dialogTemplate(): string {
+    override get _dialogTemplate(): string {
         return 'systems/shadowrun5e/dist/templates/apps/dialogs/physical-resist-test-dialog.html';
     }
 
     /**
      * This test type can't be extended.
      */
-    get canBeExtended() {
+    override get canBeExtended() {
         return false;
     }
 
-    static _getDefaultTestAction(): Partial<MinimalActionData> {
+    static override _getDefaultTestAction(): Partial<MinimalActionData> {
         return {
             'attribute': 'body',
             'armor': true
         };
     }
 
-    get testModifiers(): ModifierTypes[] {
+    override get testModifiers(): ModifierTypes[] {
         return ['soak'];
     }
 
-    applyPoolModifiers() {
+    override applyPoolModifiers() {
         super.applyPoolModifiers();
         this.applyArmorPoolModifier();
     }
@@ -83,7 +83,7 @@ export class PhysicalResistTest extends SuccessTest {
         }
     }
 
-    calculateBaseValues() {
+    override calculateBaseValues() {
         super.calculateBaseValues();
 
         // Calculate damage values in case of user dialog interaction.
@@ -103,26 +103,26 @@ export class PhysicalResistTest extends SuccessTest {
         Helpers.calcTotal(this.data.modifiedDamage.ap);
     }
 
-    get canSucceed() {
+    override get canSucceed() {
         return true;
     }
 
     /**
      * Resist Test success means ALL damage has been soaked.
      */
-    get success() {
+    override get success() {
         return this.data.incomingDamage.value <= this.hits.value;
     }
 
-    get successLabel() {
+    override get successLabel() {
         return 'SR5.ResistedAllDamage';
     }
 
-    get failureLabel() {
+    override get failureLabel() {
         return 'SR5.ResistedSomeDamage';
     }
 
-    async processResults() {
+    override async processResults() {
         await super.processResults();
 
         if (!this.actor) return;

--- a/src/module/tests/PilotVehicleTest.ts
+++ b/src/module/tests/PilotVehicleTest.ts
@@ -7,7 +7,7 @@ export class PilotVehicleTest extends SuccessTest {
      * @param item The testing item to cast
      * @param actor The vehicle actor to be casting with
      */
-    static async _getDocumentTestAction(item, actor) {
+    static override async _getDocumentTestAction(item, actor) {
         // Both item and actor are needed to determine what to roll.
         if (!item || !actor) return {};
 

--- a/src/module/tests/RangedAttackTest.ts
+++ b/src/module/tests/RangedAttackTest.ts
@@ -34,10 +34,10 @@ export interface RangedAttackTestData extends SuccessTestData {
  * TODO: Move rules into CombatRules
  */
 export class RangedAttackTest extends SuccessTest {
-    public data: RangedAttackTestData;
-    public item: SR5Item;
+    public override data: RangedAttackTestData;
+    public override item: SR5Item;
 
-    _prepareData(data, options): RangedAttackTestData {
+    override _prepareData(data, options): RangedAttackTestData {
         data = super._prepareData(data, options);
 
         data.fireModes = [];
@@ -51,7 +51,7 @@ export class RangedAttackTest extends SuccessTest {
         return data;
     }
 
-    _testDialogListeners() {
+    override _testDialogListeners() {
         return [{
             query: '#reset-progressive-recoil',
             on: 'click',
@@ -77,11 +77,11 @@ export class RangedAttackTest extends SuccessTest {
     /**
      * This test type can't be extended.
      */
-    get canBeExtended() {
+    override get canBeExtended() {
         return false;
     }
 
-    get showSuccessLabel(): boolean {
+    override get showSuccessLabel(): boolean {
         return this.success;
     }
 
@@ -176,11 +176,11 @@ export class RangedAttackTest extends SuccessTest {
         this.data.range = modifiers.environmental.applied.active.range || this.data.targetRanges[0].range.modifier;
     }
 
-    get testModifiers(): ModifierTypes[] {
+    override get testModifiers(): ModifierTypes[] {
         return ['global', 'wounds', 'environmental', 'recoil'];
     }
 
-    async prepareDocumentData(){
+    override async prepareDocumentData(){
         await this._prepareWeaponRanges();
         await this._prepareTargetRanges();
         this._prepareFireMode();
@@ -188,19 +188,19 @@ export class RangedAttackTest extends SuccessTest {
         await super.prepareDocumentData();
     }
 
-    get _dialogTemplate(): string {
+    override get _dialogTemplate(): string {
         return 'systems/shadowrun5e/dist/templates/apps/dialogs/ranged-attack-test-dialog.html';
     }
 
     /**
      * If a supression fire mode is used, ignore action opposed test configuration.
      */
-    get _opposedTestClass() {
+    override get _opposedTestClass() {
         if (this.data.fireMode.suppression) return TestCreator._getTestClass(SR5.supressionDefenseTest);
         return super._opposedTestClass;
     }
 
-    async saveUserSelectionAfterDialog() {
+    override async saveUserSelectionAfterDialog() {
         if (!this.item) return;
 
         // Store for next usage.
@@ -217,7 +217,7 @@ export class RangedAttackTest extends SuccessTest {
         await this.actor.setSituationModifiers(modifiers);
     }
 
-    prepareBaseValues() {
+    override prepareBaseValues() {
         if (!this.actor) return;
         if (!this.item) return;
 
@@ -264,7 +264,7 @@ export class RangedAttackTest extends SuccessTest {
      * NOTE: In this case it's only checked if at least ONE bullet exists.
      *       It's done this way as no matter the fire mode, you can fire it.
      */
-    canConsumeDocumentRessources() {
+    override canConsumeDocumentRessources() {
         if (!this.item.isRangedWeapon) return true;
         
         // Ammo consumption
@@ -283,7 +283,7 @@ export class RangedAttackTest extends SuccessTest {
      * Ranged Attacks not only can consume edge but also reduce ammunition.
      * 
      */
-    async consumeDocumentRessources() {        
+    override async consumeDocumentRessources() {        
         if (!await super.consumeDocumentRessources()) return false;
         if (!await this.consumeWeaponAmmo()) return false;
 
@@ -311,7 +311,7 @@ export class RangedAttackTest extends SuccessTest {
         return true;
     }
 
-    async processResults() {
+    override async processResults() {
         super.processResults();
 
         await this.markActionPhaseAsAttackUsed();

--- a/src/module/tests/SkillTest.ts
+++ b/src/module/tests/SkillTest.ts
@@ -17,7 +17,7 @@ export interface SkillTestData extends SuccessTestData {
  * Rule wise a skill test doesn't alter a default success test.
  */
 export class SkillTest extends SuccessTest {
-    data: SkillTestData
+    override data: SkillTestData
     lastUsedAttribute: string;
 
     constructor(data, documents, options) {
@@ -26,19 +26,19 @@ export class SkillTest extends SuccessTest {
         this.lastUsedAttribute = this.data.attribute;
     }
 
-    get _dialogTemplate() {
+    override get _dialogTemplate() {
         return 'systems/shadowrun5e/dist/templates/apps/dialogs/skill-test-dialog.html';
     }
 
     /**
      * Show skill label as title instead of the generic success test label.
      */
-    get title() {
+    override get title() {
         if (!this.actor) return super.title;
         return `${game.i18n.localize(this.actor.getSkillLabel(this.data.action.skill))} ${game.i18n.localize('SR5.Test')}`;
     }
 
-    _prepareData(data: any, options: TestOptions) {
+    override _prepareData(data: any, options: TestOptions) {
         data = super._prepareData(data, options);
 
         // Preselect attribute based on action.
@@ -48,7 +48,7 @@ export class SkillTest extends SuccessTest {
         return data;
     }
 
-    prepareBaseValues() {
+    override prepareBaseValues() {
         this.prepareAttributeSelection();
         this.prepareLimitSelection();
 

--- a/src/module/tests/SpellCastingTest.ts
+++ b/src/module/tests/SpellCastingTest.ts
@@ -22,9 +22,9 @@ export interface SpellCastingTestData extends SuccessTestData {
  *
  */
 export class SpellCastingTest extends SuccessTest {
-    data: SpellCastingTestData
+    override data: SpellCastingTestData
 
-    _prepareData(data, options): any {
+    override _prepareData(data, options): any {
         data = super._prepareData(data, options);
 
         data.force = data.force || 0;
@@ -35,33 +35,33 @@ export class SpellCastingTest extends SuccessTest {
         return data;
     }
 
-    get _dialogTemplate()  {
+    override get _dialogTemplate()  {
         return 'systems/shadowrun5e/dist/templates/apps/dialogs/spellcasting-test-dialog.html';
     }
 
-    get _chatMessageTemplate(): string {
+    override get _chatMessageTemplate(): string {
         return 'systems/shadowrun5e/dist/templates/rolls/spellcasting-test-message.html';
     }
 
     /**
      * This test type can't be extended.
      */
-    get canBeExtended() {
+    override get canBeExtended() {
         return false;
     }
 
-    static _getDefaultTestAction(): Partial<MinimalActionData> {
+    static override _getDefaultTestAction(): Partial<MinimalActionData> {
         return {
             skill: 'spellcasting',
             attribute: 'magic'
         };
     }
 
-    get testModifiers(): ModifierTypes[] {
+    override get testModifiers(): ModifierTypes[] {
         return ['global', 'wounds', 'background_count'];
     }
 
-    async prepareDocumentData() {
+    override async prepareDocumentData() {
         this.prepareInitialForceValue();
 
         await super.prepareDocumentData();
@@ -78,7 +78,7 @@ export class SpellCastingTest extends SuccessTest {
         this.data.force = lastUsedForce.value || suggestedForce;
     }
 
-    prepareBaseValues() {
+    override prepareBaseValues() {
         super.prepareBaseValues();
         this.prepareLimitValue();
     }
@@ -103,7 +103,7 @@ export class SpellCastingTest extends SuccessTest {
     //     const modifiers = actor.getSituationModifiers();
     // }
 
-    calculateBaseValues() {
+    override calculateBaseValues() {
         super.calculateBaseValues();
         this.calculateDrainValue();
     }
@@ -131,7 +131,7 @@ export class SpellCastingTest extends SuccessTest {
         this.data.drainDamage = DrainRules.calcDrainDamage(drain, force, magic, this.hits.value);
     }
 
-    async processResults() {
+    override async processResults() {
         this.calcDrainDamage();
 
         await super.processResults();
@@ -140,7 +140,7 @@ export class SpellCastingTest extends SuccessTest {
     /**
      * Allow the currently used force value of this spell item to be reused next time.
      */
-    async saveUserSelectionAfterDialog() {
+    override async saveUserSelectionAfterDialog() {
         if (!this.item) return;
 
         await this.item.setLastSpellForce({value: this.data.force, reckless: false});

--- a/src/module/tests/SuppressionDefenseTest.ts
+++ b/src/module/tests/SuppressionDefenseTest.ts
@@ -4,16 +4,16 @@ import MinimalActionData = Shadowrun.MinimalActionData;
 
 
 export class SuppressionDefenseTest extends PhysicalDefenseTest {
-    public data: PhysicalDefenseTestData;
+    public override data: PhysicalDefenseTestData;
 
-    static _getDefaultTestAction(): Partial<MinimalActionData> {
+    static override _getDefaultTestAction(): Partial<MinimalActionData> {
         return {
             'attribute': 'reaction',
             'attribute2': 'edge'
         };
     }
 
-    async processFailure() {
+    override async processFailure() {
         this.data.modifiedDamage = CombatRules.modifyDamageAfterSupressionHit(this.data.incomingDamage);
     }
 }

--- a/src/module/tests/ThrownAttackTest.ts
+++ b/src/module/tests/ThrownAttackTest.ts
@@ -4,7 +4,7 @@ import {SuccessTest} from "./SuccessTest";
  * Test implementation for attack tests using weapon of category thrown.
  */
 export class ThrownAttackTest extends SuccessTest {
-    get canBeExtended() {
+    override get canBeExtended() {
         return false;
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "moduleResolution": "node",
     "strictNullChecks": true,
     "skipLibCheck": true,
-    "noEmitOnError": false
+    "noEmitOnError": false,
+    "noImplicitOverride": true
   }
 }


### PR DESCRIPTION
As discussed, changed the Sheet classes to consistently use a single document accessor. Personal choice was to go for 'item'/'actor' depending on the Sheet type.

I also activated the tsconfig to disallow implicit override. This makes the code easier to read.