### PR TITLE
Add Collapse / Expand options on inventory categories.

### DIFF
--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -177,6 +177,8 @@
     },
     "SR5.ClearMarks": "Clear All Marks",
     "SR5.Close": "Close",
+    "SR5.Collapse": "Collapse",
+    "SR5.CollapseAll": "Collapse All",
     "SR5.CommonProgram": "Common Program",
     "SR5.ComplexForm": "Complex Form",
     "SR5.ComplexForms": "Complex Forms",
@@ -379,6 +381,8 @@
         "TestExpectsVehicleOnly": "This test can only be made with a vehicle type actor"
     },
     "SR5.EssenceCost": "Essence",
+    "SR5.Expand": "Expand",
+    "SR5.ExpandAll": "Expand All",
     "SR5.Extend": "Extend",
     "SR5.Extended": "Extended",
     "SR5.ExtendedHits": "Extended Hits",

--- a/public/locale/fr/config.json
+++ b/public/locale/fr/config.json
@@ -125,6 +125,8 @@
         }
     },
     "SR5.Close": "Fermé",
+    "SR5.Collapse": "Réduire",
+    "SR5.CollapseAll": "Réduire Tout",
     "SR5.CommonProgram": "Programme courant",
     "SR5.ComplexForm": "Forme complexe",
     "SR5.ComplexForms": "Formes complexes",
@@ -349,6 +351,8 @@
         "SkillWithoutAttribute": "La compétence n'a pas d'attribut assigné"
     },
     "SR5.EssenceCost": "Essence",
+    "SR5.Expand": "Etendre",
+    "SR5.ExpandAll": "Etendre Tout",
     "SR5.Extended": "Etendu",
     "SR5.ExtendedTest": "Test étendu",
     "SR5.Fade": "Disparition",

--- a/src/css/bundle.scss
+++ b/src/css/bundle.scss
@@ -642,6 +642,9 @@ select.display {
             background: rgba($grey, 0.2);
             padding: 0.25em;
             border-radius: 0.2em;
+            &.faded {
+                color: $grey;
+            }
         }
         .item-center {
             display: flex;
@@ -764,6 +767,7 @@ select.display {
             }
         }
         .item-create,
+        .item-toggle,
         .add-new-ammo,
         .add-new-mod,
         .add-new-license {

--- a/src/module/handlebars/BasicHelpers.ts
+++ b/src/module/handlebars/BasicHelpers.ts
@@ -102,6 +102,11 @@ export const registerBasicHelpers = () => {
         if (v1 === v2) return options.fn(this);
         else return options.inverse(this);
     });
