### PR TITLE
Fix creation of knowledge skills

### DIFF
--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -1332,7 +1332,7 @@ export class SR5BaseActorSheet extends ActorSheet {
         if (!skillId) return;
 
         // NOTE: Causes issues with adding knowledge skills (category undefined)
-        // await this._showSkillEditForm(LanguageSkillEditSheet, this.actor, {event}, skillId);
+        await this._showSkillEditForm(LanguageSkillEditSheet, this.actor, {event}, skillId);
     }
 
     async _onRemoveLanguageSkill(event) {
@@ -1347,12 +1347,12 @@ export class SR5BaseActorSheet extends ActorSheet {
 
     async _onAddKnowledgeSkill(event) {
         event.preventDefault();
-        const category = Helpers.listItemId(event) as keyof KnowledgeSkills;
+        const category = Helpers.listHeaderId(event) as keyof KnowledgeSkills;
         const skillId = await this.actor.addKnowledgeSkill(category);
         if (!skillId) return;
 
         // NOTE: Causes issues with adding knowledge skills (category undefined)
-        // await this._showSkillEditForm(KnowledgeSkillEditSheet, this.actor, {event}, skillId);
+        await this._showSkillEditForm(KnowledgeSkillEditSheet, this.actor, {event}, skillId);
     }
 
     async _onRemoveKnowledgeSkill(event) {

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -1331,7 +1331,6 @@ export class SR5BaseActorSheet extends ActorSheet {
         const skillId = await this.actor.addLanguageSkill({ name: '' });
         if (!skillId) return;
 
-        // NOTE: Causes issues with adding knowledge skills (category undefined)
         await this._showSkillEditForm(LanguageSkillEditSheet, this.actor, {event}, skillId);
     }
 
@@ -1351,7 +1350,6 @@ export class SR5BaseActorSheet extends ActorSheet {
         const skillId = await this.actor.addKnowledgeSkill(category);
         if (!skillId) return;
 
-        // NOTE: Causes issues with adding knowledge skills (category undefined)
         await this._showSkillEditForm(KnowledgeSkillEditSheet, this.actor, {event}, skillId);
     }
 

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -1,5 +1,5 @@
-import { SituationModifier } from './../../rules/modifiers/SituationModifier';
-import { SituationModifiersApplication } from './../../apps/SituationModifiersApplication';
+import { SituationModifier } from '../../rules/modifiers/SituationModifier';
+import { SituationModifiersApplication } from '../../apps/SituationModifiersApplication';
 import {Helpers} from "../../helpers";
 import {SR5Item} from "../../item/SR5Item";
 import {onManageActiveEffect, prepareActiveEffectCategories} from "../../effects";
@@ -1350,7 +1350,7 @@ export class SR5BaseActorSheet extends ActorSheet {
         const skillId = await this.actor.addKnowledgeSkill(category);
         if (!skillId) return;
 
-        await this._showSkillEditForm(KnowledgeSkillEditSheet, this.actor, {event}, skillId);
+        await this._showSkillEditForm(KnowledgeSkillEditSheet, this.actor, {event}, skillId, category);
     }
 
     async _onRemoveKnowledgeSkill(event) {

--- a/src/module/helpers.ts
+++ b/src/module/helpers.ts
@@ -119,6 +119,10 @@ export class Helpers {
         return event.currentTarget.closest('.list-item').dataset.itemId;
     }
 
+    static listHeaderId(event): string {
+        return event.currentTarget.closest('.list-header').dataset.itemId;
+    }
+
     // replace 'SR5.'s on keys with 'SR5_DOT_'
     //@ts-ignore TODO: foundry-vtt-types v10
     static onSetFlag(data) {


### PR DESCRIPTION
This changeset fixes creation of knowledge skills by keying off the "list-header" class instead of the "list-item" class.  The current behavior throws an error trying to add any knowledge skill except Language skills, with the following exception:
```
helpers.ts:119 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'dataset')
    at Helpers.listItemId (helpers.ts:119:56)
    at SR5CharacterSheet.<anonymous> (SR5BaseActorSheet.ts:1350:34)
    ...
```

I also re-enabled showing the Edit Form after creation - it seems to work now, so I suspect the aforementioned issue was the root cause.  I'd love to figure out how to write unit tests for this behavior, but I'm not sure how you'd go about rendering HTML forms as part of the quench tests.