### PR TITLE
[BUG] Opening character sheet causes console error 'Distance can't be converted from  to m'

### DIFF
--- a/src/module/helpers.ts
+++ b/src/module/helpers.ts
@@ -405,7 +405,7 @@ export class Helpers {
         fromUnit = fromUnit.toLowerCase();
 
         if (!Object.hasOwn(LENGTH_UNIT_TO_METERS_MULTIPLIERS, fromUnit)) {
-            console.error(`Distance can't be converted from ${fromUnit} to ${LENGTH_UNIT}`);
+            console.debug(`Shadowrun 5e | Distance can't be converted from ${fromUnit} to ${LENGTH_UNIT}. If empty, the scene unit configuration is missing.`);
             return 0;
         }
 


### PR DESCRIPTION
Fixes #1679

Caused by scene configuration field 'unit' holding no or an unsupported input. It is correctly defaulted to zero but not really an error.