### PR TITLE
[BUG] Grids Are Rolling Too Many Dice

### DIFF
--- a/src/module/tests/OpposedBruteForceTest.ts
+++ b/src/module/tests/OpposedBruteForceTest.ts
@@ -37,7 +37,7 @@ export class OpposedBruteForceTest extends OpposedMatrixTest<OpposedBruteForceTe
 
     override prepareBaseValues() {
         super.prepareBaseValues();
-        MarkPlacementFlow.prepareGridDefensePool(this);
+        MarkPlacementFlow.prepareGridBaseValues(this);
     }
 
     /**

--- a/src/module/tests/OpposedHackOnTheFlyTest.ts
+++ b/src/module/tests/OpposedHackOnTheFlyTest.ts
@@ -27,7 +27,7 @@ export class OpposedHackOnTheFlyTest extends OpposedMatrixTest {
 
     override prepareBaseValues() {
         super.prepareBaseValues();
-        MarkPlacementFlow.prepareGridDefensePool(this);
+        MarkPlacementFlow.prepareGridBaseValues(this);
     }
 
     /**

--- a/src/module/tests/flows/MarkPlacementFlow.ts
+++ b/src/module/tests/flows/MarkPlacementFlow.ts
@@ -63,9 +63,9 @@ export const MarkPlacementFlow = {
     /**
      * Grid networks have special pool calculation based on rules.
      * 
-     * Note: This is called mulitple times during execution!
+     * Note: This is called multiple times during execution!
      */
-    prepareGridDefensePool(test: MarkPlacementDefenseTest) {
+    prepareGridBaseValues(test: MarkPlacementDefenseTest) {
         if (!test.device?.isType('grid')) return;
         const modifier = MatrixRules.gridMarkPlacementDefensePool(test.device);
         if (!modifier) return;


### PR DESCRIPTION
Fixes #1568

Test Dialog was showing the correct pool modifiers. After, during test execution, prepareBaseValues will be called mulitple times to update test values baesd on test configuration.

This caused the modifier to be re-applied mulitple times before the actual success test is rolled.