### PR TITLE
[BUG] Matrix actions 'Matrix Defense Test' and 'Matrix Damage Resist' show up as matrix actions

### DIFF
--- a/src/module/actor/sheets/SR5MatrixActorSheet.ts
+++ b/src/module/actor/sheets/SR5MatrixActorSheet.ts
@@ -383,9 +383,7 @@ export class SR5MatrixActorSheet<T extends MatrixActorSheetData = MatrixActorShe
      * @protected
      */
     protected async _getMatrixPackActions() {
-        const matrixPackName = PackActionFlow.getMatrixActionsPackName();
-        // Collect all sources for matrix actions.
-        return await PackActionFlow.getPackActions(matrixPackName);
+        return await PackActionFlow.getMatrixPackActions();
     }
 
     /**

--- a/src/module/actor/sheets/SR5VehicleActorSheet.ts
+++ b/src/module/actor/sheets/SR5VehicleActorSheet.ts
@@ -79,10 +79,8 @@ export class SR5VehicleActorSheet extends SR5MatrixActorSheet<VehicleSheetDataFi
     }
 
     protected override async _getMatrixPackActions() {
-        const matrixPackName = PackActionFlow.getMatrixActionsPackName();
-
         // filter out illegal actions from the matrix actions
-        return (await PackActionFlow.getPackActions(matrixPackName)).filter((action) => {
+        return (await PackActionFlow.getMatrixPackActions()).filter((action) => {
             return !MatrixRules.isIllegalAction(
                         action.getAction()?.attribute as any,
                         action.getAction()?.attribute2 as any,

--- a/src/module/item/flows/PackActionFlow.ts
+++ b/src/module/item/flows/PackActionFlow.ts
@@ -168,6 +168,17 @@ export const PackActionFlow = {
         }
         return actions.filter((action: SR5Item) => action.hasActionCategory('matrix'));
     },
+
+    /**
+     * Retrieve matrix actions from the configured matrix actions pack.
+     *
+     * Only actions with the matrix category are returned to avoid showing unrelated actions.
+     */
+    async getMatrixPackActions(): Promise<SR5Item<'action'>[]> {
+        const matrixPackName = this.getMatrixActionsPackName();
+        const packActions = await this.getPackActions(matrixPackName);
+        return packActions.filter(action => action.hasActionCategory('matrix'));
+    },
     
     /**
      * Collect all matrix actions of an actor.
@@ -176,9 +187,7 @@ export const PackActionFlow = {
      * @returns Combined list of pack and actor matrix actions.
      */
     async getActorMatrixActions(actor: SR5Actor) {
-        const matrixPackName = this.getMatrixActionsPackName();
-        // Collect all sources for matrix actions.
-        const packActions = await this.getPackActions(matrixPackName);
+        const packActions = await this.getMatrixPackActions();
         const actorActions = this.getMatrixActions(actor);
         return [...packActions, ...actorActions];
     },


### PR DESCRIPTION
Fixes #1750

Included action category 'matrix' filter for pack actions as well.