### PR TITLE
[BUG] Local Grid/Global/Hosts are not showing when trying to connect to a Network

### DIFF
--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -2082,7 +2082,7 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
      *
      * @returns The document to retrieve all marks this actor has access to.
      */
-    async _getDocumentWithMarks(): Promise<SR5Actor | SR5Item | undefined | null> {
+    _getDocumentWithMarks(): SR5Actor | SR5Item | undefined | null {
         // CASE - IC marks are stored on their host item.
         if (this.isType('ic')) {
             return this.network;
@@ -2116,8 +2116,8 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
     /**
      * Retrieve all documents this actor has a mark placed on, directly or indirectly.
      */
-    async getAllMarkedDocuments(): Promise<Shadowrun.MarkedDocument[]> {
-        const marksDevice = await this._getDocumentWithMarks();
+    getAllMarkedDocuments(): Shadowrun.MarkedDocument[] {
+        const marksDevice = this._getDocumentWithMarks();
         if (!marksDevice) return [];
         const marks = marksDevice.marksData;
         if (!marks) return [];

--- a/src/module/actor/flows/ActorMarksFlow.ts
+++ b/src/module/actor/flows/ActorMarksFlow.ts
@@ -142,7 +142,7 @@ export const ActorMarksFlow = {
      * @param matrixData Any documents matrix mark data.
      * @returns The documents that have been marked.
      */
-    async getMarkedDocuments(matrixData: MatrixMarksType) {
+    getMarkedDocuments(matrixData: MatrixMarksType) {
         const documents: Shadowrun.MarkedDocument[] = [];
 
         for (const {uuid, name, marks} of matrixData) {

--- a/src/module/actor/sheets/SR5MatrixActorSheet.ts
+++ b/src/module/actor/sheets/SR5MatrixActorSheet.ts
@@ -119,7 +119,7 @@ export class SR5MatrixActorSheet extends SR5BaseActorSheet {
 
     async _prepareMarkedDocuments(data: MatrixActorSheetData) {
         // When marked documents overview is shown, collect all marked documents.
-        const markedDocuments = await this.actor.getAllMarkedDocuments();
+        const markedDocuments = this.actor.getAllMarkedDocuments();
         data.markedDocuments = this._prepareMarkedDocumentTargets(markedDocuments);
     }
 

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1288,7 +1288,7 @@ export class SR5Item<SubType extends Item.ConfiguredSubType = Item.ConfiguredSub
      *
      * @returns Foundry Documents with marks placed.
      */
-    async getAllMarkedDocuments(): Promise<Shadowrun.MarkedDocument[]> {
+    getAllMarkedDocuments(): Shadowrun.MarkedDocument[] {
         if (!this.isType('host')) return [];
 
         const marksData = this.marksData;

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -228,7 +228,7 @@ export class SR5ItemSheet extends foundry.appv1.sheets.ItemSheet {
         data['itemEffects'] = prepareSortedItemEffects(this.object);
 
         if (this.item.isType('host')) {
-            data['markedDocuments'] = await this.item.getAllMarkedDocuments();
+            data['markedDocuments'] = this.item.getAllMarkedDocuments();
         }
 
         if (this.item.isType('sin')) {

--- a/src/module/item/flows/MatrixNetworkFlow.ts
+++ b/src/module/item/flows/MatrixNetworkFlow.ts
@@ -323,7 +323,8 @@ export class MatrixNetworkFlow {
     }
 
     /**
-     * Collect networks to select based on GRIDs on character.
+     * Collect networks to select based on what a character should be able to connect to
+     * based on marks, public grids and SINs network subscriptions.
      * 
      * @param character Collect networks based on this character.
      */
@@ -351,6 +352,30 @@ export class MatrixNetworkFlow {
             }
         }
 
+        // add marked grids and hosts that aren't already in the list
+        for (const network of this.getMarkedNetworks(character)) {
+            if (!networks.includes(network)) {
+                networks.push(network);
+            }
+        }
+
+        return networks;
+    }
+
+    /**
+     * Retrieve all networks that have marks placed on them by the given actor.
+     * 
+     * @param actor The marks of this actor will be used.
+     */
+    static getMarkedNetworks(actor: SR5Actor) {
+        const markedDocuments = actor.getAllMarkedDocuments();
+
+        // For typesafety use a separate list with explicit type.
+        const networks: Item.Implementation[] = [];
+        markedDocuments.forEach(({document}) => {
+            if (!(document instanceof SR5Item && document.isNetwork())) return;
+            networks.push(document);
+        });
         return networks;
     }
 


### PR DESCRIPTION
Fixes #1575

This refactors the mechanisms to retrieve marked documents for both item and actors to not use async methods anymore. Those async methods where from a time where network documents were retrieved using fromUuid instead of fromUuidSync, as it was yet unclear if pack documents were necessary.

This refactor was necessary to add marked networks to MatrixNetworkFlow.getNetworksForCharacter, which is called from within a sync Dialog constructor (which itself is design flaw with our custom Dialog classes to be looked at in AppV2 reworks of them).