### PR TITLE
Add RCC (Rigger Command Console) Support

### DIFF
--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -301,6 +301,7 @@
     "SR5.Device": "Device",
     "SR5.DeviceCatCommlink": "Commlink",
     "SR5.DeviceCatCyberdeck": "Cyberdeck",
+    "SR5.DeviceCatRCC": "Rigger Command Console",
     "SR5.DeviceType": "Type",
     "SR5.Dialogs": {
         "Common": {

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -1705,7 +1705,7 @@ export class SR5BaseActorSheet extends ActorSheet {
      * Sync matrix attribute changes (order) made on the actor sheet into item data of the selected cyberdeck.
      *
      * This is done whenever a user changes matrix attribute order directly from the actor sheet matrix section.
-     * It's intent is to also order matrix attribute order on the selected matrix device of that actor.
+     * Its intent is to also order matrix attribute order on the selected matrix device of that actor.
      * 
      * @param event A mouse/pointer event
      */

--- a/src/module/apps/characterImport/gearImport/DeviceParser.ts
+++ b/src/module/apps/characterImport/gearImport/DeviceParser.ts
@@ -48,8 +48,7 @@ export class DeviceParser extends BaseGearParser {
 
         if (chummerGear.category === 'Rigger Command Consoles')
         {
-            // We are handling rccs as commlinks for the moment since we have no support for rigger command consoles yet.
-            parsedGear.system.category = 'commlink'; 
+            parsedGear.system.category = 'rcc';
         }
 
         return parsedGear;

--- a/src/module/apps/characterImport/gearImport/DeviceParser.ts
+++ b/src/module/apps/characterImport/gearImport/DeviceParser.ts
@@ -1,7 +1,7 @@
 import { BaseGearParser } from "./BaseGearParser"
 
 /**
- * Parses devices (commlinks and decks)
+ * Parses devices (commlinks, decks, and RCCs)
  */
 export class DeviceParser extends BaseGearParser {
    
@@ -13,25 +13,25 @@ export class DeviceParser extends BaseGearParser {
         parsedGear.system.atts = {
             att1:
             {
-                value: chummerGear.attack,
+                value: parseInt(chummerGear.attack),
                 att: 'attack'
             },
 
             att2:
             {
-                value: chummerGear.sleaze,
+                value: parseInt(chummerGear.sleaze),
                 att: 'sleaze'
             },
 
             att3:
             {
-                value: chummerGear.systemprocessing,
+                value: parseInt(chummerGear.dataprocessing),
                 att: 'data_processing'
             },
 
             att4:
             {
-                value: chummerGear.firewall,
+                value: parseInt(chummerGear.firewall),
                 att: 'firewall'
             } 
         };

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -179,6 +179,7 @@ export const SR5 = {
     deviceCategories: {
         commlink: 'SR5.DeviceCatCommlink',
         cyberdeck: 'SR5.DeviceCatCyberdeck',
+        rcc: 'SR5.DeviceCatRCC',
     },
 
     cyberwareGrades: {

--- a/src/module/data/SR5ItemDataWrapper.ts
+++ b/src/module/data/SR5ItemDataWrapper.ts
@@ -302,7 +302,8 @@ export class SR5ItemDataWrapper extends DataWrapper<ShadowrunItemData> {
             },
         };
 
-        if (this.isCyberdeck()) {
+        // This if statement should cover all types of devices, meaning the "getRating" calls above are always overwritten
+        if (this.isCyberdeck() || this.isRCC() || this.isCommlink()) {
             const atts = this.getData().atts;
             if (atts) {
                 for (let [key, att] of Object.entries(atts)) {

--- a/src/module/data/SR5ItemDataWrapper.ts
+++ b/src/module/data/SR5ItemDataWrapper.ts
@@ -199,6 +199,12 @@ export class SR5ItemDataWrapper extends DataWrapper<ShadowrunItemData> {
         return deviceData.category === 'cyberdeck';
     }
 
+    isRCC(): boolean {
+        if (!this.isDevice()) return false;
+        const deviceData = this.getData() as DeviceData;
+        return deviceData.category === 'rcc';
+    }
+
     isCommlink(): boolean {
         if (!this.isDevice()) return false;
         const deviceData = this.getData() as DeviceData;

--- a/src/module/item/ChatData.ts
+++ b/src/module/item/ChatData.ts
@@ -178,7 +178,7 @@ export const ChatData = {
 
     device: (system: DeviceData, labels, props) => {
         if (system.technology && system.technology.rating) props.push(`Rating ${system.technology.rating}`);
-        if (system.category === 'cyberdeck') {
+        if (system.category === 'cyberdeck' || system.category === 'rcc') {
             for (const attN of Object.values(system.atts)) {
                 props.push(`${Helpers.label(attN.att)} ${attN.value}`);
             }

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1283,6 +1283,10 @@ export class SR5Item extends Item {
         return this.wrapper.isCyberdeck();
     }
 
+    isRCC(): boolean {
+        return this.wrapper.isRCC();
+    }
+
     isCommlink(): boolean {
         return this.wrapper.isCommlink();
     }

--- a/src/module/types/item/Device.ts
+++ b/src/module/types/item/Device.ts
@@ -8,7 +8,7 @@ declare namespace Shadowrun {
     }
 
     // This category is used for both Device and Host item types to differentiate attribute handling.
-    export type DeviceCategory = 'commlink' | 'cyberdeck' | 'host' | '';
+    export type DeviceCategory = 'commlink' | 'cyberdeck' | 'rcc' | 'host' | '';
 
     export interface DevicePartData {
         category: DeviceCategory


### PR DESCRIPTION
This is my first PR to this repo (and to any Foundry system); please give me feedback if anything needs modification or improvement!

Changeset:
- Add support for Rigger Command Consoles (RCCs)
  - Add to Chummer parser types
  - Add to data importer as its own folder
  - Consume RCC and Commlink ASDF (primarily Data Processing and Firewall) for Matrix stats on Actors, affecting Matrix tests and the Matrix tab
- Modify Chummer import to parse ASDF matrix attributes as integers (not sure if this caused any issues before)
- Fix Chummer import Data Processing attribute - it would previously always return 0 for all types of devices (commlinks, RCCs, and cyberdecks), due to keying off "systemprocessing" instead of "dataprocessing"

To Consider:

- Translations - I wasn't sure if "Rigger Command Console" should be added verbatim to the other Roman alphabet languages, similar to "Commlink" and "Cyberdeck"
- Backwards Compatibility - This will have some effects on existing characters imported from Chummer - it can surely be worked around if we'd like.  For example, Commlinks and RCCs previously were being imported with 0 Data Processing - running an action like a Matrix Search would now use the sourced Data Processing attribute (0) rather than the Rating for the limit of the test (which in turn, causes the limit to be ignored because it is 0)
- Abbreviation - should we use "RCC" or "Rigger Command Console" for things like the folder name in the Items list, and the Device Type dropdown? It's a tradeoff between wordiness and clarity I guess
