### PR TITLE
[BUG] Wound modifiers mistakenly shown on too many actor types and not altered by wound tolerance modifier

### DIFF
--- a/src/templates/v2/actor/header.hbs
+++ b/src/templates/v2/actor/header.hbs
@@ -32,6 +32,7 @@
         {{else if (not isLimited)}}
             <div>
 
+                {{!-- Some actors only have matrix tracks --}}
                 {{#if (or isIC isSprite)}}
                     {{> 'systems/shadowrun5e/dist/templates/v2/actor/parts/condition-monitor.hbs'
                         id='matrix'
@@ -39,12 +40,27 @@
                         tooltip=(localize "SR5.Labels.ActorSheet.Matrix")
                     }}
                 {{/if}}
-                {{#if (or isCharacter isSpirit)}}
+                {{!-- Characters are special as in they should display wound modifiers --}}
+                {{#if isCharacter}}
                     {{> 'systems/shadowrun5e/dist/templates/v2/actor/parts/condition-monitor.hbs'
                         id='stun'
                         track=system.track.stun
                         tooltip=(localize "SR5.Labels.ActorSheet.StunTrack")
-                        woundTolerance=woundTolerance
+                        tolerance=woundTolerance
+                    }}
+                    {{> 'systems/shadowrun5e/dist/templates/v2/actor/parts/condition-monitor.hbs'
+                        id='physical'
+                        track=system.track.physical
+                        tooltip=(localize "SR5.Labels.ActorSheet.PhysicalTrack")
+                        tolerance=woundTolerance
+                    }}
+                {{else}}
+                {{!-- Other actor types only need some tracks, not both, and no wound modifiers --}}
+                {{#if isSpirit}}
+                    {{> 'systems/shadowrun5e/dist/templates/v2/actor/parts/condition-monitor.hbs'
+                        id='stun'
+                        track=system.track.stun
+                        tooltip=(localize "SR5.Labels.ActorSheet.StunTrack")
                     }}
                 {{/if}}
                 {{#unless (or isIC isSprite)}}
@@ -54,6 +70,7 @@
                         tooltip=(localize "SR5.Labels.ActorSheet.PhysicalTrack")
                     }}
                 {{/unless}}
+                {{/if}}
 
             </div>
         {{/if}}

--- a/src/templates/v2/actor/parts/condition-monitor.hbs
+++ b/src/templates/v2/actor/parts/condition-monitor.hbs
@@ -3,7 +3,7 @@
         value=track.value
         max=track.max
         id=id
-        tolerance=woundTolerance
+        tolerance=tolerance
         toleranceBase=track.pain_tolerance
         disabled=track.disabled
 }}


### PR DESCRIPTION
Fixes #1739

Wound tolerance was set to a fixed value of three instead of the calculated woundTolerance modifier given sheet context.