### PR TITLE
Fix and commonize chummer parser damage logic for Weapons

### DIFF
--- a/src/module/importer/parser/weapon/MeleeParser.ts
+++ b/src/module/importer/parser/weapon/MeleeParser.ts
@@ -1,49 +1,8 @@
 import { ImportHelper } from '../../helper/ImportHelper';
 import { WeaponParserBase } from './WeaponParserBase';
-import ActorAttribute = Shadowrun.ActorAttribute;
-import DamageData = Shadowrun.DamageData;
-import DamageType = Shadowrun.DamageType;
-import {DataDefaults} from "../../../data/DataDefaults";
 import WeaponItemData = Shadowrun.WeaponItemData;
 
 export class MeleeParser extends WeaponParserBase {
-    GetDamage(jsonData: object): DamageData {
-        let jsonDamage = ImportHelper.StringValue(jsonData, 'damage');
-        let damageCode: any = jsonDamage.match(/(STR)([+-]?)([1-9]*)\)([PS])/g)?.[0];
-
-        if (damageCode == null) {
-            return DataDefaults.damageData();
-        }
-
-        let damageBase = 0;
-        let damageAp = ImportHelper.IntValue(jsonData, 'ap', 0);
-
-        let splitDamageCode = damageCode.split(')');
-        let damageType = splitDamageCode[1].includes('P') ? 'physical' : 'stun';
-
-        let splitBaseCode = damageCode.includes('+') ? splitDamageCode[0].split('+') : splitDamageCode[0].split('-');
-        if (splitDamageCode[0].includes('+') || splitDamageCode[0].includes('-')) {
-            damageBase = parseInt(splitBaseCode[1], 0);
-        }
-        let damageAttribute = damageCode.includes('STR') ? 'strength' : '';
-
-        const partialDamageData = {
-            type: {
-                base: damageType as DamageType,
-                value: damageType as DamageType,
-            },
-            base: damageBase,
-            value: damageBase,
-            ap: {
-                base: damageAp,
-                value: damageAp,
-                mod: [],
-            },
-            attribute: damageAttribute as ActorAttribute,
-        }
-        return DataDefaults.damageData(partialDamageData);
-    }
-
     override Parse(jsonData: object, item: WeaponItemData, jsonTranslation?: object): WeaponItemData {
         item = super.Parse(jsonData, item, jsonTranslation);
 

--- a/src/module/importer/parser/weapon/RangedParser.ts
+++ b/src/module/importer/parser/weapon/RangedParser.ts
@@ -7,34 +7,6 @@ import {DataDefaults} from "../../../data/DataDefaults";
 import WeaponItemData = Shadowrun.WeaponItemData;
 
 export class RangedParser extends WeaponParserBase {
-    public GetDamage(jsonData: object): DamageData {
-        let jsonDamage = ImportHelper.StringValue(jsonData, 'damage');
-        let damageCode = jsonDamage.match(/[0-9]+[PS]/g)?.[0];
-
-        if (damageCode == null) {
-            return DataDefaults.damageData();
-        }
-
-        let damageType = damageCode.includes('P') ? 'physical' : 'stun';
-        let damageAmount = parseInt(damageCode.replace(damageType[0].toUpperCase(), ''));
-        let damageAp = ImportHelper.IntValue(jsonData, 'ap', 0);
-
-        const partialDamageData = {
-            type: {
-                base: damageType as DamageType,
-                value: damageType as DamageType,
-            },
-            base: damageAmount,
-            value: damageAmount,
-            ap: {
-                base: damageAp,
-                value: damageAp,
-                mod: []
-            }
-        }
-        return DataDefaults.damageData(partialDamageData);
-    }
-
     protected GetAmmo(weaponJson: object) {
         let jsonAmmo = ImportHelper.StringValue(weaponJson, 'ammo');
         let match = jsonAmmo.match(/([0-9]+)/g)?.[0];
@@ -63,10 +35,13 @@ export class RangedParser extends WeaponParserBase {
         item.system.ammo.current.value = this.GetAmmo(jsonData);
         item.system.ammo.current.max = this.GetAmmo(jsonData);
 
-        item.system.range.modes.single_shot = ImportHelper.StringValue(jsonData, 'mode').includes('SS');
-        item.system.range.modes.semi_auto = ImportHelper.StringValue(jsonData, 'mode').includes('SA');
-        item.system.range.modes.burst_fire = ImportHelper.StringValue(jsonData, 'mode').includes('BF');
-        item.system.range.modes.full_auto = ImportHelper.StringValue(jsonData, 'mode').includes('FA');
+        const modeData = ImportHelper.StringValue(jsonData, 'mode');
+        item.system.range.modes = {
+            single_shot: modeData.includes('SS'),
+            semi_auto: modeData.includes('SA'),
+            burst_fire: modeData.includes('BF'),
+            full_auto: modeData.includes('FA'),
+        };
 
         return item;
     }

--- a/src/module/importer/parser/weapon/ThrownParser.ts
+++ b/src/module/importer/parser/weapon/ThrownParser.ts
@@ -2,68 +2,9 @@ import { ImportHelper } from '../../helper/ImportHelper';
 import { WeaponParserBase } from './WeaponParserBase';
 import { Constants } from '../../importer/Constants';
 import BlastData = Shadowrun.BlastData;
-import ActorAttribute = Shadowrun.ActorAttribute;
-import DamageData = Shadowrun.DamageData;
-import DamageType = Shadowrun.DamageType;
-import {DataDefaults} from "../../../data/DataDefaults";
 import WeaponItemData = Shadowrun.WeaponItemData;
 
 export class ThrownParser extends WeaponParserBase {
-    public GetDamage(jsonData: object): DamageData {
-        let jsonDamage = ImportHelper.StringValue(jsonData, 'damage');
-
-        let damageAmount = 0;
-        let damageType = 'physical';
-        let damageAttribute = '';
-
-        //STR scaling weapons like the boomerang
-        if (jsonDamage.includes('STR')) {
-            damageAttribute = 'strength';
-
-            let damageMatch = jsonDamage.match(/((STR)([+-])[0-9]\)[PS])/g)?.[0];
-            if (damageMatch !== undefined) {
-                let amountMatch = damageMatch.match(/-?[0-9]+/g)?.[0];
-                damageAmount = amountMatch !== undefined ? parseInt(amountMatch) : 0;
-            }
-        } else {
-            let damageMatch = jsonDamage.match(/([0-9]+[PS])/g)?.[0];
-
-            if (damageMatch !== undefined) {
-                let amountMatch = damageMatch.match(/[0-9]+/g)?.[0];
-                if (amountMatch !== undefined) {
-                    damageAmount = parseInt(amountMatch);
-                }
-            } else {
-                const partialDamageData = {
-                    type: {
-                        base: 'physical' as DamageType,
-                        value: 'physical' as DamageType
-                    }
-                }
-                return DataDefaults.damageData(partialDamageData);
-            }
-        }
-        damageType = jsonDamage.includes('P') ? 'physical' : 'stun';
-
-        let damageAp = ImportHelper.IntValue(jsonData, 'ap', 0);
-
-        const partialDamageData = {
-            type: {
-                base: damageType as DamageType,
-                value: damageType as DamageType,
-            },
-            base: damageAmount,
-            value: damageAmount,
-            ap: {
-                base: damageAp,
-                value: damageAp,
-                mod: [],
-            },
-            attribute: damageAttribute as ActorAttribute,
-        }
-        return DataDefaults.damageData(partialDamageData);
-    }
-
     public GetBlast(jsonData: object, item: WeaponItemData): BlastData {
         let blastData: BlastData = {
             radius: 0,

--- a/src/module/importer/parser/weapon/WeaponParserBase.ts
+++ b/src/module/importer/parser/weapon/WeaponParserBase.ts
@@ -76,9 +76,9 @@ export class WeaponParserBase extends TechnologyItemParserBase<WeaponItemData> {
     protected GetDamage(jsonData: object): DamageData {
         const jsonDamage = ImportHelper.StringValue(jsonData, 'damage');
         // ex. 15S(e)
-        const simpleDamage = /^([0-9]+)([PS])? ?(\([a-zA-Z]+\))?/g.exec(jsonDamage);
+        const simpleDamage = /^([0-9]+)([PSM])? ?(\([a-zA-Z]+\))?/g.exec(jsonDamage);
         // ex. ({STR}+1)P(fire)
-        const strengthDamage = /^\({STR}([+-]?[0-9]*)\)([PS])? ?(\([a-zA-Z]+\))?/g.exec(jsonDamage);
+        const strengthDamage = /^\({STR}([+-]?[0-9]*)\)([PSM])? ?(\([a-zA-Z]+\))?/g.exec(jsonDamage);
 
         let damageType: DamageType = '';
         let damageAttribute: PhysicalAttribute | '' = '';
@@ -101,8 +101,8 @@ export class WeaponParserBase extends TechnologyItemParserBase<WeaponItemData> {
 
         const partialDamageData: RecursivePartial<DamageData> = {
             type: {
-                base: damageType,
-                value: damageType,
+                base: damageType || 'physical',
+                value: damageType || 'physical',
             },
             base: damageBase,
             value: damageBase,

--- a/src/unittests/quench.ts
+++ b/src/unittests/quench.ts
@@ -10,6 +10,7 @@ import {shadowrunSR5ActiveEffect} from "./sr5.ActiveEffect.spec";
 import {shadowrunNetworkDevices} from "./sr5.NetworkDevices.spec";
 import {shadowrunTesting} from "./sr5.Testing.spec";
 import {shadowrunInventoryFlow} from "./sr5.Inventory.spec";
+import {weaponParserTesting} from "./sr5.WeaponParser.spec";
 import { Quench } from "@ethaks/fvtt-quench";
 
 
@@ -40,4 +41,6 @@ export const quenchRegister = (quench: Quench) => {
     quench.registerBatch("shadowrun5e.flow.tests", shadowrunTesting, {displayName: "SHADOWRUN5e: SuccessTest Test"});
     quench.registerBatch("shadowrun5e.flow.tests_attack", shadowrunAttackTesting, {displayName: "SHADOWRUN5e: Attack Test"});
     quench.registerBatch("shadowrun5e.flow.sr5roll", shadowrunRolling, {displayName: "SHADOWRUN5e: SR5Roll"});
+
+    quench.registerBatch("shadowrun5e.parser.weapon", weaponParserTesting, {displayName: "SHADOWRUN5e: Data Importer Weapon Parsing"});
 };

--- a/src/unittests/sr5.WeaponParser.spec.ts
+++ b/src/unittests/sr5.WeaponParser.spec.ts
@@ -15,7 +15,7 @@ function mockXmlData(data: object): object {
             [key, { '_TEXT': value }]));
 }
 
-function getData(damageString: string, apString?: string): object {
+function getData(damageString: string): object {
     return mockXmlData({
         damage: damageString,
     });
@@ -41,6 +41,7 @@ export const weaponParserTesting = (context: QuenchBatchContext) => {
                 },
             }));
         });
+
         it("Parses elemental damage", () => {
             const output = mut.GetDamage(getData("8S(e)"));
             assert.deepEqual(output, DataDefaults.damageData({
@@ -56,6 +57,7 @@ export const weaponParserTesting = (context: QuenchBatchContext) => {
                 },
             }));
         });
+
         it("Parses strength-based damage", () => {
             const output = mut.GetDamage(getData("({STR}+3)P"));
             assert.deepEqual(output, DataDefaults.damageData({
@@ -68,6 +70,43 @@ export const weaponParserTesting = (context: QuenchBatchContext) => {
                 attribute: 'strength',
             }));
         });
+
+        it("Parses damage without type as physical", () => {
+            const output = mut.GetDamage(getData("11"));
+            assert.deepEqual(output, DataDefaults.damageData({
+                base: 11,
+                value: 11,
+                type: {
+                    base: 'physical',
+                    value: 'physical',
+                },
+            }));
+        });
+
+        it("Parses 0 damage", () => {
+            const output = mut.GetDamage(getData("0"));
+            assert.deepEqual(output, DataDefaults.damageData({
+                base: 0,
+                value: 0,
+                type: {
+                    base: 'physical',
+                    value: 'physical',
+                },
+            }));
+        });
+
+        it("Parses basic matrix damage", () => {
+            const output = mut.GetDamage(getData("7M"));
+            assert.deepEqual(output, DataDefaults.damageData({
+                base: 7,
+                value: 7,
+                type: {
+                    base: 'matrix',
+                    value: 'matrix',
+                },
+            }));
+        });
+
         it("Parses strength-based damage without modifier", () => {
             const output = mut.GetDamage(getData("({STR})P"));
             assert.deepEqual(output, DataDefaults.damageData({

--- a/src/unittests/sr5.WeaponParser.spec.ts
+++ b/src/unittests/sr5.WeaponParser.spec.ts
@@ -1,0 +1,85 @@
+import { QuenchBatchContext } from '@ethaks/fvtt-quench';
+import { WeaponParserBase } from '../module/importer/parser/weapon/WeaponParserBase';
+import DamageData = Shadowrun.DamageData;
+import { DataDefaults } from '../module/data/DataDefaults';
+
+class TestWeaponParser extends WeaponParserBase {
+    public override GetDamage(jsonData: object): DamageData {
+        return super.GetDamage(jsonData);
+    }
+}
+
+function mockXmlData(data: object): object {
+    return Object.fromEntries(Object.entries(data)
+        .map(([key, value]) =>
+            [key, { '_TEXT': value }]));
+}
+
+function getData(damageString: string, apString?: string): object {
+    return mockXmlData({
+        damage: damageString,
+    });
+}
+
+export const weaponParserTesting = (context: QuenchBatchContext) => {
+    const { describe, it, assert, before, after } = context;
+
+    let mut = new TestWeaponParser();
+
+    before(async () => {})
+    after(async () => {})
+
+    describe("Weapon Damage Values", () => {
+        it("Parses simple damage", () => {
+            const output = mut.GetDamage(getData("12P"));
+            assert.deepEqual(output, DataDefaults.damageData({
+                base: 12,
+                value: 12,
+                type: {
+                    base: 'physical',
+                    value: 'physical',
+                },
+            }));
+        });
+        it("Parses elemental damage", () => {
+            const output = mut.GetDamage(getData("8S(e)"));
+            assert.deepEqual(output, DataDefaults.damageData({
+                base: 8,
+                value: 8,
+                type: {
+                    base: 'stun',
+                    value: 'stun',
+                },
+                element: {
+                    base: 'electricity',
+                    value: 'electricity',
+                },
+            }));
+        });
+        it("Parses strength-based damage", () => {
+            const output = mut.GetDamage(getData("({STR}+3)P"));
+            assert.deepEqual(output, DataDefaults.damageData({
+                base: 3,
+                value: 3,
+                type: {
+                    base: 'physical',
+                    value: 'physical',
+                },
+                attribute: 'strength',
+            }));
+        });
+        it("Parses strength-based damage without modifier", () => {
+            const output = mut.GetDamage(getData("({STR})P"));
+            assert.deepEqual(output, DataDefaults.damageData({
+                base: 0,
+                value: 0,
+                type: {
+                    base: 'physical',
+                    value: 'physical',
+                },
+                attribute: 'strength',
+            }));
+        });
+    })
+}
+


### PR DESCRIPTION
This changeset commonizes the damage parsing logic between melee, ranged, and throwing weapons.  The previous logic failed to parse strength-based melee weapons - perhaps this is due to a breaking change in chummer data.  It also makes an attempt to parse previously unparsed data, such as Electricity and Fire elemental damage.  Finally, it adds some unit tests around the damage parsing logic; these tests should eventually be expanded to cover the rest of the logic within the weapon parser base class and subclasses.