### PR TITLE
Fix sheet input focus restore on rerender and simplify selection handling

### DIFF
--- a/src/module/handlebars/SR5ApplicationMixin.ts
+++ b/src/module/handlebars/SR5ApplicationMixin.ts
@@ -113,6 +113,7 @@ export function SR5ApplicationMixin<BaseClass extends Identity<typeof AnyApplica
         }
 
         #captureFormFieldState(target: EventTarget | null) {
+            this.pendingFormFieldIndex = undefined;
             if (!this.#isTrackableFormField(target) || !this.element) return;
             if (!this.element.contains(target)) return;
             const index = this.#getFormFields().indexOf(target);
@@ -308,6 +309,7 @@ export function SR5ApplicationMixin<BaseClass extends Identity<typeof AnyApplica
         }
 
         protected override _configureRenderOptions(options: Parameters<BaseType["_configureRenderOptions"]>[0]) {
+            this.pendingFormFieldIndex = undefined;
             this.#captureFormFieldState(document.activeElement);
             super._configureRenderOptions(options);
             if (options.mode && this.isEditable) this._mode = options.mode;

--- a/src/module/handlebars/SR5ApplicationMixin.ts
+++ b/src/module/handlebars/SR5ApplicationMixin.ts
@@ -75,6 +75,15 @@ export function SR5ApplicationMixin<BaseClass extends Identity<typeof AnyApplica
         private editIcon?: HTMLElement;
         private wrenchIcon?: HTMLElement;
         private formFocusAbortController?: AbortController;
+
+        /**
+         * Rerender focus memory:
+         * Stores the index of the currently focused form field (input/textarea/select)
+         * right before a render caused by submitOnChange.
+         *
+         * We use a simple index instead of selector/caret state so unnamed fields
+         * (like list inputs) are still restorable across rerenders.
+         */
         private pendingFormFieldIndex?: number;
 
         static override DEFAULT_OPTIONS = {
@@ -112,6 +121,12 @@ export function SR5ApplicationMixin<BaseClass extends Identity<typeof AnyApplica
             );
         }
 
+        /**
+         * Capture the focused field before rerender.
+         *
+         * If focus is outside this application (or not a trackable field),
+         * the memory is cleared to avoid stale focus restoration.
+         */
         #captureFormFieldState(target: EventTarget | null) {
             this.pendingFormFieldIndex = undefined;
             if (!this.#isTrackableFormField(target) || !this.element) return;
@@ -127,6 +142,13 @@ export function SR5ApplicationMixin<BaseClass extends Identity<typeof AnyApplica
             } catch { /* Some input types may not support select(). Ignore safely. */ }
         }
 
+        /**
+         * Restore focus to the previously captured form field after rerender.
+         *
+         * Why immediate + requestAnimationFrame?
+         * - Immediate handles very fast typing right after Tab.
+         * - RAF handles post-render browser/foundry focus side-effects that can overwrite selection.
+         */
         #restoreFormFieldState() {
             const index = this.pendingFormFieldIndex;
             this.pendingFormFieldIndex = undefined;
@@ -149,6 +171,12 @@ export function SR5ApplicationMixin<BaseClass extends Identity<typeof AnyApplica
             requestAnimationFrame(focusAndSelect);
         }
 
+        /**
+         * Track field focus changes while the sheet is live.
+         *
+         * On `focusin`, we eagerly select text to prevent caret-at-start race conditions
+         * during quick tab-and-type interactions on rerendering forms.
+         */
         #bindFormFocusTracking() {
             if (!this.element) return;
 
