### PR TITLE
Fixing some skill item inconsistencies and issues

### DIFF
--- a/src/module/actor/prep/functions/SkillFieldPrep.ts
+++ b/src/module/actor/prep/functions/SkillFieldPrep.ts
@@ -56,13 +56,12 @@ export const SkillFieldPrep = {
     createSkillField(skill: SR5Item<'skill'>) {
             const key = SkillNamingFlow.nameToKey(skill.name) || skill.id!;
             const group = skill.system.skill.group;
-            const hasCustomImage = skill.img && skill.img !== 'icons/svg/item-bag.svg';
 
             const skillField = DataDefaults.createData('skill_field', {
                 id: skill.id,
                 key,
                 name: skill.name,
-                img: hasCustomImage ? skill.img : '',
+                img: skill.img,
                 label: SkillNamingFlow.localizeSkillName(skill.name),
                 base: skill.system.skill.rating,
                 description: skill.system.description.value,

--- a/src/module/item/flows/UpdateSkillFlow.ts
+++ b/src/module/item/flows/UpdateSkillFlow.ts
@@ -32,7 +32,5 @@ export const UpdateSkillFlow = {
                 changeData['system.skill.attribute'] = SkillRules.languageSkillAttribute();
                 break;
         }
-
-        changeData['system.skill.defaulting'] = false;
     },
 };

--- a/src/module/item/sheets/SR5SkillSheet.ts
+++ b/src/module/item/sheets/SR5SkillSheet.ts
@@ -28,8 +28,6 @@ interface SR5SkillSheetData extends SR5BaseItemSheetData {
     showCompendiumWarning: boolean
     // Whether the skill attribute can be edited, based on the skill category.
     canEditSkillAttribute: boolean
-    // Whether the skill defaulting can be edited, based on the skill category.
-    canEditSkillDefaulting: boolean
     // Whether the skill can be native, based on the skill category.
     canBeNative: boolean
     // Taken directly from an owning actor to show the derived value.
@@ -134,7 +132,6 @@ export class SR5SkillSheet<T extends SR5SkillSheetData = SR5SkillSheetData> exte
         // Default skill-set actor type is only meaningful for compendium-stored skill items.
         context.showCompendiumWarning = !this.document.pack;
         context.canEditSkillAttribute = this.canEditSkillAttribute();
-        context.canEditSkillDefaulting = this.canEditSkillDefaulting();
         context.canBeNative = this.canBeNative();
         context.skillValue = this.getActorSkillValue();
         context.hasSkillValue = context.skillValue !== undefined;
@@ -176,11 +173,6 @@ export class SR5SkillSheet<T extends SR5SkillSheetData = SR5SkillSheetData> exte
     }
 
     canEditSkillAttribute() {
-        if (this.document.system.type !== 'skill') return true;
-        return !SkillRules.fixedCategoryValues(this.document.system.skill.category);
-    }
-
-    canEditSkillDefaulting() {
         if (this.document.system.type !== 'skill') return true;
         return !SkillRules.fixedCategoryValues(this.document.system.skill.category);
     }

--- a/src/templates/v2/item/footer/skill.hbs
+++ b/src/templates/v2/item/footer/skill.hbs
@@ -22,7 +22,7 @@
         <label data-tooltip="{{systemFields.skill.fields.defaulting.hint}}">
             {{localize "SR5.CanDefault"}}
             {{formInput systemFields.skill.fields.defaulting value=source.system.skill.defaulting
-                        rootId=@root.rootId disabled=(or @root.isPlayMode (not @root.canEditSkillDefaulting))}}
+                        rootId=@root.rootId disabled=@root.isPlayMode}}
         </label>
         {{#if (and @root.canBeNative systemFields.skill.fields.language)}}
             <label data-tooltip="{{systemFields.skill.fields.language.fields.isNative.hint}}">

--- a/src/templates/v2/list-items/skill/item.hbs
+++ b/src/templates/v2/list-items/skill/item.hbs
@@ -13,30 +13,7 @@
                                         skip=@root.bindings.skip descr=@root.bindings.card}}"
                 {{#if @root.isPlayMode}} data-action="rollSkill" {{else}} data-action="editSkill" {{/if}}
                >
-                <img
-                    {{#if skill.img}}
-                        src="{{skill.img}}"
-                    {{else}}
-                        {{#if (eq skill.attribute 'agility')}}
-                            src="systems/shadowrun5e/dist/icons/redist/run.svg"
-                        {{else if (eq skill.attribute 'body')}}
-                            src="systems/shadowrun5e/dist/icons/importer/bioware/cultured.svg"
-                        {{else if (eq skill.attribute 'strength')}}
-                            src="systems/shadowrun5e/dist/icons/redist/fist.svg"
-                        {{else if (eq skill.attribute 'reaction')}}
-                            src="systems/shadowrun5e/dist/icons/dodge.svg"
-                        {{else if (eq skill.attribute 'willpower')}}
-                            src="systems/shadowrun5e/dist/icons/bell-shield.svg"
-                        {{else if (eq skill.attribute 'logic')}}
-                            src="systems/shadowrun5e/dist/icons/redist/brain.svg"
-                        {{else if (eq skill.attribute 'intuition')}}
-                            src="systems/shadowrun5e/dist/icons/dodging.svg"
-                        {{else if (eq skill.attribute 'charisma')}}
-                            src="systems/shadowrun5e/dist/icons/importer/adept_power.svg"
-                        {{else}}
-                            src="systems/shadowrun5e/dist/icons/importer/action.svg"
-                        {{/if}}
-                    {{/if}}
+                <img src="{{skill.img}}"                    
                     {{#if @root.isEditMode}}
                      class="list-item-image-edit"
                     {{else}}


### PR DESCRIPTION
- Skill items used attribute specific icons if the skill used the default FoundryVTT item icon. This was confusing.
- Only active skills could set canDefault, however even if actor do not have a knowledge / language skill, they can still try do default