### PR TITLE
[Bug] Missing Migration for Delta Actors

### DIFF
--- a/src/module/migrator/Migrator.ts
+++ b/src/module/migrator/Migrator.ts
@@ -265,7 +265,7 @@ export class Migrator {
         for (const scene of game.scenes) {
             this.updateProgressbar();
             await TokenDocument.implementation.updateDocuments(
-                scene.tokens.filter(t => !t.actorLink).map(t => t.toObject()),
+                scene.tokens.map(t => t.toObject()),
                 { diff: false, recursive: false, parent: scene }
             );
         }


### PR DESCRIPTION
Delta Actors containing custom items were not being updated during migration when `updateAllMigratableDocuments` was executed.
This fix ensures that all items and effects within linked Actor tokens are migrated.