### PR TITLE
[FIX, Importer] Preserve `_id` on nested items to restore interactivity

### DIFF
--- a/src/module/apps/itemImport/parser/metatype/MetatypeParserBase.ts
+++ b/src/module/apps/itemImport/parser/metatype/MetatypeParserBase.ts
@@ -25,7 +25,7 @@ export abstract class MetatypeParserBase<TResult extends ShadowrunActorData> ext
                 continue;
             }
 
-            const itemBase = game.items!.fromCompendium(foundItem) as ItemDataSource;
+            const itemBase = game.items!.fromCompendium(foundItem, { keepId: true }) as ItemDataSource;
 
             if (item.$?.select)
                 itemBase.name += ` (${item.$.select})`;

--- a/src/module/apps/itemImport/parser/vehicle/VehicleParser.ts
+++ b/src/module/apps/itemImport/parser/vehicle/VehicleParser.ts
@@ -30,7 +30,7 @@ export class VehicleParser extends Parser<VehicleActorData> {
                 continue;
             }
 
-            const itemBase = game.items!.fromCompendium(foundItem) as ItemDataSource;
+            const itemBase = game.items!.fromCompendium(foundItem, { keepId: true }) as ItemDataSource;
 
             if ('technology' in itemBase.system)
                 itemBase.system.technology.equipped = true;

--- a/src/module/apps/itemImport/parser/weapon/WeaponParserBase.ts
+++ b/src/module/apps/itemImport/parser/weapon/WeaponParserBase.ts
@@ -42,7 +42,10 @@ export class WeaponParserBase extends Parser<WeaponItemData> {
                 continue;
             }
 
-            const accessoryBase = game.items!.fromCompendium(foundItem) as Shadowrun.ModificationItemData;
+            // Create a new _id since it will not be created on the creation of the item.
+            const accessoryBase = game.items!.fromCompendium(foundItem, { keepId: true }) as Shadowrun.ModificationItemData;
+            // @ts-expect-error
+            accessoryBase._id = foundry.utils.randomID();
             accessoryBase.system.technology.equipped = true;
 
             const ratingText = accessory.rating?._TEXT;


### PR DESCRIPTION
In Foundry, an `_id` is automatically assigned to `Item`s on `Actor`s, unless explicitly specified. However, this behavior does not apply to `nested Item`s (i.e., items embedded within other items), which are not officially supported by Foundry.

When using `fromCompendium`, the `_id` field is stripped from nested items and never re-assigned, breaking their ability to be interacted with—since `_id` is required to uniquely identify them for operations like updates or deletions.

This PR does the following:
- Adds `{ keepId: true }` to `fromCompendium` when used in `WeaponParserBase`, ensuring `_id`s are retained for `nested item`s.
- Adds a call to `randomID()` on the weapon item to avoid potential ID collisions when duplicating the same item.

Even though the fix is currently only applied in `WeaponParserBase`, this change serves as a reference and reminder to apply `{ keepId: true }` in other nested item scenarios.

Example of the issue:
- Imported weapons lose interactivity on their nested items (e.g., mods and ammo cannot be edited) due to missing `_id`.
