### PR TITLE
[Bug] Windows titels weren't visible in minimized applications

### DIFF
--- a/src/css/actor.scss
+++ b/src/css/actor.scss
@@ -253,7 +253,8 @@
             background-repeat: repeat;
             background-size: 100% 20px auto;
             flex: 0 0 20px;
-            padding: 0 3px 0 0;
+            padding-inline: 0.5rem;
+            padding-block: 0rem;
             border-top-left-radius: 8px;
             border-top-right-radius: 8px;
 
@@ -271,6 +272,23 @@
 
             & .window-title {
                 font-size: 0;
+
+                // set the left margin of the icon to mirror the increased inline padding
+                // so maximized window icons are still symetrically spaced to the borders
+                // of the window header
+                a {
+                    margin-left: 0.25rem;
+                }
+            }
+        }
+
+        // Display the window-title when the window is minimized, and restore margin
+        &.minimized .window-header .window-title {
+            font-size: inherit;
+            font-weight: inherit;
+
+            a {
+                margin-left: 0.5rem;
             }
         }
     }

--- a/src/css/item.scss
+++ b/src/css/item.scss
@@ -236,7 +236,8 @@
             background-repeat: repeat;
             background-size: 100% 20px auto;
             flex: 0 0 20px;
-            padding: 0 3px 0 0;
+            padding-inline: 0.5rem;
+            padding-block: 0rem;
             border-top-left-radius: 8px;
             border-top-right-radius: 8px;
 
@@ -254,6 +255,23 @@
 
             & .window-title {
                 font-size: 0;
+
+                // set the left margin of the icon to mirror the increased inline padding
+                // so maximized window icons are still symetrically spaced to the borders
+                // of the window header
+                a {
+                    margin-left: 0.25rem;
+                }
+            }
+        }
+
+        // Display the window-title when the window is minimized, and restore margin
+        &.minimized .window-header .window-title {
+            font-size: inherit;
+            font-weight: inherit;
+
+            a {
+                margin-left: 0.5rem;
             }
         }
     }


### PR DESCRIPTION
This PR restores the missing feature of displaying **sheet titles when minimized**, as requested in [#1547](https://github.com/SR5-FoundryVTT/SR5-FoundryVTT/issues/1547)

### Scope of this PR
- A minor change: while implementing the fix I had to auto-format two files to properly locate the relevant style properties.
- Added the correct CSS behaviour for showing titles on minimized sheets.

### What is _not_ fixed here
- The incorrect background image reported in #1547 remains untouched.
- Fixing this properly requires cleaning up multiple SCSS files, where background images are applied repeatedly, with inconsistent darkening effects and half-duplications across single sheets, but they are not necessarily in the same partial.

### Why it’s deferred
I’ve already invested days into improving SCSS maintainability in [#1468](https://github.com/SR5-FoundryVTT/SR5-FoundryVTT/pull/1468), which:
- Removes duplications.
- Normalizes darkening / background behaviour.
- Renames partials.
- Provides a maintainable scaffolding instead of the current cross-partial "side-effect zoo."

Since that work is already complete and mergeable for at least a month, it doesn’t make sense to redo it piecemeal here, especially when the remaining issue is only a visual glitch that does not affect readability.