### PR TITLE
[BUG] Driver sheet can't be opened from vehicle sheet

### DIFF
--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -375,9 +375,6 @@ export class SR5BaseActorSheet extends ActorSheet {
 
         // Reset Actor Run Data
         html.find('.reset-actor-run-data').on('click', this._onResetActorRunData.bind(this));
-
-        // Linked documents on sheets.
-        html.find('.entity-link').on('click', Helpers.renderEntityLinkSheet);
     }
 
     /**

--- a/src/module/apps/dialogs/TestDialog.ts
+++ b/src/module/apps/dialogs/TestDialog.ts
@@ -53,9 +53,6 @@ export class TestDialog extends FormDialog {
     override activateListeners(html: JQuery) {
         super.activateListeners(html);
 
-        // Handle in-dialog entity links to render the respective sheets.
-        html.find('.entity-link').on('click', Helpers.renderEntityLinkSheet)
-
         this._injectExternalActiveListeners(html);
     }
 

--- a/src/templates/actor/parts/ic/ICConfiguration.html
+++ b/src/templates/actor/parts/ic/ICConfiguration.html
@@ -29,7 +29,7 @@
     {{#> "systems/shadowrun5e/dist/templates/common/NameLineBlock.html" name=(localize "SR5.ItemTypes.Host") }}
         <div>
             {{#if host }}
-                <a class="entity-link content-link" draggable="true" data-type="Item" data-id="{{host.id}}" data-uuid="{{host.uuid}}"><i class="fas fa-user">{{host.name}}</i></a>
+                <a class="content-link" draggable="true" data-link data-type="Item" data-id="{{host.id}}" data-uuid="{{host.uuid}}"><i class="fas fa-user">{{host.name}}</i></a>
                 <a class="close entity-remove"><i class="fas fa-times"></i></a>
             {{else}}
                 {{localize "SR5.IC.MissingHost"}}

--- a/src/templates/actor/parts/magic/SpiritOptions.html
+++ b/src/templates/actor/parts/magic/SpiritOptions.html
@@ -2,7 +2,7 @@
 {{#> "systems/shadowrun5e/dist/templates/common/NameLineBlock.html" name=(localize "SR5.Spirit.Summoner") }}
 <div>
     {{#if summoner}}
-    <a class="entity-link content-link" draggable="true" data-type="Actor" data-id="{{summoner.id}}" data-uuid="{{summoner.uuid}}">
+    <a class="content-link" draggable="true" data-link data-type="Actor" data-id="{{summoner.id}}" data-uuid="{{summoner.uuid}}">
         <i class="fas fa-user"></i>{{summoner.name}}
         <a class="close summoner-remove"><i class="fas fa-times"></i></a>
     </a>

--- a/src/templates/actor/parts/vehicle/VehicleSecondStatsList.html
+++ b/src/templates/actor/parts/vehicle/VehicleSecondStatsList.html
@@ -3,7 +3,7 @@
     {{#> "systems/shadowrun5e/dist/templates/common/NameLineBlock.html" name=(localize "SR5.Vehicle.Driver") }}
     <div>
         {{#if vehicle.driver}}
-        <a class="entity-link content-link" draggable="true" data-type="Actor" data-id="{{vehicle.driver.id}}" data-uuid="{{vehicle.driver.uuid}}">
+        <a class="content-link" draggable="true" data-link data-type="Actor" data-id="{{vehicle.driver.id}}" data-uuid="{{vehicle.driver.uuid}}">
             <i class="fas fa-user"></i>
             {{vehicle.driver.name}}
         </a>

--- a/src/templates/actor/tabs/matrix/SpriteSkillsTab.html
+++ b/src/templates/actor/tabs/matrix/SpriteSkillsTab.html
@@ -30,7 +30,7 @@
                                 </div>
                                 <div class="item-right">
                                     {{#if technomancer}}
-                                    <a class="entity-link content-link" draggable="true" data-type="Actor" data-id="{{technomancer.id}}" data-uuid="{{technomancer.uuid}}">
+                                    <a class="content-link" draggable="true" data-link data-type="Actor" data-id="{{technomancer.id}}" data-uuid="{{technomancer.uuid}}">
                                         <i class="fas fa-user"></i>{{technomancer.name}}
                                         <a class="close technomancer-remove"><i class="fas fa-times"></i></a>
                                     </a>

--- a/src/templates/apps/dialogs/parts/success-test-documents.html
+++ b/src/templates/apps/dialogs/parts/success-test-documents.html
@@ -1,14 +1,12 @@
 {{#if test.actor}}
 <div class="document">
     <img src="{{speakerImg test.actor}}"/>
-    <a class="entity-link content-link" data-type="Actor"
-        data-id="{{test.actor.id}}" data-uuid="{{test.actor.uuid}}">{{speakerName test.actor}}</a>
+    <a class="content-link" data-type="Actor" data-link data-id="{{test.actor.id}}" data-uuid="{{test.actor.uuid}}">{{speakerName test.actor}}</a>
 </div>
 {{#if test.item}}
 <div class="document">
     <img src="{{test.item.img}}"/>
-    <a class="entity-link content-link" data-type="Item"
-        data-id="{{test.item.id}}" data-uuid="{{test.item.uuid}}">{{test.item.name}}</a>
+    <a class="content-link" data-type="Item" data-link data-id="{{test.item.id}}" data-uuid="{{test.item.uuid}}">{{test.item.name}}</a>
 </div>
 {{/if}}
 {{/if}}

--- a/src/templates/common/List/ListEntityItem.html
+++ b/src/templates/common/List/ListEntityItem.html
@@ -1,7 +1,7 @@
 {{#> "systems/shadowrun5e/dist/templates/common/NameLineBlock.html" name=lineName}}
   <div>
       {{#ifne id undefined}}
-      <a class="entity-link content-link" draggable="true" data-type="{{type}}" data-id="{{id}}" {{#if pack}}data-pack="{{pack}}"{{/if}}><i class="fas fa-user">{{linkName}}</i></a>
+      <a class="content-link" draggable="true" data-type="{{type}}" data-link data-id="{{id}}" {{#if pack}}data-pack="{{pack}}"{{/if}}><i class="fas fa-user">{{linkName}}</i></a>
       <a class="close entity-remove" data-entity="{{type}}" data-list="{{list}}" data-position={{position}}><i class="fas fa-times"></i></a>
       {{else}}
       {{localize missingLabel}}

--- a/src/templates/item/parts/contact.html
+++ b/src/templates/item/parts/contact.html
@@ -59,7 +59,7 @@
             </div>
             <div>
                 {{#if linkedActor}}
-                <a class="entity-link content-link" draggable="false" data-type="Actor" data-id="{{linkedActor.id}}"
+                <a class="content-link" draggable="false" data-link data-type="Actor" data-id="{{linkedActor.id}}"
                     data-uuid="{{linkedActor.uuid}}">
                     <i class="fas fa-user"></i>
                     {{linkedActor.name}}


### PR DESCRIPTION
Fixes #1459

There used to be custom handling for this that we removed to use Foundry default handling.

Foundry in turn now added a 'data-link' attribute as mandatory requirement, breaking all links across the system.

Chat message links seem to not work with foundry, so I left custom handling there...