### PR TITLE
[BUG] Unselecting a environmental modifier doesn't work

### DIFF
--- a/src/module/rules/DocumentSituationModifiers.ts
+++ b/src/module/rules/DocumentSituationModifiers.ts
@@ -361,8 +361,8 @@ export class DocumentSituationModifiers {
      */
     static async setDocumentModifiers(document: ModifiableDocumentTypes, modifiers: SituationModifiersSourceData) {
         if (document instanceof SR5Actor) {
-            // Disable diffing to overwrite the whole object. 
-            await document.update({'system.situation_modifiers': modifiers}, {diff: false});
+            // Overwrite the whole modifier object.
+            await document.update({'system.==situation_modifiers': modifiers});
         } else {
             // Due to active selection merging by Foundry mergeObject, we need to delete first.
             await document.unsetFlag(SYSTEM_NAME, FLAGS.Modifier);


### PR DESCRIPTION

{diff: false} doesn´t apply differntial values but remove existing ones. In this case a modifier was removed causing it's data to be removed as wall. Non existant keys will not cause existing ones to be removed, no matter what diff-context used.

Instead we have to wholesale replace the situation_modifiers object, which since v12 can be done with ==

Fixes #1424