### PR TITLE
[BUG] Improve handling of chummer exports containing multiple same elements

### DIFF
--- a/src/module/apps/itemImport/parser/Parser.ts
+++ b/src/module/apps/itemImport/parser/Parser.ts
@@ -4,6 +4,7 @@ import { DataImporter } from "../importer/DataImporter";
 import { Sanitizer } from "@/module/sanitizer/Sanitizer";
 import { BonusHelper as BH } from "../helper/BonusHelper";
 import * as IconAssign from "../../iconAssigner/iconAssign";
+import { ImportHelper as IH } from "../helper/ImportHelper";
 import { TechnologyType } from "src/module/types/template/Technology";
 import { DataDefaults, SystemConstructorArgs, SystemEntityType } from "src/module/data/DataDefaults";
 
@@ -43,7 +44,7 @@ export abstract class Parser<SubType extends SystemEntityType> {
 
         const entity = {
             img: undefined as string | undefined | null,
-            name: jsonData.translate?._TEXT ?? jsonData.name._TEXT,
+            name: IH.getArray(jsonData.translate)[0]?._TEXT ?? jsonData.name._TEXT,
             type: this.parseType as any,
             system: this.getSanitizedSystem(jsonData),
             folder: (await this.getFolder(jsonData, compendiumKey)).id,
@@ -64,7 +65,7 @@ export abstract class Parser<SubType extends SystemEntityType> {
             bonusPromise = BH.addBonus(entity as any, jsonData.bonus);
 
         if (jsonData.page && jsonData.source) {
-            const page = jsonData.altpage?._TEXT ?? jsonData.page._TEXT;
+            const page = IH.getArray(jsonData.altpage)[0]?._TEXT ?? jsonData.page._TEXT;
             const source = jsonData.source._TEXT;
             system.description.source = `${source} ${page}`;
         }

--- a/src/module/apps/itemImport/schema/ActionsSchema.ts
+++ b/src/module/apps/itemImport/schema/ActionsSchema.ts
@@ -27,8 +27,9 @@ export interface Action {
         limit?: { _TEXT: string; };
     };
     type: { _TEXT: "Complex" | "Extended" | "Free" | "Interrupt" | "No" | "Simple"; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface ActionsSchema {

--- a/src/module/apps/itemImport/schema/ArmorSchema.ts
+++ b/src/module/apps/itemImport/schema/ArmorSchema.ts
@@ -50,8 +50,9 @@ export interface Armor {
             name: { _TEXT: "Survival"; };
         };
     };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface Mod {
@@ -77,8 +78,9 @@ export interface Mod {
             value: { _TEXT: IntegerString; };
         };
     };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface ArmorSchema {

--- a/src/module/apps/itemImport/schema/BiowareSchema.ts
+++ b/src/module/apps/itemImport/schema/BiowareSchema.ts
@@ -2,7 +2,7 @@
 
 import { BonusSchema } from './BonusSchema';
 import { ConditionsSchema } from './ConditionsSchema';
-import { Empty, Many, IntegerString } from './Types';
+import { Empty, Many, OneOrMany, IntegerString } from './Types';
 
 export interface Bioware {
     addtoparentess?: Empty;
@@ -49,8 +49,9 @@ export interface Bioware {
     requireparent?: Empty;
     selectside?: Empty;
     source?: { _TEXT: IntegerString | "CF" | "DTR" | "HT" | "KC" | "NF" | "SR5"; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface Grade {
@@ -62,8 +63,9 @@ export interface Grade {
     name: { _TEXT: string; };
     page?: { _TEXT: IntegerString; };
     source?: { _TEXT: "CF" | "SG" | "SR5"; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface BiowareSchema {

--- a/src/module/apps/itemImport/schema/ComplexformsSchema.ts
+++ b/src/module/apps/itemImport/schema/ComplexformsSchema.ts
@@ -2,7 +2,7 @@
 
 import { BonusSchema } from './BonusSchema';
 import { ConditionsSchema } from './ConditionsSchema';
-import { Many, IntegerString } from './Types';
+import { Empty, Many, OneOrMany, IntegerString } from './Types';
 
 export interface Complexform {
     bonus?: BonusSchema;
@@ -14,8 +14,9 @@ export interface Complexform {
     required?: ConditionsSchema;
     source?: { _TEXT: "CF" | "DT" | "KC" | "SR5"; };
     target: { _TEXT: "Cyberware" | "Device" | "File" | "Host" | "IC" | "Icon" | "Persona" | "Self" | "Sprite"; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface ComplexformsSchema {

--- a/src/module/apps/itemImport/schema/CritterpowersSchema.ts
+++ b/src/module/apps/itemImport/schema/CritterpowersSchema.ts
@@ -2,7 +2,7 @@
 
 import { BonusSchema } from './BonusSchema';
 import { ConditionsSchema } from './ConditionsSchema';
-import { Empty, Many, IntegerString } from './Types';
+import { Empty, Many, OneOrMany, IntegerString } from './Types';
 
 export interface Power {
     action: Empty | { _TEXT: "As ritual" | "Auto" | "Complex" | "Free" | "None" | "Simple" | "Special"; };
@@ -22,8 +22,9 @@ export interface Power {
     source?: { _TEXT: "AET" | "DTR" | "FA" | "HS" | "KC" | "RF" | "SG" | "SR5"; };
     toxic?: { _TEXT: "True"; };
     type: Empty | { _TEXT: string; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface CritterpowersSchema {

--- a/src/module/apps/itemImport/schema/CyberwareSchema.ts
+++ b/src/module/apps/itemImport/schema/CyberwareSchema.ts
@@ -149,8 +149,9 @@ export interface Cyberware {
         $: { includeself: "False"; };
         name: { _TEXT: "Reaction Enhancers" | "Wired Reflexes"; };
     };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface Grade {
@@ -163,8 +164,9 @@ export interface Grade {
     name: { _TEXT: string; };
     page?: { _TEXT: IntegerString; };
     source?: { _TEXT: "BTB" | "CF" | "SG" | "SR5"; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface CyberwareSchema {

--- a/src/module/apps/itemImport/schema/EchoesSchema.ts
+++ b/src/module/apps/itemImport/schema/EchoesSchema.ts
@@ -1,7 +1,7 @@
 // AUTO‑GENERATED — DO NOT EDIT - Check utils/generate_schemas.py for more info
 
 import { BonusSchema } from './BonusSchema';
-import { Empty, Many, IntegerString } from './Types';
+import { Empty, Many, OneOrMany, IntegerString } from './Types';
 
 export interface Echo {
     bonus?: BonusSchema;
@@ -11,8 +11,9 @@ export interface Echo {
     name: { _TEXT: string; };
     page?: { _TEXT: IntegerString; };
     source?: { _TEXT: "DT" | "DTD" | "DTR" | "KC" | "SR5"; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface EchoesSchema {

--- a/src/module/apps/itemImport/schema/GearSchema.ts
+++ b/src/module/apps/itemImport/schema/GearSchema.ts
@@ -79,8 +79,9 @@ export interface Gear {
         userange?: { _TEXT: "Holdouts" | "Light Pistols"; };
     };
     weight?: { _TEXT: IntegerString | "Rating"; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface GearSchema {

--- a/src/module/apps/itemImport/schema/MetatypeSchema.ts
+++ b/src/module/apps/itemImport/schema/MetatypeSchema.ts
@@ -100,8 +100,9 @@ export interface Metatype {
     wilaug: { _TEXT: IntegerString | "F" | "F+1" | "F+2" | "F+4" | "F-1" | "F-2"; };
     wilmax: { _TEXT: IntegerString | "F" | "F+1" | "F+2" | "F+4" | "F-1" | "F-2"; };
     wilmin: { _TEXT: IntegerString | "F" | "F+1" | "F+2" | "F+4" | "F-1" | "F-2"; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface MetatypeSchema {

--- a/src/module/apps/itemImport/schema/PowersSchema.ts
+++ b/src/module/apps/itemImport/schema/PowersSchema.ts
@@ -2,7 +2,7 @@
 
 import { BonusSchema } from './BonusSchema';
 import { ConditionsSchema } from './ConditionsSchema';
-import { Empty, Many, IntegerString } from './Types';
+import { Empty, Many, OneOrMany, IntegerString } from './Types';
 
 export interface Enhancement {
     bonus?: BonusSchema;
@@ -12,8 +12,9 @@ export interface Enhancement {
     power: Empty | { _TEXT: string; };
     required: ConditionsSchema;
     source?: { _TEXT: "SG"; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface Power {
@@ -40,8 +41,9 @@ export interface Power {
     points: { _TEXT: IntegerString; };
     required?: ConditionsSchema;
     source?: { _TEXT: "BB" | "BLB" | "BTB" | "CA" | "FA" | "HT" | "SG" | "SGE" | "SR5" | "SS" | "SSP"; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface PowersSchema {

--- a/src/module/apps/itemImport/schema/QualitiesSchema.ts
+++ b/src/module/apps/itemImport/schema/QualitiesSchema.ts
@@ -56,16 +56,18 @@ export interface Quality {
     required?: ConditionsSchema;
     source?: { _TEXT: string; };
     stagedpurchase?: { _TEXT: "True"; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface Query {
     display: { _TEXT: string; };
     id: { _TEXT: string; };
     xpath: { _TEXT: string; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface QualitiesSchema {

--- a/src/module/apps/itemImport/schema/SpellsSchema.ts
+++ b/src/module/apps/itemImport/schema/SpellsSchema.ts
@@ -2,7 +2,7 @@
 
 import { BonusSchema } from './BonusSchema';
 import { ConditionsSchema } from './ConditionsSchema';
-import { Empty, Many, IntegerString } from './Types';
+import { Empty, Many, OneOrMany, IntegerString } from './Types';
 
 export interface Spell {
     bonus?: BonusSchema;
@@ -19,8 +19,9 @@ export interface Spell {
     source?: { _TEXT: "BB" | "BTB" | "CA" | "FA" | "HT" | "PGG" | "SFCR" | "SG" | "SR5" | "SS" | "SSP"; };
     type: { _TEXT: "M" | "P"; };
     useskill?: { _TEXT: "Animal Handling"; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface SpellsSchema {

--- a/src/module/apps/itemImport/schema/VehiclesSchema.ts
+++ b/src/module/apps/itemImport/schema/VehiclesSchema.ts
@@ -31,8 +31,9 @@ export interface Mod {
         subsystem: Many<{ _TEXT: string; }>;
     };
     weaponmountcategories?: { _TEXT: string; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface Vehicle {
@@ -111,8 +112,9 @@ export interface Vehicle {
             name: { _TEXT: string; };
         }>;
     };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface Weaponmount {
@@ -130,8 +132,9 @@ export interface Weaponmount {
     source?: { _TEXT: "R5" | "SR5"; };
     weaponcategories?: { _TEXT: string; };
     weaponfilter?: { _TEXT: "((type != \"Melee\") or (type = \"Melee\" and reach = \"0\"))"; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface VehiclesSchema {

--- a/src/module/apps/itemImport/schema/WeaponsSchema.ts
+++ b/src/module/apps/itemImport/schema/WeaponsSchema.ts
@@ -46,8 +46,9 @@ export interface Accessory {
     required?: ConditionsSchema;
     source?: { _TEXT: IntegerString | "BTB" | "CF" | "GH3" | "HT" | "KK" | "RG" | "SAG" | "SL" | "SLG2" | "SOTG" | "SR5"; };
     specialmodification?: { _TEXT: "True"; };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface Weapon {
@@ -118,8 +119,9 @@ export interface Weapon {
     wirelessweaponbonus?: {
         accuracy: { _TEXT: IntegerString; };
     };
-    translate?: { _TEXT: string; };
-    altpage?: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    altpage?: OneOrMany<{ _TEXT: string; }>;
+    altnameonpage?: OneOrMany<Empty>;
 };
 
 export interface WeaponsSchema {

--- a/utils/generate_schemas.py
+++ b/utils/generate_schemas.py
@@ -383,8 +383,9 @@ def build_type(
 
     # Optional translation fields
     if depth == 2 and addTranslate:
-        props.append(f"{ind}{ts_key('translate')}?: {{ _TEXT: string; }};")
-        props.append(f"{ind}{ts_key('altpage')}?: {{ _TEXT: string; }};")
+        props.append(f"{ind}{ts_key('translate')}?: OneOrMany<{{ _TEXT: string; }}>;")
+        props.append(f"{ind}{ts_key('altpage')}?: OneOrMany<{{ _TEXT: string; }}>;")
+        props.append(f"{ind}{ts_key('altnameonpage')}?: OneOrMany<Empty>;")
 
     if depth == 1:
         body = "{\n        " + f"\n        ".join(props) + "\n    }"
@@ -454,7 +455,7 @@ def generate_header(imports: list[str] = [], body_content: str = "") -> str:
         lines.append(f"import {{ {imp} }} from './{imp}';")
 
     types_to_check = ["Empty", "Many", "OneOrMany", "IntegerString"]
-    used_types = [t for t in types_to_check if t in body_content]
+    used_types = [t for t in types_to_check if re.search(rf"\b{t}\b", body_content)]
     if used_types:
         lines.append(f"import {{ {', '.join(used_types)} }} from './Types';")
 


### PR DESCRIPTION
Under some circumstances, `translate`, `altpage` and `altnameonpage` tags are duplicated.
To see more info see [Discord Message](https://discord.com/channels/365227581018079232/365227867535310858/1444710667516117133).
Whether this is a bug or not, there is a simple way for us to go around it.