### PR TITLE
[BUG] Wrongly assigning agility in chummer importer

### DIFF
--- a/public/locale/de/config.json
+++ b/public/locale/de/config.json
@@ -3196,6 +3196,7 @@
                     "AssaultCannon": "Sturmkanone",
                     "AssaultRifle": "Sturmgewehr",
                     "Bow": "Bogen",
+                    "Carbine": "Karabiner",
                     "Flamethrower": "Flammenwerfer",
                     "GrenadeLauncher": "Granatwerfer",
                     "HarpoonGun": "Harpunengewehr",
@@ -3218,6 +3219,7 @@
                     "Shuriken": "Shuriken",
                     "SniperRifle": "Scharfschützengewehr",
                     "SportingRifle": "Sportgewehr",
+                    "SprayPen": "Sprühstift",
                     "StandardThrownGrenade": "Standard-Granate",
                     "Taser": "Taser",
                     "ThrownKnife": "Wurfmesser"

--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -3150,6 +3150,7 @@
                     "AssaultCannon": "Assault Cannon",
                     "AssaultRifle": "Assault Rifle",
                     "Bow": "Bow",
+                    "Carbine": "Carbine",
                     "Flamethrower": "Flamethrower",
                     "GrenadeLauncher": "Grenade Launcher",
                     "HarpoonGun": "Harpoon Gun",
@@ -3172,6 +3173,7 @@
                     "Shuriken": "Shuriken",
                     "SniperRifle": "Sniper Rifle",
                     "SportingRifle": "Sporting Rifle",
+                    "SprayPen": "Spray Pen",
                     "StandardThrownGrenade": "Standard Grenade",
                     "Taser": "Taser",
                     "ThrownKnife": "Thrown Knife"

--- a/public/locale/ko/config.json
+++ b/public/locale/ko/config.json
@@ -3008,6 +3008,7 @@
                     "AssaultCannon": "돌격용 기관포",
                     "AssaultRifle": "돌격용 소총",
                     "Bow": "활",
+                    "Carbine": "카빈",
                     "Flamethrower": "화염방사기",
                     "GrenadeLauncher": "유탄 발사기",
                     "HarpoonGun": "작살총",
@@ -3030,6 +3031,7 @@
                     "Shuriken": "표창",
                     "SniperRifle": "저격총",
                     "SportingRifle": "스포츠용 소총",
+                    "SprayPen": "스프레이 펜",
                     "StandardThrownGrenade": "표준형 수류탄",
                     "Taser": "테이저",
                     "ThrownKnife": "투척용 나이프"

--- a/public/locale/pt-BR/config.json
+++ b/public/locale/pt-BR/config.json
@@ -1579,6 +1579,7 @@
                     "AssaultCannon": "Canhão de Assalto",
                     "AssaultRifle": "Fuzil de Assalto",
                     "Bow": "Arco",
+                    "Carbine": "Carabina",
                     "Flamethrower": "Lança-chamas",
                     "GrenadeLauncher": "Lançador de Granadas",
                     "HarpoonGun": "Arpão",
@@ -1601,6 +1602,7 @@
                     "Shuriken": "Shuriken",
                     "SniperRifle": "Fuzil de Precisão",
                     "SportingRifle": "Fuzil Esportivo",
+                    "SprayPen": "Caneta Spray",
                     "StandardThrownGrenade": "Granada Padrão",
                     "Taser": "Taser",
                     "ThrownKnife": "Faca de Arremesso"

--- a/src/module/apps/itemImport/importer/Constants.ts
+++ b/src/module/apps/itemImport/importer/Constants.ts
@@ -100,7 +100,7 @@ export class Constants {
         'Unarmed': 'unarmed_combat',
     } as const;
 
