### PR TITLE
Fix unshuffleable host matrix attributes and add logic to swap slots when shuffled

### DIFF
--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -1729,6 +1729,7 @@ export class SR5BaseActorSheet extends ActorSheet {
         };
 
         // go through atts on device, setup matrix attributes on it
+        // This logic swaps the two slots when a new one is selected
         for (let i = 1; i <= 4; i++) {
             let tmp = `att${i}`;
             let key = `system.atts.att${i}.att`;

--- a/src/module/handlebars/BasicHelpers.ts
+++ b/src/module/handlebars/BasicHelpers.ts
@@ -1,8 +1,6 @@
 import { Helpers } from '../helpers';
 import {SafeString} from "handlebars";
 import SkillField = Shadowrun.SkillField;
-import {SR5} from "../config";
-import {FLAGS, SR, SYSTEM_NAME} from "../constants";
 import {SR5Actor} from "../actor/SR5Actor";
 
 export const registerBasicHelpers = () => {
@@ -156,5 +154,14 @@ export const registerBasicHelpers = () => {
      */
     Handlebars.registerHelper('objValue', function(obj: Object, key: string) {
         return obj[key] ||  '';
+    });
+
+    /**
+     * Creates an array from a spread set of objects ie. (toArray "foo" "bar") => ["foo", "bar"]
+     */
+    Handlebars.registerHelper('toArray', function(...vals) {
+        const copy = [...vals];
+        copy.splice(-1); //Remove handlebars options object from last item in array
+        return copy;
     });
 };

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -330,6 +330,8 @@ export class SR5ItemSheet extends ItemSheet {
         html.find('.origin-link').on('click', this._onOpenOriginLink.bind(this));
         html.find('.controller-remove').on('click', this._onControllerRemove.bind(this));
 
+        html.find('.matrix-att-selector').on('change', this._onMatrixAttributeSelected.bind(this));
+
         this._activateTagifyListeners(html);        
     }
 
@@ -404,6 +406,30 @@ export class SR5ItemSheet extends ItemSheet {
     _onOpenSource(event) {
         event.preventDefault();
         this.item.openSource();
+    }
+
+    //Swap slots (att1, att2, etc.) for ASDF matrix attributes
+    async _onMatrixAttributeSelected(event) {
+        if (!this.item.system.atts) return;
+
+        // sleaze, attack, etc.
+        const selectedAtt = event.currentTarget.value;
+        // att1, att2, etc..
+        const changedSlot = event.currentTarget.dataset.att;
+
+        const oldValue = this.item.system.atts[changedSlot].att;
+
+        let data = {}
+
+        Object.entries(this.item.system.atts).forEach(([slot, { att }]) => {
+            if(slot === changedSlot) {
+                data[`system.atts.${slot}.att`] = selectedAtt;
+            } else if (att === selectedAtt) {
+                data[`system.atts.${slot}.att`] = oldValue;
+            }
+        });
+
+        await this.item.update(data);
     }
 
     async _onEditItem(event) {

--- a/src/templates/item/parts/matrix.html
+++ b/src/templates/item/parts/matrix.html
@@ -20,16 +20,15 @@
     {{/ife}}
     <div class="form-line">
         <div class="label">
-            {{#ife system.category "cyberdeck"}}
-            <select name="system.atts.att1.att">
+            {{#ifin system.category (toArray "cyberdeck" "host")}}
+            <select class="matrix-att-selector" name="system.atts.att1.att" data-att="att1">
                 {{#select system.atts.att1.att}} {{#each config.matrixAttributes as |name type|}}
                 <option value="{{type}}">{{localize name}}</option>
                 {{/each}} {{/select}}
             </select>
-            {{/ife}}
-            {{#ifne system.category "cyberdeck"}}
+            {{else}}
             <label>{{localize (lookup config.matrixAttributes system.atts.att1.att)}}</label>
-            {{/ifne}}
+            {{/ifin}}
         </div>
         <div class="inputs">
             <input
@@ -46,16 +45,15 @@
     </div>
     <div class="form-line">
         <div class="label">
-            {{#ife system.category "cyberdeck"}}
-            <select name="system.atts.att2.att">
+            {{#ifin system.category (toArray "cyberdeck" "host")}}
+            <select class="matrix-att-selector" name="system.atts.att2.att" data-att="att2">
                 {{#select system.atts.att2.att}} {{#each config.matrixAttributes as |name type|}}
                 <option value="{{type}}">{{localize name}}</option>
                 {{/each}} {{/select}}
             </select>
-            {{/ife}}
-            {{#ifne system.category "cyberdeck"}}
+            {{else}}
             <label>{{localize (lookup config.matrixAttributes system.atts.att2.att)}}</label>
-            {{/ifne}}
+            {{/ifin}}
         </div>
         <div class="inputs">
             <input
@@ -72,16 +70,15 @@
     </div>
     <div class="form-line">
         <div class="label">
-            {{#ife system.category "cyberdeck"}}
-            <select name="system.atts.att3.att">
+            {{#ifin system.category (toArray "cyberdeck" "host")}}
+            <select class="matrix-att-selector" name="system.atts.att3.att" data-att="att3">
                 {{#select system.atts.att3.att}} {{#each config.matrixAttributes as |name type|}}
                 <option value="{{type}}">{{localize name}}</option>
                 {{/each}} {{/select}}
             </select>
-            {{/ife}}
-            {{#ifne system.category "cyberdeck"}}
+            {{else}}
             <label>{{localize (lookup config.matrixAttributes system.atts.att3.att)}}</label>
-            {{/ifne}}
+            {{/ifin}}
         </div>
         <div class="inputs">
             <input
@@ -98,16 +95,15 @@
     </div>
     <div class="form-line">
         <div class="label">
-            {{#ife system.category "cyberdeck"}}
-            <select name="system.atts.att4.att">
+            {{#ifin system.category (toArray "cyberdeck" "host")}}
+            <select class="matrix-att-selector" name="system.atts.att4.att" data-att="att4">
                 {{#select system.atts.att4.att}} {{#each config.matrixAttributes as |name type|}}
                 <option value="{{type}}">{{localize name}}</option>
                 {{/each}} {{/select}}
             </select>
-            {{/ife}}
-            {{#ifne system.category "cyberdeck"}}
+            {{else}}
             <label>{{localize (lookup config.matrixAttributes system.atts.att4.att)}}</label>
-            {{/ifne}}
+            {{/ifin}}
         </div>
         <div class="inputs">
             <input


### PR DESCRIPTION
Addresses #830 
* Allow hosts to once again shuffle their ASDF matrix attributes (broken in #804 - sorry!)
* Update shuffling logic to swap slots similar to the logic on the Matrix tab of the Actor sheet

See demo:

https://github.com/smilligan93/SR5-FoundryVTT/assets/2165323/892c098c-753c-4aea-9f18-cdb67838f504