@@ -310,6 +338,7 @@ export function SR5ApplicationMixin<BaseClass extends Identity<typeof AnyApplica
 
         protected override _configureRenderOptions(options: Parameters<BaseType["_configureRenderOptions"]>[0]) {
             this.pendingFormFieldIndex = undefined;
+            // Capture whichever field is currently active before render mutates the DOM.
             this.#captureFormFieldState(document.activeElement);
             super._configureRenderOptions(options);
             if (options.mode && this.isEditable) this._mode = options.mode;

--- a/src/module/handlebars/SR5ApplicationMixin.ts
+++ b/src/module/handlebars/SR5ApplicationMixin.ts
@@ -13,6 +13,7 @@ import HandlebarsApplicationMixin = foundry.applications.api.HandlebarsApplicati
 const { TextEditor, SearchFilter } = foundry.applications.ux;
 const { fromUuid } = foundry.utils;
 type SR5DragDropHandler = InstanceType<typeof foundry.applications.ux.DragDrop.implementation>;
+type TrackableField = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
 
 export namespace SR5ApplicationMixinTypes {
     export interface RenderContext extends ApplicationV2.RenderContext, HandlebarsApplicationMixin.RenderContext {
@@ -73,6 +74,8 @@ export function SR5ApplicationMixin<BaseClass extends Identity<typeof AnyApplica
         private readonly expandedUuids = new Set<string>();
         private editIcon?: HTMLElement;
         private wrenchIcon?: HTMLElement;
+        private formFocusAbortController?: AbortController;
+        private pendingFormFieldIndex?: number;
 
         static override DEFAULT_OPTIONS = {
             classes: [SR5_APPV2_CSS_CLASS] as string[],
@@ -96,6 +99,79 @@ export function SR5ApplicationMixin<BaseClass extends Identity<typeof AnyApplica
             super(...args);
             this.#filters = this.#createFilters();
             this.#dragDrop = this.#createDragDropHandlers();
+        }
+
+        #isTrackableFormField(t: EventTarget | null): t is TrackableField {
+            return t instanceof HTMLInputElement || t instanceof HTMLTextAreaElement || t instanceof HTMLSelectElement;
+        }
+
+        #getFormFields() {
+            if (!this.element) return [];
+            return Array.from(
+                this.element.querySelectorAll<TrackableField>('input, textarea, select')
+            );
+        }
+
+        #captureFormFieldState(target: EventTarget | null) {
+            if (!this.#isTrackableFormField(target) || !this.element) return;
+            if (!this.element.contains(target)) return;
+            const index = this.#getFormFields().indexOf(target);
+            this.pendingFormFieldIndex = index >= 0 ? index : undefined;
+        }
+
+        #selectAllFieldText(target: HTMLInputElement | HTMLTextAreaElement) {
+            if (target.disabled || target.readOnly) return;
+            try {
+                target.select();
+            } catch { /* Some input types may not support select(). Ignore safely. */ }
+        }
+
+        #restoreFormFieldState() {
+            const index = this.pendingFormFieldIndex;
+            this.pendingFormFieldIndex = undefined;
+            if (index === undefined || !this.element) return;
+
+            const target = this.#getFormFields()[index];
+            if (!this.#isTrackableFormField(target)) return;
+
+            const focusAndSelect = () => {
+                if (!this.element?.contains(target)) return;
+                target.focus({ preventScroll: true });
+
+                if (!(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement)) return;
+                this.#selectAllFieldText(target);
+            };
+
+            // Apply immediately so rapid typing after Tab still replaces the full value.
+            focusAndSelect();
+            // Re-apply on next frame to survive browser/foundry focus side effects.
+            requestAnimationFrame(focusAndSelect);
+        }
+
+        #bindFormFocusTracking() {
+            if (!this.element) return;
+
+            this.formFocusAbortController?.abort();
+            const controller = new AbortController();
+            this.formFocusAbortController = controller;
+
+            const captureTarget = (event: Event) => {
+                this.#captureFormFieldState(event.target);
+
+                // Select as soon as focus changes so quick typing doesn't insert at caret start.
+                if (event.type === 'focusin') {
+                    const target = event.target;
+                    if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+                        queueMicrotask(() => {
+                            if (document.activeElement === target) {
+                                this.#selectAllFieldText(target);
+                            }
+                        });
+                    }
+                }
+            };
+
+            this.element.addEventListener('focusin', captureTarget, { capture: true, signal: controller.signal });
         }
 
         #createFilters() {
@@ -232,6 +308,7 @@ export function SR5ApplicationMixin<BaseClass extends Identity<typeof AnyApplica
         }
 
         protected override _configureRenderOptions(options: Parameters<BaseType["_configureRenderOptions"]>[0]) {
+            this.#captureFormFieldState(document.activeElement);
             super._configureRenderOptions(options);
             if (options.mode && this.isEditable) this._mode = options.mode;
             // New sheets should always start in edit mode
@@ -322,10 +399,12 @@ export function SR5ApplicationMixin<BaseClass extends Identity<typeof AnyApplica
             return super._renderHTML(context, options) as Promise<Record<string, HTMLElement>>;
         }
 
-        protected override async _onRender(...[context, options]: Parameters<BaseType["_onRender"]>) {
+        protected override async _onRender(...args: Parameters<BaseType["_onRender"]>): Promise<void> {
             this.#filters.forEach(d => d.bind(this.element));
             this.#dragDrop.forEach(d => d.bind(this.element));
-            return super._onRender(context, options);
+            this.#bindFormFocusTracking();
+            await super._onRender(...args);
+            this.#restoreFormFieldState();
         }
 
         /**


### PR DESCRIPTION
This PR fixes sheet form navigation issues caused by submitOnChange rerenders and simplifies the focus/caret code path.

## What changed
- Reworked input focus tracking to use a single pendingFormFieldIndex instead of selector/caret state.
- Restores focus to the same form field after rerender using field order (input, textarea, select).
- Selects full text when restoring input/textarea focus so typing replaces existing values reliably.
- Added immediate and next-frame selection during restore to prevent fast typing from landing at caret start.
- Keeps focusin-time select behavior so tabbing between fields is consistent.
- Removed extra event/selector complexity used by previous implementations.

## Bug fixes covered
- Tabbing through skill rating fields no longer jumps back to the filter field.
- Fast typing after focus change no longer behaves like caret is at position 0.
- Text/numeric field edits remain predictable across rerenders.

before:
https://github.com/user-attachments/assets/c672a94d-2081-482e-b343-2bbb535daa1d

after:
https://github.com/user-attachments/assets/68820639-674a-4233-ae31-f3d3f586abf8