+    // if then
+    Handlebars.registerHelper('ift', function (v1, v2) {
+        if (v1) return v2;
+    });
+
     // if empty (object, array, string)
     Handlebars.registerHelper('empty', function (value) {
         if (foundry.utils.getType(value) === 'Array') return value.length === 0;

--- a/src/module/handlebars/ItemLineHelpers.ts
+++ b/src/module/handlebars/ItemLineHelpers.ts
@@ -2,9 +2,33 @@ import {SR5ItemDataWrapper} from '../data/SR5ItemDataWrapper';
 import {SR5} from "../config";
 import ShadowrunItemData = Shadowrun.ShadowrunItemData;
 import MarkedDocument = Shadowrun.MarkedDocument;
+import { InventorySheetDataByType } from '../actor/sheets/SR5BaseActorSheet';
 
 export const registerItemLineHelpers = () => {
-    Handlebars.registerHelper('ItemHeaderIcons', function (type) {
+    Handlebars.registerHelper('InventoryHeaderIcons', function (section: InventorySheetDataByType) {
+        var icons = Handlebars.helpers['ItemHeaderIcons'](section.type) as object[];
+
+        icons.push(section.isOpen
+            ? {
+                icon: 'fas fa-square-chevron-up',
+                title: game.i18n.localize('SR5.Collapse'),
+                cssClass: 'item-toggle',
+                // Add HTML data attributes using a key<string>:value<string> structure
+                data: {}
+            }
+            : {
+                icon: 'fas fa-square-chevron-down',
+                title: game.i18n.localize('SR5.Expand'),
+                cssClass: 'item-toggle',
+                // Add HTML data attributes using a key<string>:value<string> structure
+                data: {}
+            }
+        );
+
+        return icons;
+    })
+
+    Handlebars.registerHelper('ItemHeaderIcons', function (type: string) {
         const PlusIcon = 'fas fa-plus';
         const AddText = game.i18n.localize('SR5.Add');
         const addIcon = {
@@ -89,7 +113,7 @@ export const registerItemLineHelpers = () => {
         }
     });
 
-    Handlebars.registerHelper('InventoryIcons', function(name) {
+    Handlebars.registerHelper('InventoryIcons', function(name: string) {
         const addItemIcon = {
             icon: 'fas fa-plus',
             text: game.i18n.localize('SR5.Add'),
@@ -102,7 +126,7 @@ export const registerItemLineHelpers = () => {
         return [addItemIcon];
     });
 
-    Handlebars.registerHelper('ItemHeaderRightSide', function (id) {
+    Handlebars.registerHelper('ItemHeaderRightSide', function (id: string) {
         switch (id) {
             case 'action':
                 return [

--- a/src/templates/actor/tabs/InventoryTab.html
+++ b/src/templates/actor/tabs/InventoryTab.html
@@ -32,29 +32,38 @@
                         <i class="item-icon fas fa-plus"></i>
                         {{localize "SR5.Add"}}
                     </a>
+                    <a class="inventory-collapse" title="{{localize 'SR5.CollapseAll'}}">
+                        <i class="item-icon fas fa-chevrons-up"></i>
+                    </a>
+                    <a class="inventory-expand" title="{{localize 'SR5.ExpandAll'}}">
+                        <i class="item-icon fas fa-chevrons-down"></i>
+                    </a>
                 </div>
             </div>
         </div>
         <div class="scroll-area">
             {{#each inventory.types as |section type|}}
                 {{> 'systems/shadowrun5e/dist/templates/common/List/ListHeader.html'
+                        itemCssClass=(ift (not section.isOpen) 'faded')
                         name=(localize section.label)
                         itemId=section.type
-                        icons=(ItemHeaderIcons section.type)
+                        icons=(InventoryHeaderIcons section)
                         rightSide=(ItemHeaderRightSide section.type)
                 }}
-                {{#each section.items}}
-                    {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
-                            img=this.img
-                            name=this.name
-                            itemId=this._id
-                            icons=(InventoryItemIcons this)
-                            rightSide=(ItemRightSide this)
-                            hasDesc="true"
-                            hasRoll="true"
-                            description=this.description.value
-                    }}
-                {{/each}}
+                {{#if section.isOpen }}
+                    {{#each section.items}}
+                        {{> 'systems/shadowrun5e/dist/templates/common/List/ListItem.html'
+                                img=this.img
+                                name=this.name
+                                itemId=this._id
+                                icons=(InventoryItemIcons this)
+                                rightSide=(ItemRightSide this)
+                                hasDesc="true"
+                                hasRoll="true"
+                                description=this.description.value
+                        }}
+                    {{/each}}
+                {{/if}}
             {{/each}}
         </div>
     </div>


### PR DESCRIPTION
Here is a proposition to have collapse/expand feature on item categories with the following properties:
- One icon added to the end of the section line to toggle visibility
- 2 icons added to the inventory heeder line to collapse/expand all sections at once
- When collapsed, the title of the section is greyed out to give a visible hint that the section is not just empty
- Adding an item to the section opens it
- The state is not persisted in the server storage
- The state is not per inventory, only per section (changing inventory won't change the visibility settings

**New default interface**
> ![image](https://user-images.githubusercontent.com/13865717/230746874-26ea0b26-511b-41dc-8ba6-90163dc09717.png)

**With some section collapsed**
> ![image](https://user-images.githubusercontent.com/13865717/232279259-5edc61c6-fa16-472f-9d8a-49fddeb58e34.png)


#641 