### PR TITLE
Switch `hasOwnProperty` to `Object.hasOwn`

### DIFF
--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -860,17 +860,17 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         const skills = rollData?.skills ?? this.getSkills();
 
         // Find skill by direct id to key matching.
-        if (skills.active.hasOwnProperty(id)) {
+        if (Object.hasOwn(skills.active, id)) {
             return skills.active[id];
         }
-        if (skills.language.value.hasOwnProperty(id)) {
+        if (Object.hasOwn(skills.language.value, id)) {
             return skills.language.value[id];
         }
         // Knowledge skills are de-normalized into categories (street, hobby, ...)
         for (const categoryKey in skills.knowledge) {
-            if (skills.knowledge.hasOwnProperty(categoryKey)) {
+            if (Object.hasOwn(skills.knowledge, categoryKey)) {
                 const category = skills.knowledge[categoryKey];
-                if (category.value.hasOwnProperty(id)) {
+                if (Object.hasOwn(category.value, id)) {
                     return category.value[id];
                 }
             }
@@ -900,7 +900,7 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
 
         // Iterate over all different knowledge skill categories
         for (const categoryKey in skills.knowledge) {
-            if (!skills.knowledge.hasOwnProperty(categoryKey)) continue;
+            if (!Object.hasOwn(skills.knowledge, categoryKey)) continue;
             // TODO: check this function Typescript can't follow the flow here...
             const categorySkills = skills.knowledge[categoryKey].value as SkillFieldType[];
             for (const [id, skill] of Object.entries(categorySkills)) {
@@ -947,7 +947,7 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         category: KnowledgeSkillCategory,
         skill: Partial<SkillFieldType> = { name: SKILL_DEFAULT_NAME }
     ): Promise<string|undefined> {
-        if (!this.system.skills.knowledge.hasOwnProperty(category)) {
+        if (!Object.hasOwn(this.system.skills.knowledge, category)) {
             console.error(`Shadowrun5e | Tried creating knowledge skill with unknown category ${category}`);
             return;
         }
@@ -1040,7 +1040,7 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
      */
     async removeActiveSkill(skillId: string) {
         const activeSkills = this.getActiveSkills();
-        if (!activeSkills.hasOwnProperty(skillId)) return;
+        if (!Object.hasOwn(activeSkills, skillId)) return;
         const skill = this.getSkill(skillId);
         if (!skill) return;
 

--- a/src/module/actor/flows/InventoryFlow.ts
+++ b/src/module/actor/flows/InventoryFlow.ts
@@ -24,7 +24,7 @@ export class InventoryFlow {
     constructor(actor: SR5Actor) {
         // Check for sub-type actors.
         // NOTE: This should be checked through actor.system.modelProvider, though this doesn´t exist sometimes?
-        if (actor.type.includes('.') || !game.model.Actor.hasOwnProperty(actor.type)) {
+        if (actor.type.includes('.') || !Object.hasOwn(game.model.Actor, actor.type)) {
             console.debug(`Shadowrun 5e | InventoryFlow ignored actor ${actor.name} as it has a non-system DataModel`);
             return;
         }

--- a/src/module/actor/flows/TeamworkFlow.ts
+++ b/src/module/actor/flows/TeamworkFlow.ts
@@ -128,7 +128,9 @@ export class TeamworkTest {
      * @returns 
      */
     static async _handleUpdateSocketMessage(socketMessage: Shadowrun.SocketMessageData) {
-        if (!socketMessage.data.hasOwnProperty('messageUuid') || !socketMessage.data.hasOwnProperty('content') || !socketMessage.data.hasOwnProperty('teamworkData')) {
+        const requiredProps = ['messageUuid', 'content', 'teamworkData'] as const;
+        const missingProps = requiredProps.some(prop => !Object.hasOwn(socketMessage.data, prop));
+        if (missingProps) {
             console.error(`Shadowrun 5e | Teamwork Socket Message is missing necessary properties`, socketMessage);
             return;
         }

--- a/src/module/actor/prep/ICPrep.ts
+++ b/src/module/actor/prep/ICPrep.ts
@@ -104,7 +104,7 @@ export class ICPrep {
         const { attributes, host } = system;
 
         for (const id of Object.keys(SR5.attributes)) {
-            if (!attributes.hasOwnProperty(id)) continue;
+            if (!Object.hasOwn(attributes, id)) continue;
             // Exclude invalid attributes for IC
             if (['magic', 'edge', 'essence', 'resonance'].includes(id)) continue
 
@@ -129,7 +129,7 @@ export class ICPrep {
         const { matrix } = system;
 
         for (const id of Object.keys(SR5.matrixAttributes)) {
-            if (!matrix.hasOwnProperty(id)) continue;
+            if (!Object.hasOwn(matrix, id)) continue;
 
             const attribute = matrix[id];
             AttributesPrep.prepareAttribute(id, attribute);

--- a/src/module/actor/prep/functions/AttributesPrep.ts
+++ b/src/module/actor/prep/functions/AttributesPrep.ts
@@ -34,7 +34,7 @@ export class AttributesPrep {
      */
     static prepareAttribute(name: string, attribute: AttributeFieldType, ranges?: Record<string, {min: number, max?: number}>) {
         // Check for valid attributes. Active Effects can cause unexpected properties to appear.
-        if (!SR5.attributes.hasOwnProperty(name) || !attribute) return;
+        if (!Object.hasOwn(SR5.attributes, name) || !attribute) return;
 
         // Each attribute can have a unique value range.
         // TODO:  Implement metatype attribute value ranges for character actors.
@@ -52,7 +52,7 @@ export class AttributesPrep {
      */
     static calculateAttribute(name: string, attribute: AttributeFieldType, ranges?: Record<string, {min: number, max?: number}>) {
         // Check for valid attributes. Active Effects can cause unexpected properties to appear.
-        if (!SR5.attributes.hasOwnProperty(name) || !attribute) return;
+        if (!Object.hasOwn(SR5.attributes, name) || !attribute) return;
 
         // Each attribute can have a unique value range.
         // TODO:  Implement metatype attribute value ranges for character actors.

--- a/src/module/actor/prep/functions/ModifiersPrep.ts
+++ b/src/module/actor/prep/functions/ModifiersPrep.ts
@@ -5,7 +5,7 @@ export class ModifiersPrep {
         const { attributes } = system;
         for (const [name, attribute] of Object.entries(attributes)) {
             // Check for valid attributes. Active Effects can cause unexpected properties to appear.
-            if (!SR5.attributes.hasOwnProperty(name) || !attribute) return;
+            if (!Object.hasOwn(SR5.attributes, name) || !attribute) return;
 
             attribute.mod = [];
         }
@@ -20,7 +20,7 @@ export class ModifiersPrep {
     static clearLimitMods(system: Actor.SystemOfType<'character' | 'critter' | 'spirit' | 'sprite' | 'vehicle'>) {
         const {limits} = system;
         for (const [name, limit] of Object.entries(limits)) {
-            if (!SR5.limits.hasOwnProperty(name) || !limit) return;
+            if (!Object.hasOwn(SR5.limits, name) || !limit) return;
 
             limit.mod = [];
         }

--- a/src/module/apps/dialogs/TestDialog.ts
+++ b/src/module/apps/dialogs/TestDialog.ts
@@ -135,7 +135,7 @@ export class TestDialog extends FormDialog {
         Object.entries(data).forEach(([key, value]) => {
             // key is expected to be relative from TestDialog.data and begin with 'test'
             const valueField = foundry.utils.getProperty(this.data, key) as ModifiableValueType | undefined | null;
-            if (!valueField || foundry.utils.getType(valueField) !== 'Object' || !valueField.hasOwnProperty('mod')) return;
+            if (!valueField || foundry.utils.getType(valueField) !== 'Object' || !Object.hasOwn(valueField, 'mod')) return;
 
             // Remove from further automatic data merging.
             delete data[key];

--- a/src/module/combat/SR5Combat.ts
+++ b/src/module/combat/SR5Combat.ts
@@ -439,7 +439,7 @@ export class SR5Combat<SubType extends Combat.SubType = Combat.SubType> extends 
     }
 
     static async _handleDoNextRoundSocketMessage(message: SocketMessageData) {
-        if (!message.data.hasOwnProperty('id') && typeof message.data.id !== 'string') {
+        if (!Object.hasOwn(message.data, 'id') && typeof message.data.id !== 'string') {
             console.error(`SR5Combat Socket Message ${FLAGS.DoNextRound} data.id must be a string (combat id) but is ${typeof message.data} (${message.data})!`);
             return;
         }
@@ -448,7 +448,7 @@ export class SR5Combat<SubType extends Combat.SubType = Combat.SubType> extends 
     }
 
     static async _handleDoInitPassSocketMessage(message: SocketMessageData) {
-        if (!message.data.hasOwnProperty('id') && typeof message.data.id !== 'string') {
+        if (!Object.hasOwn(message.data, 'id') && typeof message.data.id !== 'string') {
             console.error(`SR5Combat Socket Message ${FLAGS.DoInitPass} data.id must be a string (combat id) but is ${typeof message.data} (${message.data})!`);
             return;
         }
@@ -461,7 +461,7 @@ export class SR5Combat<SubType extends Combat.SubType = Combat.SubType> extends 
      * @param message 
      */
     static async _handleDoNewActionPhaseSocketMessage(message: SocketMessageData) {
-        if (!message.data.hasOwnProperty('id') && typeof message.data.id !== 'string') {
+        if (!Object.hasOwn(message.data, 'id') && typeof message.data.id !== 'string') {
             console.error(`SR5Combat Socket Message ${FLAGS.DoNewActionPhase} data.id must be a string (combat id) but is ${typeof message.data} (${message.data})!`);
             return;
         }

--- a/src/module/effect/flows/SuccessTestEffectsFlow.ts
+++ b/src/module/effect/flows/SuccessTestEffectsFlow.ts
@@ -227,7 +227,7 @@ export class SuccessTestEffectsFlow<T extends SuccessTest> {
      * @returns 
      */
     static async _handleCreateTargetedEffectsSocketMessage(message: Shadowrun.SocketMessageData) {
-        if (!message.data.hasOwnProperty('actorUuid') && !message.data.hasOwnProperty('effectsData')) {
+        if (!Object.hasOwn(message.data, 'actorUuid') && !Object.hasOwn(message.data, 'effectsData')) {
             console.error(`Shadowrun 5e | ${this.name} Socket Message is missing necessary properties`, message);
             return;
         }

--- a/src/module/handlebars/BasicHelpers.ts
+++ b/src/module/handlebars/BasicHelpers.ts
@@ -55,7 +55,7 @@ export const registerBasicHelpers = () => {
         return v1 / v2;
     });
     Handlebars.registerHelper('hasprop', function (this: any, obj, prop, options) {
-        if (obj.hasOwnProperty(prop)) {
+        if (Object.hasOwn(obj, prop)) {
             return options.fn(this);
         } else return options.inverse(this);
     });

--- a/src/module/helpers.ts
+++ b/src/module/helpers.ts
@@ -257,7 +257,7 @@ export class Helpers {
 
     static addLabels(obj, label) {
         if (typeof obj === 'object' && obj !== null) {
-            if (!obj.hasOwnProperty('label') && obj.hasOwnProperty('value') && label !== '') {
+            if (!Object.hasOwn(obj, 'label') && Object.hasOwn(obj, 'value') && label !== '') {
                 obj.label = label;
             }
             Object.entries(obj)
@@ -404,7 +404,7 @@ export class Helpers {
     static convertLengthUnit(length: number, fromUnit: string): number {
         fromUnit = fromUnit.toLowerCase();
 
-        if (!LENGTH_UNIT_TO_METERS_MULTIPLIERS.hasOwnProperty(fromUnit)) {
+        if (!Object.hasOwn(LENGTH_UNIT_TO_METERS_MULTIPLIERS, fromUnit)) {
             console.error(`Distance can't be converted from ${fromUnit} to ${LENGTH_UNIT}`);
             return 0;
         }
@@ -901,7 +901,7 @@ export class Helpers {
      */
     static objectHasKeys(obj: object, keys: string[]): boolean {
         for (const key of keys) {
-            if (!obj.hasOwnProperty(key)) return false;
+            if (!Object.hasOwn(obj, key)) return false;
         }
 
         return true;

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1211,7 +1211,7 @@ export class SR5Item<SubType extends Item.ConfiguredSubType = Item.ConfiguredSub
     }
 
     get _isNestedItem(): boolean {
-        return this.hasOwnProperty('parent') && this.parent instanceof SR5Item;
+        return Object.hasOwn(this, 'parent') && this.parent instanceof SR5Item;
     }
 
     /**

--- a/src/module/rules/AttributeRules.ts
+++ b/src/module/rules/AttributeRules.ts
@@ -62,10 +62,10 @@ export class AttributeRules {
      */
     static replacePhysicalAttributesWithMentalAttributes(action: MinimalActionType) {
         // check the attributes used by the action
-        if (this.PhysicalToMentalAttributeMap.hasOwnProperty(action.attribute)) {
+        if (Object.hasOwn(this.PhysicalToMentalAttributeMap, action.attribute)) {
             action.attribute = this.PhysicalToMentalAttributeMap[action.attribute];
         }
-        if (this.PhysicalToMentalAttributeMap.hasOwnProperty(action.attribute2)) {
+        if (Object.hasOwn(this.PhysicalToMentalAttributeMap, action.attribute2)) {
             action.attribute2 = this.PhysicalToMentalAttributeMap[action.attribute2];
         }
     }

--- a/src/module/rules/DocumentSituationModifiers.ts
+++ b/src/module/rules/DocumentSituationModifiers.ts
@@ -132,7 +132,7 @@ export class DocumentSituationModifiers {
      * @returns true, when a total modifier can be calculated by a handler.
      */
     handlesTotalFor(category: string) {
-        return this._modifiers.hasOwnProperty(category);
+        return Object.hasOwn(this._modifiers, category);
     }
 
     /**
@@ -181,7 +181,7 @@ export class DocumentSituationModifiers {
         data = foundry.utils.duplicate(data);
 
         for (const [category, modifiers] of Object.entries(DocumentSituationModifiers._defaultModifiers)) {
-            if (!data.hasOwnProperty(category)) data[category] = modifiers;
+            if (!Object.hasOwn(data, category)) data[category] = modifiers;
         }
 
         return data as SituationModifiersSourceData;
@@ -271,7 +271,7 @@ export class DocumentSituationModifiers {
     static async clearTypeOn(document: ModifiableDocumentTypes, category: keyof SituationModifiersSourceData): Promise<DocumentSituationModifiers> {
         const modifiers = DocumentSituationModifiers.getDocumentModifiers(document);
 
-        if (!modifiers.source.hasOwnProperty(category)) return modifiers;
+        if (!Object.hasOwn(modifiers.source, category)) return modifiers;
         modifiers.source[category] = DocumentSituationModifiers._defaultModifier;
 
         await DocumentSituationModifiers.setDocumentModifiers(document, modifiers.source);

--- a/src/module/rules/modifiers/SituationModifier.ts
+++ b/src/module/rules/modifiers/SituationModifier.ts
@@ -132,14 +132,14 @@ export class SituationModifier {
      * Determine if a fixed value has been set.
      */
     get hasFixed(): boolean {
-        return this.applied.hasOwnProperty('fixed');
+        return Object.hasOwn(this.applied, 'fixed');
     }
 
     /**
      * Determine if a fixed user selection has been made.
      */
     get hasFixedSelection(): boolean {
-        return this.applied.active.hasOwnProperty('value');
+        return Object.hasOwn(this.applied.active, 'value');
     }
 
     /**
@@ -189,7 +189,7 @@ export class SituationModifier {
      * @param modifier The possibly active modifier to check
      */
     isActive(modifier: string) {
-        return this.source.active.hasOwnProperty(modifier);
+        return Object.hasOwn(this.source.active, modifier);
     }
 
     /**

--- a/src/module/tests/TestCreator.ts
+++ b/src/module/tests/TestCreator.ts
@@ -78,7 +78,7 @@ export const TestCreator = {
             console.warn(`Shadowrun 5e | An action without a defined test handler defaulted to ${'SuccessTest'}`);
         }
 
-        if (!game.shadowrun5e.tests.hasOwnProperty(action.test)) {
+        if (!Object.hasOwn(game.shadowrun5e.tests, action.test)) {
             console.error(`Shadowrun 5e | Test registration for test ${action.test} is missing`);
             return;
         }
@@ -105,7 +105,7 @@ export const TestCreator = {
             console.warn(`Shadowrun 5e | An action without a defined test handler defaulted to ${'SuccessTest'}`);
         }
 
-        if (!game.shadowrun5e.tests.hasOwnProperty(action.test)) {
+        if (!Object.hasOwn(game.shadowrun5e.tests, action.test)) {
             console.error(`Shadowrun 5e | Test registration for test ${action.test} is missing`);
             return;
         }
@@ -329,7 +329,7 @@ export const TestCreator = {
      */
     _getTestClass: function(testName: string): any | undefined {
         if (!testName) return;
-        if (!game.shadowrun5e.tests.hasOwnProperty(testName)) {
+        if (!Object.hasOwn(game.shadowrun5e.tests, testName)) {
             console.error(`Shadowrun 5e | Tried getting a Test Class ${testName}, which isn't registered in: `, game.shadowrun5e.tests);
             return;
         }

--- a/src/module/tests/flows/MatrixTestDataFlow.ts
+++ b/src/module/tests/flows/MatrixTestDataFlow.ts
@@ -50,7 +50,7 @@ export const MatrixTestDataFlow = {
      * @param attribute
      */
     isMatrixAttribute(attribute: string): boolean {
-        return SR5.matrixAttributes.hasOwnProperty(attribute);
+        return Object.hasOwn(SR5.matrixAttributes, attribute);
     },
 
     /**


### PR DESCRIPTION
This updates the codebase to use `Object.hasOwn(obj, key)` instead of calling `obj.hasOwnProperty(key)`.

Why?
- It’s the modern, recommended way to check own properties
- Avoids issues when objects override `hasOwnProperty` [security]
- Keeps things consistent across the project

Just swapped out the old calls for the new form. No behavior changes expected.