### PR TITLE
[BUG] The skill search filter does not work in Korean and for German umlaute

### DIFF
--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -1514,7 +1514,7 @@ export class SR5BaseActorSheet<T extends SR5ActorSheetData = SR5ActorSheetData> 
      * @param key search string fall back if skill is not provided.
      * @param skill skill to be searched through
      * @param text text to search for, can be an empty string.
-     * @returns true, if skill contains
+     * @returns true, if skill contains search text
      */
     _doesSkillContainText(key: string, skill: SkillFieldType, text: string) {
         if (!text) {


### PR DESCRIPTION
Fixes #1751

The issue was related with how Foundry does normalization of filter strings passed through their SearchFilter class.

As it applied normalization (NFD) and replaces German umlauts, we have to apply the same handling to all textx before search, as the two fortmats otherwise will not compare.