### PR TITLE
[Code] Reworked Drain Test allowing it to trigger targeted effects

### DIFF
--- a/src/module/tests/DrainTest.ts
+++ b/src/module/tests/DrainTest.ts
@@ -111,9 +111,7 @@ export class DrainTest extends SuccessTest<DrainTestData> {
         if(this.data.modifiedDrain.value <= 0){
             return 'SR5.TestResults.ResistedAllDamage';
         }
-        else{
-            return 'SR5.TestResults.ResistedSomeDamage';
-        }
+        return 'SR5.TestResults.ResistedSomeDamage';
     }
 
     override async processResults() {


### PR DESCRIPTION
- Drain tests are no longer failures if damage is leftover, allowing active effects to trigger.
- Instead, the successLabel method determines whether to show the appropriate label based on damage remaining.
- Additionally, it no longer checks hasThreshold to show a success message. This was causing showSuccessLabel in the base class to always return false. I can't think of a reason a drain test would need this check, but do please correct me if I'm wrong.