-    public static readonly MAP_IMPORT_RANGE_CATEGORY_TO_SYSTEM_RANGE_CATEGORY = {
+    public static readonly RANGE_CATEGORY_MAP = {
         'Tasers': 'taser',
         'Holdouts': 'holdOutPistol',
         'Light Pistols': 'lightPistol',
@@ -130,6 +130,8 @@ export class Constants {
         'Harpoon Gun': 'harpoonGun',
         'Harpoon Gun (Underwater)': 'harpoonGunUnderwater',
         'Flamethrowers': 'flamethrower',
+        'Spray Pen': 'sprayPen',
+        'Carbines': 'carbine',
     } as const satisfies Record<string, Exclude<keyof typeof SR5.weaponRangeCategories, "manual">> ;
 
     public static readonly attributeTable = {

--- a/src/module/apps/itemImport/importer/WeaponImporter.ts
+++ b/src/module/apps/itemImport/importer/WeaponImporter.ts
@@ -17,7 +17,7 @@ export class WeaponImporter extends DataImporter {
         private readonly thrownParser = new ThrownParser();
 
         public async Parse(jsonData: Weapon, compendiumKey: CompendiumKey): Promise<Item.CreateData> {
-            const category = WeaponParserBase.GetWeaponType(jsonData);
+            const category = WeaponParserBase.getWeaponType(jsonData);
             const selectedParser = category === 'range' ? this.rangedParser
                                  : category === 'melee' ? this.meleeParser
                                                         : this.thrownParser;

--- a/src/module/apps/itemImport/parser/weapon/RangedParser.ts
+++ b/src/module/apps/itemImport/parser/weapon/RangedParser.ts
@@ -1,7 +1,5 @@
-import { ImportHelper } from '../../helper/ImportHelper';
-import { WeaponParserBase } from './WeaponParserBase';
-import { DataDefaults } from '../../../../data/DataDefaults';
 import { Weapon } from '../../schema/WeaponsSchema';
+import { WeaponParserBase } from './WeaponParserBase';
 
 export class RangedParser extends WeaponParserBase {
     protected GetAmmo(weaponJson: Weapon) {
@@ -18,7 +16,7 @@ export class RangedParser extends WeaponParserBase {
         system.range.rc.value = Number(jsonData?.rc?._TEXT) || 0;
 
         const rangeCategory = jsonData.range?._TEXT || jsonData.category._TEXT;
-        system.range.ranges = DataDefaults.createData('range', this.GetRangeDataFromImportedCategory(rangeCategory));
+        system.range.ranges = this.getRangeData(rangeCategory);
 
         system.ammo.current.value = this.GetAmmo(jsonData);
         system.ammo.current.max = this.GetAmmo(jsonData);

--- a/src/module/apps/itemImport/parser/weapon/ThrownParser.ts
+++ b/src/module/apps/itemImport/parser/weapon/ThrownParser.ts
@@ -2,7 +2,6 @@ import { SystemType } from '../Parser';
 import { Weapon } from '../../schema/WeaponsSchema';
 import { WeaponParserBase } from './WeaponParserBase';
 import { BlastType } from 'src/module/types/item/Weapon';
-import { DataDefaults } from '../../../../data/DataDefaults';
 
 export class ThrownParser extends WeaponParserBase {
     public GetBlast(system: SystemType<'weapon'>, jsonData: Weapon): BlastType {
@@ -34,7 +33,7 @@ export class ThrownParser extends WeaponParserBase {
         const system = super.getSystem(jsonData);
 
         const rangeCategory = jsonData.range?._TEXT || jsonData.category._TEXT;
-        system.thrown.ranges = DataDefaults.createData('range', this.GetRangeDataFromImportedCategory(rangeCategory));
+        system.thrown.ranges = this.getRangeData(rangeCategory);
 
         system.thrown.blast = this.GetBlast(system, jsonData);
 

--- a/src/module/apps/itemImport/parser/weapon/WeaponParserBase.ts
+++ b/src/module/apps/itemImport/parser/weapon/WeaponParserBase.ts
@@ -45,7 +45,7 @@ export class WeaponParserBase extends Parser<'weapon'> {
         return result;
     }
 
-    private GetSkill(weaponJson: Weapon): string {
+    private getSkill(weaponJson: Weapon): string {
         if (weaponJson.useskill?._TEXT) {
             const jsonSkill = weaponJson.useskill._TEXT;
             if (Constants.MAP_CATEGORY_TO_SKILL[jsonSkill])
@@ -62,7 +62,7 @@ export class WeaponParserBase extends Parser<'weapon'> {
         }
     }
 
-    public static GetWeaponType(weaponJson: Weapon): SystemType<'weapon'>['category'] {
+    public static getWeaponType(weaponJson: Weapon): SystemType<'weapon'>['category'] {
         const type = weaponJson.type._TEXT;
         //melee is the least specific, all melee entries are accurate
         if (type === 'Melee') {
@@ -85,11 +85,11 @@ export class WeaponParserBase extends Parser<'weapon'> {
 
         const category = jsonData.category._TEXT;
 
-        system.category = WeaponParserBase.GetWeaponType(jsonData);
+        system.category = WeaponParserBase.getWeaponType(jsonData);
         system.subcategory = category.toLowerCase();
 
-        system.action.skill = this.GetSkill(jsonData);
-        system.action.damage = this.GetDamage(jsonData as any);
+        system.action.skill = this.getSkill(jsonData);
+        system.action.damage = this.getDamage(jsonData as any);
 
         if (jsonData.accuracy?._TEXT) {
             let accuracy: string = jsonData.accuracy._TEXT;
@@ -106,7 +106,7 @@ export class WeaponParserBase extends Parser<'weapon'> {
         return system;
     }
     
-    protected GetDamage(jsonData: Weapon): DamageType {
+    protected getDamage(jsonData: Weapon): DamageType {
         const jsonDamage = jsonData.damage._TEXT;
         // ex. 15S(e)
         const simpleDamage = /^([0-9]+)([PSM])? ?(\([a-zA-Z]+\))?/g.exec(jsonDamage);
@@ -198,7 +198,7 @@ export class WeaponParserBase extends Parser<'weapon'> {
 
     protected override async getFolder(jsonData: Weapon, compendiumKey: CompendiumKey): Promise<Folder> {
         const categoryData = jsonData.category._TEXT;
-        const root = WeaponParserBase.GetWeaponType(jsonData).capitalize() ?? "Other";
+        const root = WeaponParserBase.getWeaponType(jsonData).capitalize() ?? "Other";
         const folderName = IH.getTranslatedCategory('weapons', categoryData);
 
         return IH.getFolder(compendiumKey, root, root === 'Thrown' ? undefined : folderName);

--- a/src/module/apps/itemImport/parser/weapon/WeaponParserBase.ts
+++ b/src/module/apps/itemImport/parser/weapon/WeaponParserBase.ts
@@ -174,15 +174,18 @@ export class WeaponParserBase extends Parser<'weapon'> {
         }
     }
 
-    protected GetRangeDataFromImportedCategory(category: string): RangeType|undefined {
-        const systemRangeCategory: Exclude<keyof typeof SR5.weaponRangeCategories, "manual"> | undefined = Constants.MAP_IMPORT_RANGE_CATEGORY_TO_SYSTEM_RANGE_CATEGORY[category];
-        if(!systemRangeCategory) return;
+    protected getRangeData(category: string): RangeType {
+        if (!(category in Constants.RANGE_CATEGORY_MAP))
+            return DataDefaults.createData("range");
 
-        return {
-            ...SR5.weaponRangeCategories[systemRangeCategory].ranges,
-            category: systemRangeCategory,
-            attribute: 'agility',
-        };
+        const mappedCategory = Constants.RANGE_CATEGORY_MAP[
+            category as keyof typeof Constants.RANGE_CATEGORY_MAP
+        ];
+
+        return DataDefaults.createData("range", {
+            ...SR5.weaponRangeCategories[mappedCategory].ranges,
+            category: mappedCategory,
+        });
     }
 
     protected override setImporterFlags(entity: Item.CreateData, jsonData: Weapon): void {

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -380,6 +380,24 @@ export const SR5 = {
                 long: -1,
                 extreme: -1,
             },
+        },
+        sprayPen: {
+            label: 'SR5.Weapon.Range.Category.SprayPen',
+            ranges: {
+                short: 2,
+                medium: -1,
+                long: -1,
+                extreme: -1,
+            },
+        },
+        carbine: {
+            label: 'SR5.Weapon.Range.Category.Carbine',
+            ranges: {
+                short: 10,
+                medium: 40,
+                long: 80,
+                extreme: 150,
+            },
         }
 
     },

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -568,13 +568,12 @@ export class SR5ItemSheet<T extends SR5BaseItemSheetData = SR5ItemSheetData> ext
                 },
             });
         } else {
-            type RangesType = Omit<RangeType, 'category' | 'attribute'> & { attribute?: string };
-            const ranges: RangesType = SR5.weaponRangeCategories[selectedRangeCategory].ranges;
+            const ranges = SR5.weaponRangeCategories[selectedRangeCategory].ranges;
 
             await this.item.update({
                 [key]: {
                     ...ranges,
-                    attribute: ranges.attribute || null,
+                    attribute: 'attribute' in ranges ? ranges.attribute : '',
                     category: selectedRangeCategory,
                 },
             });

--- a/src/module/migrator/versions/Version0_33_0.ts
+++ b/src/module/migrator/versions/Version0_33_0.ts
@@ -101,7 +101,7 @@ export class Version0_33_0 extends VersionMigration {
         ] as const;
 
         for (const ranges of rangeTargets) {
-            if (!ranges) continue;
+            if (!ranges || ranges.category === 'manual') continue;
             ranges.attribute = strengthSet.has(ranges.category) ? "strength" : "";
         }
     }

--- a/src/module/migrator/versions/Version0_33_0.ts
+++ b/src/module/migrator/versions/Version0_33_0.ts
@@ -2,6 +2,7 @@ import { SR5 } from '@/module/config';
 import { DataDefaults } from '@/module/data/DataDefaults';
 import { SYSTEM_NAME } from '@/module/constants';
 import { VersionMigration } from "../VersionMigration";
+import { SR5Item } from '@/module/item/SR5Item';
 
 
 type LegacySkillCategory = 'active' | 'language' | 'knowledge';
@@ -70,6 +71,28 @@ export class Version0_33_0 extends VersionMigration {
                 change.mode = CONST.ACTIVE_EFFECT_MODES.ADD;
     }
 
+    override handlesItem(item: Readonly<any>): boolean {
+        return item.type === 'weapon'
+            && item.system?.range?.ranges
+            && item.system.range.ranges.category !== 'manual'
+            && item.system.range.ranges.attribute === 'agility';
+    }
+
+    override migrateItem(item: any): void {
+        const strengthSet = new Set([
+            "thrownKnife",
+            "net",
+            "shuriken",
+            "standardThrownGrenade",
+            "aerodynamicThrownGrenade",
+            "bow"
+        ] as const);
+
+        const category = item.system.range.ranges.category;
+        const attribute = strengthSet.has(category) ? "strength" : "";
+
+        item.system.range.ranges.attribute = attribute;
+    }
 
     /**
      * Only migrate if an actor actually has skills.

--- a/src/module/migrator/versions/Version0_33_0.ts
+++ b/src/module/migrator/versions/Version0_33_0.ts
@@ -1,8 +1,7 @@
 import { SR5 } from '@/module/config';
-import { DataDefaults } from '@/module/data/DataDefaults';
 import { SYSTEM_NAME } from '@/module/constants';
 import { VersionMigration } from "../VersionMigration";
-import { SR5Item } from '@/module/item/SR5Item';
+import { DataDefaults } from '@/module/data/DataDefaults';
 
 
 type LegacySkillCategory = 'active' | 'language' | 'knowledge';
@@ -72,10 +71,18 @@ export class Version0_33_0 extends VersionMigration {
     }
 
     override handlesItem(item: Readonly<any>): boolean {
-        return item.type === 'weapon'
-            && item.system?.range?.ranges
-            && item.system.range.ranges.category !== 'manual'
-            && item.system.range.ranges.attribute === 'agility';
+        if (item.type !== 'weapon') return false;
+
+        const rangeTargets = [
+            item.system?.range?.ranges,
+            item.system?.thrown?.ranges
+        ] as const;
+
+        return rangeTargets.some(ranges => 
+            ranges 
+            && ranges.category !== 'manual' 
+            && ranges.attribute === 'agility'
+        );
     }
 
     override migrateItem(item: any): void {
@@ -88,10 +95,15 @@ export class Version0_33_0 extends VersionMigration {
             "bow"
         ] as const);
 
-        const category = item.system.range.ranges.category;
-        const attribute = strengthSet.has(category) ? "strength" : "";
+        const rangeTargets = [
+            item.system?.range?.ranges,
+            item.system?.thrown?.ranges
+        ] as const;
 
-        item.system.range.ranges.attribute = attribute;
+        for (const ranges of rangeTargets) {
+            if (!ranges) continue;
+            ranges.attribute = strengthSet.has(ranges.category) ? "strength" : "";
+        }
     }
 
     /**

--- a/src/unittests/sr5.WeaponParser.spec.ts
+++ b/src/unittests/sr5.WeaponParser.spec.ts
@@ -5,8 +5,8 @@ import { Weapon } from '../module/apps/itemImport/schema/WeaponsSchema';
 import { WeaponParserBase } from '../module/apps/itemImport/parser/weapon/WeaponParserBase';
 
 class TestWeaponParser extends WeaponParserBase {
-    public override GetDamage(jsonData: Weapon): DamageType {
-        return super.GetDamage(jsonData);
+    public override getDamage(jsonData: Weapon): DamageType {
+        return super.getDamage(jsonData);
     }
 }
 
@@ -29,7 +29,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
 
     describe("Weapon Damage Values", () => {
         it("Parses simple damage", () => {
-            const output = mut.GetDamage(getData("12P") as Weapon);
+            const output = mut.getDamage(getData("12P") as Weapon);
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 12,
                 value: 12,
@@ -41,7 +41,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
 
         it("Parses elemental damage", () => {
-            const output = mut.GetDamage(getData("8S(e)") as Weapon);
+            const output = mut.getDamage(getData("8S(e)") as Weapon);
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 8,
                 value: 8,
@@ -57,7 +57,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
 
         it("Parses strength-based damage", () => {
-            const output = mut.GetDamage(getData("({STR}+3)P") as Weapon);
+            const output = mut.getDamage(getData("({STR}+3)P") as Weapon);
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 3,
                 value: 3,
@@ -70,7 +70,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
 
         it("Parses damage without type as physical", () => {
-            const output = mut.GetDamage(getData("11") as Weapon);
+            const output = mut.getDamage(getData("11") as Weapon);
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 11,
                 value: 11,
@@ -82,7 +82,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
 
         it("Parses 0 damage", () => {
-            const output = mut.GetDamage(getData("0") as Weapon);
+            const output = mut.getDamage(getData("0") as Weapon);
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 0,
                 value: 0,
@@ -94,7 +94,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
 
         it("Parses basic matrix damage", () => {
-            const output = mut.GetDamage(getData("7M") as Weapon);
+            const output = mut.getDamage(getData("7M") as Weapon);
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 7,
                 value: 7,
@@ -106,7 +106,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
 
         it("Parses strength-based damage without modifier", () => {
-            const output = mut.GetDamage(getData("({STR})P") as Weapon);
+            const output = mut.getDamage(getData("({STR})P") as Weapon);
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 0,
                 value: 0,


### PR DESCRIPTION
- Fixes importing all ranged/thrown weapons using the attribute multiplier with `agility`
- Added missing `Spray Pen` and `Carbine` range types