### PR TITLE
Allow vehicles to be added to PANs and improve matrix device item edit page

### DIFF
--- a/src/css/item.scss
+++ b/src/css/item.scss
@@ -169,6 +169,9 @@
                 border-radius: 0.3em;
                 border-color: $dark;
             }
+            label {
+                color: $yellow;
+            }
         }
     }
 }

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -595,12 +595,7 @@ export class SR5Actor extends Actor {
     async setNetworkController(networkController: string|undefined): Promise<void> {
         if(!this.isVehicle()) return;
 
-        if(networkController === undefined) {
-            const update = Helpers.getDeleteKeyUpdateData('system', 'networkController');
-            await this.update(update)
-        } else {
-            await this.update({ 'system.networkController': networkController });
-        }
+        await this.update({ 'system.networkController': networkController });
     }
 
     get canBeNetworkDevice(): boolean {

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -592,10 +592,15 @@ export class SR5Actor extends Actor {
         return this.asVehicle()?.system?.networkController;
     }
 
-    async setNetworkController(networkController: string): Promise<void> {
+    async setNetworkController(networkController: string|undefined): Promise<void> {
         if(!this.isVehicle()) return;
 
-        await this.update({ 'system.networkController': networkController });
+        if(networkController === undefined) {
+            const update = Helpers.getDeleteKeyUpdateData('system', 'networkController');
+            await this.update(update)
+        } else {
+            await this.update({ 'system.networkController': networkController });
+        }
     }
 
     get canBeNetworkDevice(): boolean {

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -586,6 +586,22 @@ export class SR5Actor extends Actor {
         return this.system.skills.active;
     }
 
+    getNetworkController(): string|undefined {
+        if(!this.isVehicle()) return;
+
+        return this.asVehicle()?.system?.networkController;
+    }
+
+    async setNetworkController(networkController: string): Promise<void> {
+        if(!this.isVehicle()) return;
+
+        await this.update({ 'system.networkController': networkController });
+    }
+
+    get canBeNetworkDevice(): boolean {
+        return this.isVehicle();
+    }
+
     /**
      * Determine if an actor can choose a special trait using the special field.
      */

--- a/src/module/actor/sheets/SR5VehicleActorSheet.ts
+++ b/src/module/actor/sheets/SR5VehicleActorSheet.ts
@@ -1,9 +1,12 @@
 import {SR5BaseActorSheet} from "./SR5BaseActorSheet";
 import SR5ActorSheetData = Shadowrun.SR5ActorSheetData;
 import {SR5Actor} from "../SR5Actor";
+import { SR5Item } from '../../item/SR5Item';
+import { NetworkDeviceFlow } from '../../item/flows/NetworkDeviceFlow';
 
 interface VehicleSheetDataFields {
     driver: SR5Actor|undefined
+    networkController: SR5Item | undefined
 }
 
 interface VehicleActorSheetData extends SR5ActorSheetData {
@@ -65,6 +68,10 @@ export class SR5VehicleActorSheet extends SR5BaseActorSheet {
 
         // Vehicle Sheet related handlers...
         html.find('.driver-remove').on('click', this._handleRemoveVehicleDriver.bind(this));
+
+        // PAN/WAN
+        html.find('.origin-link').on('click', this._onOpenOriginLink.bind(this));
+        html.find('.controller-remove').on('click', this._onControllerRemove.bind(this));
     }
 
     /**
@@ -92,13 +99,36 @@ export class SR5VehicleActorSheet extends SR5BaseActorSheet {
     _prepareVehicleFields(): VehicleSheetDataFields {
         const driver = this.actor.getVehicleDriver();
 
+        const networkControllerLink = this.actor.getNetworkController();
+        const networkController = networkControllerLink ? NetworkDeviceFlow.resolveItemLink(networkControllerLink) : undefined;
+
         return {
-            driver
+            driver,
+            networkController,
         };
     }
 
     async _handleRemoveVehicleDriver(event) {
         event.preventDefault();
         await this.actor.removeVehicleDriver();
+    }
+
+    async _onOpenOriginLink(event) {
+        event.preventDefault();
+
+        console.log('Shadowrun 5e | Opening PAN/WAN network controller');
+
+        const originLink = event.currentTarget.dataset.originLink;
+        const device = await fromUuid(originLink);
+        if (!device) return;
+
+        // @ts-ignore
+        device.sheet.render(true);
+    }
+
+    async _onControllerRemove(event) {
+        event.preventDefault();
+
+        await NetworkDeviceFlow.removeDeviceFromController(this.actor);
     }
 }

--- a/src/module/item/ChatData.ts
+++ b/src/module/item/ChatData.ts
@@ -183,9 +183,17 @@ export const ChatData = {
 
     device: (system: DeviceData, labels, props) => {
         if (system.technology && system.technology.rating) props.push(`Rating ${system.technology.rating}`);
+        // Show ALL matrix ratings for these devices
         if (system.category === 'cyberdeck' || system.category === 'rcc') {
-            for (const attN of Object.values(system.atts)) {
-                props.push(`${Helpers.label(attN.att)} ${attN.value}`);
+            for (const attribute of Object.values(system.atts)) {
+                props.push(`${Helpers.label(attribute.att)} ${attribute.value}`);
+            }
+        }
+        // Commlinks CAN have all values, but tend to only have dp and fw
+        // Therefore only show non-zero values
+        if (system.category === 'commlink') {
+            for (const attribute of Object.values(system.atts)) {
+                if (attribute.value) props.push(`${Helpers.label(attribute.att)} ${attribute.value}`);
             }
         }
     },

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1051,6 +1051,14 @@ export class SR5Item extends Item {
         return this.wrapper.getTechnology();
     }
 
+    getNetworkController(): string|undefined {
+        return this.getTechnologyData()?.networkController;
+    }
+
+    async setNetworkController(networkController: string): Promise<void> {
+        await this.update({ 'system.technology.networkController': networkController });
+    }
+
     getRange(): CritterPowerRange|SpellRange|RangeWeaponData|undefined {
         return this.wrapper.getRange();
     }
@@ -1610,22 +1618,11 @@ export class SR5Item extends Item {
      * Configure the given matrix item to be controlled by this item in a PAN/WAN.
      * @param target The matrix item to be connected.
      */
-    async addNetworkDevice(target: SR5Item) {
+    async addNetworkDevice(target: SR5Item|SR5Actor) {
         // TODO: Add device to WAN network
         // TODO: Add IC actor to WAN network
         // TODO: setup networkController link on networked devices.
         await NetworkDeviceFlow.addDeviceToNetwork(this, target);
-    }
-
-    /**
-     * Configure the given vehicle to be controlled by this item in a PAN/WAN.
-     * @param target The matrix item to be connected.
-     */
-    async addNetworkVehicle(target: SR5Actor) {
-        // TODO: Add device to WAN network
-        // TODO: Add IC actor to WAN network
-        // TODO: setup networkController link on networked devices.
-        await NetworkDeviceFlow.addVehicleToNetwork(this, target);
     }
 
     /**
@@ -1685,7 +1682,7 @@ export class SR5Item extends Item {
     /**
      * Return all network device items within a possible PAN or WAN.
      */
-    get networkDevices(): SR5Item[] {
+    get networkDevices(): (SR5Item|SR5Actor)[] {
         const controller = this.asDevice || this.asHost;
         if (!controller) return [];
 

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1618,6 +1618,17 @@ export class SR5Item extends Item {
     }
 
     /**
+     * Configure the given vehicle to be controlled by this item in a PAN/WAN.
+     * @param target The matrix item to be connected.
+     */
+    async addNetworkVehicle(target: SR5Actor) {
+        // TODO: Add device to WAN network
+        // TODO: Add IC actor to WAN network
+        // TODO: setup networkController link on networked devices.
+        await NetworkDeviceFlow.addVehicleToNetwork(this, target);
+    }
+
+    /**
      * Alias method for addNetworkDevice, both do the same.
      * @param target
      */

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1055,7 +1055,7 @@ export class SR5Item extends Item {
         return this.getTechnologyData()?.networkController;
     }
 
-    async setNetworkController(networkController: string): Promise<void> {
+    async setNetworkController(networkController: string|undefined): Promise<void> {
         await this.update({ 'system.technology.networkController': networkController });
     }
 

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -341,7 +341,6 @@ export class SR5ItemSheet extends ItemSheet {
 
         // Parse drop data.
         const data = this.parseDropData(event);
-        console.log("_onDrop", data);
         if (!data) return;
 
         // Add items to a weapons modification / ammo
@@ -389,9 +388,11 @@ export class SR5ItemSheet extends ItemSheet {
 
             if (!actor || !actor.id) return console.error('Shadowrun 5e | Actor could not be retrieved from DropData', data);
 
-            if(actor.isVehicle()) {
-                return await this.item.addNetworkDevice(actor);
+            if(!actor.isVehicle()) {
+                return ui.notifications?.error(game.i18n.localize('SR5.Errors.CanOnlyAddTechnologyItemsToANetwork'));
             }
+
+            return await this.item.addNetworkDevice(actor);
         }
     }
 

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -3,6 +3,7 @@ import {SR5Item} from './SR5Item';
 import {SR5} from "../config";
 import {onManageActiveEffect, prepareActiveEffectCategories} from "../effects";
 import { createTagify } from '../utils/sheets';
+import { SR5Actor } from '../actor/SR5Actor';
 
 /**
  * FoundryVTT ItemSheetData typing
@@ -340,7 +341,7 @@ export class SR5ItemSheet extends ItemSheet {
 
         // Parse drop data.
         const data = this.parseDropData(event);
-
+        console.log("_onDrop", data);
         if (!data) return;
 
         // Add items to a weapons modification / ammo
@@ -380,6 +381,18 @@ export class SR5ItemSheet extends ItemSheet {
             if (!item || !item.id) return console.error('Shadowrun 5e | Item could not be retrieved from DropData', data);
             
             return await this.item.addNetworkDevice(item);
+        }
+
+        // Add vehicles to a network (PAN/WAN).
+        if (this.item.canBeNetworkController && data.type === 'Actor') {
+            const actor = await fromUuid(data.uuid) as SR5Actor;
+
+            if (!actor || !actor.id) return console.error('Shadowrun 5e | Actor could not be retrieved from DropData', data);
+
+            if(actor.isVehicle()) {
+                return await this.item.addNetworkVehicle(actor);
+            }
+
         }
     }
 

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -53,7 +53,7 @@ interface SR5ItemSheetData extends SR5BaseItemSheetData {
 
     // Host Item.
     markedDocuments: Shadowrun.MarkedDocument[]
-    networkDevices: SR5Item[]
+    networkDevices: (SR5Item|SR5Actor)[]
     networkController: SR5Item | undefined
 
     // Action Items. (not only type = action)
@@ -390,9 +390,8 @@ export class SR5ItemSheet extends ItemSheet {
             if (!actor || !actor.id) return console.error('Shadowrun 5e | Actor could not be retrieved from DropData', data);
 
             if(actor.isVehicle()) {
-                return await this.item.addNetworkVehicle(actor);
+                return await this.item.addNetworkDevice(actor);
             }
-
         }
     }
 

--- a/src/module/item/flows/NetworkDeviceFlow.ts
+++ b/src/module/item/flows/NetworkDeviceFlow.ts
@@ -136,10 +136,10 @@ export class NetworkDeviceFlow {
 
      * @param device A network device that's connected to a controller.
      */
-    static async removeDeviceFromController(device: SR5Item|undefined) {
+    static async removeDeviceFromController(device: SR5Item|SR5Actor|undefined) {
         if (!device) return;
 
-        console.log(`Shadowrun 5e | Removing device ${device.name} from it's controller`);
+        console.log(`Shadowrun 5e | Removing device ${device.name} from its controller`);
 
         await NetworkDeviceFlow._removeDeviceFromController(device);
         await NetworkDeviceFlow._removeControllerFromDevice(device);
@@ -156,7 +156,6 @@ export class NetworkDeviceFlow {
         const controllerData = controller.asController();
         const device = NetworkDeviceFlow.resolveLink(deviceLink);
 
-        console.log("removeDeviceLinkFromNetwork", device);
         // Remove an existing item from the network.
         if (device) {
             const networkController = device.getNetworkController();
@@ -196,7 +195,7 @@ export class NetworkDeviceFlow {
     private static async _removeControllerFromDevice(device: SR5Item|SR5Actor) {
         if (!device.canBeNetworkDevice) return console.error('Shadowrun 5e | Given device cant be part of a network', device);
         if (!NetworkDeviceFlow._currentUserCanModifyDevice(device)) return;
-        await device.update({'data.technology.networkController': ''})
+        await device.setNetworkController(undefined);
     }
 
     private static async _setDevicesOnController(controller: SR5Item, deviceLinks: string[]) {
@@ -210,8 +209,8 @@ export class NetworkDeviceFlow {
     }
 
     /**
-     * As part of the deleteItem FoundryVTT event this method will called by all active users, even if they lack permission.
-     * @param device The device that is to removed from the network controller.
+     * As part of the deleteItem FoundryVTT event this method will be called by all active users, even if they lack permission.
+     * @param device The device that is to be removed from the network controller.
      * @private
      */
     private static async _removeDeviceFromController(device: SR5Item|SR5Actor){

--- a/src/module/item/flows/NetworkDeviceFlow.ts
+++ b/src/module/item/flows/NetworkDeviceFlow.ts
@@ -195,7 +195,7 @@ export class NetworkDeviceFlow {
     private static async _removeControllerFromDevice(device: SR5Item|SR5Actor) {
         if (!device.canBeNetworkDevice) return console.error('Shadowrun 5e | Given device cant be part of a network', device);
         if (!NetworkDeviceFlow._currentUserCanModifyDevice(device)) return;
-        await device.setNetworkController(undefined);
+        await device.setNetworkController("");
     }
 
     private static async _setDevicesOnController(controller: SR5Item, deviceLinks: string[]) {

--- a/src/module/types/actor/Vehicle.ts
+++ b/src/module/types/actor/Vehicle.ts
@@ -32,6 +32,7 @@ declare namespace Shadowrun {
             environment: VehicleEnvironment
             vehicle_stats: VehicleStats
             attributes: VehicleAttributes
+            networkController: string
         }
 
     export interface VehicleStats {

--- a/src/templates/actor/parts/vehicle/VehicleSecondStatsList.html
+++ b/src/templates/actor/parts/vehicle/VehicleSecondStatsList.html
@@ -51,4 +51,12 @@
     {{#> "systems/shadowrun5e/dist/templates/common/NameLineBlock.html" name=(localize "SR5.Vehicle.IsOffRoad") }}
         <input type="checkbox" class="checkbox" name="system.isOffRoad" {{checked system.isOffRoad}}/>
     {{/"systems/shadowrun5e/dist/templates/common/NameLineBlock.html"}}
+    {{#> "systems/shadowrun5e/dist/templates/common/NameLineBlock.html" name=(localize "SR5.Labels.Sheet.PAN") }}
+    {{#if vehicle.networkController}}
+    <span>
+                <a class="origin-link" draggable="false" data-origin-link="{{vehicle.networkController.uuid}}">{{vehicle.networkController.name}}</a>
+                <a class="close controller-remove"><i class="fas fa-times"></i></a>
+            </span>
+    {{/if}}
+    {{/"systems/shadowrun5e/dist/templates/common/NameLineBlock.html"}}
 </div>

--- a/src/templates/actor/tabs/NetworkTab.html
+++ b/src/templates/actor/tabs/NetworkTab.html
@@ -7,7 +7,7 @@
                 rightSide=(NetworkDevicesListRightSide)
                 icons=(NetworkDevicesListHeaderIcons)
         }}
-        {{!-- Don't use the ListItem Handlebar helper as to avoid it's item drag&drop functionality. --}}
+        {{!-- Don't use the ListItem Handlebar helper as to avoid its item drag&drop functionality. --}}
         {{#each networkDevices}}
         <div class="list-item" data-token-id="{{this.actor.token.id}}" data-actor-id="{{this.actor.id}}" data-device-id="{{this.id}}" data-list-item-index="{{@index}}">
             <div class="list-item-content">

--- a/src/templates/item/parts/matrix.html
+++ b/src/templates/item/parts/matrix.html
@@ -16,10 +16,9 @@
         </div>
     </div>
     {{/ife}}
-    {{#ifne system.category "commlink"}}
     <div class="form-line">
         <div class="label">
-            <select name="system.atts.att1.att">
+            <select name="system.atts.att1.att" {{#ifne system.category "cyberdeck"}}disabled{{/ifne}}>
                 {{#select system.atts.att1.att}} {{#each config.matrixAttributes as |name type|}}
                 <option value="{{type}}">{{localize name}}</option>
                 {{/each}} {{/select}}
@@ -40,7 +39,7 @@
     </div>
     <div class="form-line">
         <div class="label">
-            <select name="system.atts.att2.att">
+            <select name="system.atts.att2.att" {{#ifne system.category "cyberdeck"}}disabled{{/ifne}}>
                 {{#select system.atts.att2.att}} {{#each config.matrixAttributes as |name type|}}
                 <option value="{{type}}">{{localize name}}</option>
                 {{/each}} {{/select}}
@@ -61,7 +60,7 @@
     </div>
     <div class="form-line">
         <div class="label">
-            <select name="system.atts.att3.att">
+            <select name="system.atts.att3.att" {{#ifne system.category "cyberdeck"}}disabled{{/ifne}}>
                 {{#select system.atts.att3.att}} {{#each config.matrixAttributes as |name type|}}
                 <option value="{{type}}">{{localize name}}</option>
                 {{/each}} {{/select}}
@@ -82,7 +81,7 @@
     </div>
     <div class="form-line">
         <div class="label">
-            <select name="system.atts.att4.att">
+            <select name="system.atts.att4.att" {{#ifne system.category "cyberdeck"}}disabled{{/ifne}}>
                 {{#select system.atts.att4.att}} {{#each config.matrixAttributes as |name type|}}
                 <option value="{{type}}">{{localize name}}</option>
                 {{/each}} {{/select}}
@@ -101,5 +100,4 @@
             />
         </div>
     </div>
-    {{/ifne}}
 </div>

--- a/src/templates/item/parts/matrix.html
+++ b/src/templates/item/parts/matrix.html
@@ -5,7 +5,9 @@
     {{#ife type "device"}}
     <div class="form-line">
         <div class="label">
-            {{localize "SR5.DeviceType"}}
+            <label>
+                {{localize "SR5.DeviceType"}}
+            </label>
         </div>
         <div class="inputs">
             <select name="system.category">

--- a/src/templates/item/parts/matrix.html
+++ b/src/templates/item/parts/matrix.html
@@ -18,11 +18,16 @@
     {{/ife}}
     <div class="form-line">
         <div class="label">
-            <select name="system.atts.att1.att" {{#ifne system.category "cyberdeck"}}disabled{{/ifne}}>
+            {{#ife system.category "cyberdeck"}}
+            <select name="system.atts.att1.att">
                 {{#select system.atts.att1.att}} {{#each config.matrixAttributes as |name type|}}
                 <option value="{{type}}">{{localize name}}</option>
                 {{/each}} {{/select}}
             </select>
+            {{/ife}}
+            {{#ifne system.category "cyberdeck"}}
+            <label>{{localize (lookup config.matrixAttributes system.atts.att1.att)}}</label>
+            {{/ifne}}
         </div>
         <div class="inputs">
             <input
@@ -39,11 +44,16 @@
     </div>
     <div class="form-line">
         <div class="label">
-            <select name="system.atts.att2.att" {{#ifne system.category "cyberdeck"}}disabled{{/ifne}}>
+            {{#ife system.category "cyberdeck"}}
+            <select name="system.atts.att2.att">
                 {{#select system.atts.att2.att}} {{#each config.matrixAttributes as |name type|}}
                 <option value="{{type}}">{{localize name}}</option>
                 {{/each}} {{/select}}
             </select>
+            {{/ife}}
+            {{#ifne system.category "cyberdeck"}}
+            <label>{{localize (lookup config.matrixAttributes system.atts.att2.att)}}</label>
+            {{/ifne}}
         </div>
         <div class="inputs">
             <input
@@ -60,11 +70,16 @@
     </div>
     <div class="form-line">
         <div class="label">
-            <select name="system.atts.att3.att" {{#ifne system.category "cyberdeck"}}disabled{{/ifne}}>
+            {{#ife system.category "cyberdeck"}}
+            <select name="system.atts.att3.att">
                 {{#select system.atts.att3.att}} {{#each config.matrixAttributes as |name type|}}
                 <option value="{{type}}">{{localize name}}</option>
                 {{/each}} {{/select}}
             </select>
+            {{/ife}}
+            {{#ifne system.category "cyberdeck"}}
+            <label>{{localize (lookup config.matrixAttributes system.atts.att3.att)}}</label>
+            {{/ifne}}
         </div>
         <div class="inputs">
             <input
@@ -81,11 +96,16 @@
     </div>
     <div class="form-line">
         <div class="label">
-            <select name="system.atts.att4.att" {{#ifne system.category "cyberdeck"}}disabled{{/ifne}}>
+            {{#ife system.category "cyberdeck"}}
+            <select name="system.atts.att4.att">
                 {{#select system.atts.att4.att}} {{#each config.matrixAttributes as |name type|}}
                 <option value="{{type}}">{{localize name}}</option>
                 {{/each}} {{/select}}
             </select>
+            {{/ife}}
+            {{#ifne system.category "cyberdeck"}}
+            <label>{{localize (lookup config.matrixAttributes system.atts.att4.att)}}</label>
+            {{/ifne}}
         </div>
         <div class="inputs">
             <input

--- a/src/unittests/sr5.NetworkDevices.spec.ts
+++ b/src/unittests/sr5.NetworkDevices.spec.ts
@@ -5,7 +5,7 @@ import {NetworkDeviceFlow} from "../module/item/flows/NetworkDeviceFlow";
 import { QuenchBatchContext } from "@ethaks/fvtt-quench";
 
 export const shadowrunNetworkDevices = (context: QuenchBatchContext) => {
-    const {describe, it, assert, should, before, after} = context;
+    const {describe, it, assert, before, after} = context;
 
     let testActor;
     let testItem;
@@ -73,19 +73,33 @@ export const shadowrunNetworkDevices = (context: QuenchBatchContext) => {
             assert.strictEqual(token?.id, resolvedToken?.id);
         });
 
-        it('connect a device controller to a network device', async () => {
+        it('connect a device controller to an item network device', async () => {
             const controller = await testItem.create({type: 'device'});
             const device = await testItem.create({type: 'weapon'});
 
             await NetworkDeviceFlow.addDeviceToNetwork(controller, device);
 
             assert.strictEqual(device.system.technology.networkController, controller.uuid);
+            assert.strictEqual(device.getNetworkController(), controller.uuid);
             assert.strictEqual(await NetworkDeviceFlow.resolveLink(device.system.technology.networkController), controller);
 
             assert.deepEqual(controller.system.networkDevices, [device.uuid]);
         });
 
-        it('connect a host controller to a network device', async () => {
+        it('connect a device controller to a vehicle network device', async () => {
+            const controller = await testItem.create({type: 'device'});
+            const device = await testActor.create({type: 'vehicle'});
+
+            await NetworkDeviceFlow.addDeviceToNetwork(controller, device);
+
+            assert.strictEqual(device.system.networkController, controller.uuid);
+            assert.strictEqual(device.getNetworkController(), controller.uuid);
+            assert.strictEqual(await NetworkDeviceFlow.resolveLink(device.system.networkController), controller);
+
+            assert.deepEqual(controller.system.networkDevices, [device.uuid]);
+        });
+
+        it('connect a host controller to a item network device', async () => {
             const controller = await testItem.create({type: 'host'});
             const device = await testItem.create({type: 'weapon'});
 
@@ -97,10 +111,24 @@ export const shadowrunNetworkDevices = (context: QuenchBatchContext) => {
             assert.deepEqual(controller.system.networkDevices, [device.uuid]);
         });
 
+        it('connect a host controller to a vehicle network device', async () => {
+            const controller = await testItem.create({type: 'host'});
+            const device = await testActor.create({type: 'vehicle'});
+
+            await NetworkDeviceFlow.addDeviceToNetwork(controller, device);
+
+            assert.strictEqual(device.system.networkController, controller.uuid);
+            assert.strictEqual(device.getNetworkController(), controller.uuid);
+            assert.strictEqual(await NetworkDeviceFlow.resolveLink(device.system.networkController), controller);
+
+            assert.deepEqual(controller.system.networkDevices, [device.uuid]);
+        });
+
         it('get all connected network devices of a controller as their Document', async () => {
             const controller = await testItem.create({type: 'device'});
             const devices = [
-                await testItem.create({type: 'weapon'})
+                await testItem.create({type: 'weapon'}),
+                await testActor.create({type: 'vehicle'}),
             ];
 
             for (const device of devices) {
@@ -110,8 +138,8 @@ export const shadowrunNetworkDevices = (context: QuenchBatchContext) => {
             const fetchedDevices = NetworkDeviceFlow.getNetworkDevices(controller);
 
             // Check for structural equality.
-            assert.strictEqual(controller.system.networkDevices.length, 1);
-            assert.strictEqual(fetchedDevices.length, 1);
+            assert.strictEqual(controller.system.networkDevices.length, 2);
+            assert.strictEqual(fetchedDevices.length, 2);
 
             // Check for referential equality.
             for (const fetched of fetchedDevices) {
@@ -119,7 +147,7 @@ export const shadowrunNetworkDevices = (context: QuenchBatchContext) => {
             }
         });
 
-        it('remove a device from a network', async () => {
+        it('remove a item device from a network', async () => {
             const controller = await testItem.create({type: 'device'});
             const device = await testItem.create({type: 'weapon'});
 
@@ -130,7 +158,19 @@ export const shadowrunNetworkDevices = (context: QuenchBatchContext) => {
             assert.strictEqual(device.system.technology.networkController, '');
         });
 
-        it('remove a device from a network when it is added to a new one', async () => {
+        it('remove a vehicle device from a network', async () => {
+            const controller = await testItem.create({type: 'device'});
+            const device = await testActor.create({type: 'vehicle'});
+
+            await NetworkDeviceFlow.addDeviceToNetwork(controller, device);
+            await NetworkDeviceFlow.removeDeviceLinkFromNetwork(controller, device.uuid);
+
+            assert.deepEqual(controller.system.networkDevices, []);
+            assert.strictEqual(device.system.networkController, '');
+        });
+
+
+        it('remove an item device from a network when it is added to a new one', async () => {
             const controller = await testItem.create({type: 'device'});
             const newController = await testItem.create({type: 'device'});
             const device = await testItem.create({type: 'weapon'});
@@ -143,7 +183,20 @@ export const shadowrunNetworkDevices = (context: QuenchBatchContext) => {
             assert.strictEqual(device.system.technology.networkController, newController.uuid);
         });
 
-        it('remove a network device that doesnt exist anymore', async () => {
+        it('remove a vehicle device from a network when it is added to a new one', async () => {
+            const controller = await testItem.create({type: 'device'});
+            const newController = await testItem.create({type: 'device'});
+            const device = await testActor.create({type: 'vehicle'});
+
+            await NetworkDeviceFlow.addDeviceToNetwork(controller, device);
+            await NetworkDeviceFlow.addDeviceToNetwork(newController, device);
+
+            assert.deepEqual(controller.system.networkDevices, []);
+            assert.deepEqual(newController.system.networkDevices, [device.uuid]);
+            assert.strictEqual(device.system.networkController, newController.uuid);
+        });
+
+        it('remove an item network device that doesnt exist anymore', async () => {
             const controller = await testItem.create({type: 'device'});
             const device = await testItem.create({type: 'weapon'});
             const deviceId = device.id;
@@ -162,10 +215,32 @@ export const shadowrunNetworkDevices = (context: QuenchBatchContext) => {
             assert.deepEqual(controller.system.networkDevices, []);
         });
 
+        it('remove a vehicle network device that doesnt exist anymore', async () => {
+            const controller = await testItem.create({type: 'device'});
+            const device = await testActor.create({type: 'vehicle'});
+            const deviceId = device.id;
+            await NetworkDeviceFlow.addDeviceToNetwork(controller, device);
+            // Simulate user deleting the network item.
+            await device.delete();
+
+            // Make sure item is actually deleted.
+            const collectionItem = game.items?.get(deviceId);
+            assert.strictEqual(collectionItem, undefined);
+
+            // However the device is still connected to the controller.
+            assert.strictEqual(controller.system.networkDevices.length, 1);
+            await NetworkDeviceFlow.removeDeviceLinkFromNetwork(controller, controller.system.networkDevices[0]);
+
+            assert.deepEqual(controller.system.networkDevices, []);
+        });
+
         it('remove all devices from a controller', async () => {
             const controller = await testItem.create({type: 'device'});
+            const itemDevice = await testItem.create({type: 'weapon'});
+            const vehicleDevice = await testActor.create({type: 'vehicle'});
             const devices = [
-                await testItem.create({type: 'weapon'})
+                itemDevice,
+                vehicleDevice,
             ];
 
             for (const device of devices) {
@@ -175,9 +250,18 @@ export const shadowrunNetworkDevices = (context: QuenchBatchContext) => {
             await NetworkDeviceFlow.removeAllDevicesFromNetwork(controller);
 
             assert.deepEqual(controller.system.networkDevices, []);
-            for (const device of devices) {
-                assert.strictEqual(device.system.technology.networkController, '');
-            }
+            assert.strictEqual(itemDevice.system.technology.networkController, '');
+            assert.strictEqual(vehicleDevice.system.networkController, '');
+        });
+
+        it('should not allow non-vehicle actors to be added to controller', async() => {
+            const controller = await testItem.create({type: 'device'});
+            const device = await testActor.create({type: 'character'});
+
+            await NetworkDeviceFlow.addDeviceToNetwork(controller, device);
+
+            assert.deepEqual(controller.system.networkDevices, []);
+            assert.strictEqual(device.system.networkController, undefined);
         });
     });
 };


### PR DESCRIPTION
- Allows vehicles to be added to PANs via drag-and-drop
  - Shows PAN on vehicle actor's sheet
  - Attempts to unify the network logic to accept either items or actors seamlessly
  - Adds a new `networkController` key onto vehicle actor data
- Updates matrix device item edit page to not allow shuffling ASDF stats on RCCs, in addition to showing stats for commlinks to support things like oddmods (see #784 )

RCC Matrix Stats (Commlink looks identical):
![image](https://github.com/smilligan93/SR5-FoundryVTT/assets/2165323/68234124-e556-44c9-9cdd-713b1df7deb0)
