### PR TITLE
[BUG] Active Effect apply-to test with skill not working until skill filter is re selected

### DIFF
--- a/src/module/effect/flows/SuccessTestEffectsFlow.ts
+++ b/src/module/effect/flows/SuccessTestEffectsFlow.ts
@@ -95,7 +95,7 @@ export class SuccessTestEffectsFlow<T extends SuccessTest> {
         const skills = effect.system.selection_skills.map(test => test.id);
         const skillId = this.test.data.action.skill;
         const skillName = this.test.actor?.getSkill(skillId)?.name || skillId;
-        if (skills.length > 0 && !skills.includes(skillName)) return true;
+        if (skills.length > 0 && !skills.includes(skillId) && !skills.includes(skillName)) return true;
 
         // Check for test attributes used.
         const attributes = effect.system.selection_attributes.map(test => test.id);

--- a/src/module/item/flows/ActionFlow.ts
+++ b/src/module/item/flows/ActionFlow.ts
@@ -123,11 +123,12 @@ export class ActionFlow {
         //        the major use case is owned items, where the actor is available.
         const activeSkills = actor.getActiveSkills();
 
-        // Convert skill data to a value label mapping.
+        // Convert skill data to a canonical key -> label mapping so effect skill filters
+        // persist the same skill identifiers that tests use internally.
         const skills: Record<string, Translation> = {};
         for (const [id, skill] of Object.entries(activeSkills)) {
-            const key = skill.name || id;
-            const label = skill.name;
+            const key = id;
+            const label = skill.name || id;
             skills[key] = label as Translation;
         }
 

--- a/src/module/item/flows/ActionFlow.ts
+++ b/src/module/item/flows/ActionFlow.ts
@@ -9,6 +9,7 @@ import { ModifiableValue } from "../../mods/ModifiableValue";
 import { Translation } from "../../utils/strings";
 import { DamageType } from "src/module/types/item/Action";
 import { ModifiableValueLinkedType } from "src/module/types/template/Base";
+import { SkillNamingFlow } from "@/module/flows/SkillNamingFlow";
 
 export class ActionFlow {
     /**
@@ -153,6 +154,7 @@ export class ActionFlow {
 
         const foundCustomSkill = Object.values(skills).some(name => name === skillName);
         if (foundCustomSkill) return;
-        if (skillName && !skills[skillName]) skills[skillName] = skillName as Translation;
+        const skillKey = SkillNamingFlow.nameToKey(skillName);
+        if (skillName && !skills[skillKey]) skills[skillKey] = skillName as Translation;
     }
 }

--- a/src/module/migrator/Migrator.ts
+++ b/src/module/migrator/Migrator.ts
@@ -13,6 +13,7 @@ import { Version0_32_0 } from './versions/Version0_32_0';
 import { Version0_32_1 } from './versions/Version0_32_1';
 import { Version0_32_4 } from './versions/Version0_32_4';
 import { Version0_33_0 } from './versions/Version0_33_0';
+import { Version0_33_1 } from './versions/Version0_33_1';
 import { VersionMigration, MigratableDocument, MigratableDocumentName } from "./VersionMigration";
 const { deepClone } = foundry.utils;
 
@@ -52,6 +53,7 @@ export class Migrator {
         new Version0_32_1(),
         new Version0_32_4(),
         new Version0_33_0(),
+        new Version0_33_1(),
     ] as const;
 
     private static documentsToBeMigrated = 0;

--- a/src/module/migrator/versions/Version0_33_1.ts
+++ b/src/module/migrator/versions/Version0_33_1.ts
@@ -4,15 +4,25 @@ type MigratingActiveEffectChange = {
     key: string;
 };
 
+type MigratingActiveEffectSystem = {
+    applyTo?: string;
+};
+
 type MigratingActiveEffect = {
     changes?: MigratingActiveEffectChange[];
+    system?: MigratingActiveEffectSystem;
 };
 
 /**
  * Migrations for 0.33.0 missing schema changes:
- * - A) change keys including .mods instead of .changes
+ * - A) change keys using legacy ModifiableValue .mod to .changes
+ * - B) test effect keys referencing legacy data.modifiers(.mod) instead of data.pool
  */
 export class Version0_33_1 extends VersionMigration {
+    private static readonly LegacyModifiableValueKeyPattern = /\.mod$/;
+    private static readonly LegacyTestModifierKeyPattern = /^data\.modifiers(?:\.mod)?$/;
+    private static readonly ModernTestPoolKey = 'data.pool';
+
     readonly TargetVersion = "0.33.1";
     override handlesActiveEffect(_effect: Readonly<unknown>): boolean {
         const effect = _effect as MigratingActiveEffect;
@@ -20,19 +30,23 @@ export class Version0_33_1 extends VersionMigration {
         // A) Some changes referenced a legacy ModifiableValue schema suffix.
         if (effect.changes?.some(change => Version0_33_1.LegacyModifiableValueKeyPattern.test(change.key))) return true;
 
+        // B) Some test effects referenced the legacy test modifier field.
+        if (Version0_33_1.EffectUsesLegacyTestModifierKey(effect)) return true;
+
         return false;
     }
 
     override migrateActiveEffect(effect: unknown): void {
+        // Migration Case B)
+        Version0_33_1.MigrateTestModifierKeyToPool(effect);
+
         // Migration Case A)
         Version0_33_1.MigrateEffectKeysFromModToChanges(effect);
     }
 
     /**
-     * 0.32.x had ModifiableValueSchema contain a .mod/.mods property, while
-     * 0.33.0 uses the .changes property instead.
+        * 0.32.x used .mod for ModifiableValue data.
      */
-    private static readonly LegacyModifiableValueKeyPattern = /\.mods?$/;
     static MigrateEffectKeysFromModToChanges(effect: unknown): void {
         const migratingEffect = effect as MigratingActiveEffect;
 
@@ -41,5 +55,31 @@ export class Version0_33_1 extends VersionMigration {
                 change.key = change.key.replace(Version0_33_1.LegacyModifiableValueKeyPattern, '.changes');
             }
         }
+    }
+
+    /**
+        * Earlier test-targeted effects wrote to data.modifiers or data.modifiers.mod,
+        * while current tests use data.pool.
+     */
+    static MigrateTestModifierKeyToPool(effect: unknown): void {
+        const migratingEffect = effect as MigratingActiveEffect;
+
+        if (!Version0_33_1.isTestScopedEffect(migratingEffect)) return;
+
+        for (const change of migratingEffect.changes ?? []) {
+            if (Version0_33_1.LegacyTestModifierKeyPattern.test(change.key)) {
+                change.key = Version0_33_1.ModernTestPoolKey;
+            }
+        }
+    }
+
+    private static EffectUsesLegacyTestModifierKey(effect: MigratingActiveEffect): boolean {
+        if (!Version0_33_1.isTestScopedEffect(effect)) return false;
+
+        return effect.changes?.some(change => Version0_33_1.LegacyTestModifierKeyPattern.test(change.key)) ?? false;
+    }
+
+    private static isTestScopedEffect(effect: MigratingActiveEffect): boolean {
+        return effect.system?.applyTo === 'test_all' || effect.system?.applyTo === 'test_item';
     }
 }

--- a/src/module/migrator/versions/Version0_33_1.ts
+++ b/src/module/migrator/versions/Version0_33_1.ts
@@ -1,0 +1,45 @@
+import { VersionMigration } from "../VersionMigration";
+
+type MigratingActiveEffectChange = {
+    key: string;
+};
+
+type MigratingActiveEffect = {
+    changes?: MigratingActiveEffectChange[];
+};
+
+/**
+ * Migrations for 0.33.0 missing schema changes:
+ * - A) change keys including .mods instead of .changes
+ */
+export class Version0_33_1 extends VersionMigration {
+    readonly TargetVersion = "0.33.1";
+    override handlesActiveEffect(_effect: Readonly<unknown>): boolean {
+        const effect = _effect as MigratingActiveEffect;
+
+        // A) Some changes referenced a legacy ModifiableValue schema suffix.
+        if (effect.changes?.some(change => Version0_33_1.LegacyModifiableValueKeyPattern.test(change.key))) return true;
+
+        return false;
+    }
+
+    override migrateActiveEffect(effect: unknown): void {
+        // Migration Case A)
+        Version0_33_1.MigrateEffectKeysFromModToChanges(effect);
+    }
+
+    /**
+     * 0.32.x had ModifiableValueSchema contain a .mod/.mods property, while
+     * 0.33.0 uses the .changes property instead.
+     */
+    private static readonly LegacyModifiableValueKeyPattern = /\.mods?$/;
+    static MigrateEffectKeysFromModToChanges(effect: unknown): void {
+        const migratingEffect = effect as MigratingActiveEffect;
+
+        for (const change of migratingEffect.changes ?? []) {
+            if (Version0_33_1.LegacyModifiableValueKeyPattern.test(change.key)) {
+                change.key = change.key.replace(Version0_33_1.LegacyModifiableValueKeyPattern, '.changes');
+            }
+        }
+    }
+}

--- a/src/unittests/ItemSkill.spec.ts
+++ b/src/unittests/ItemSkill.spec.ts
@@ -4,6 +4,7 @@ import { SR5Actor } from '@/module/actor/SR5Actor';
 import { SkillGroupFlow } from '@/module/actor/flows/SkillGroupFlow';
 import { SkillSetFlow } from '@/module/actor/flows/SkillSetFlow';
 import { SkillSelectionFlow } from '@/module/flows/SkillSelectionFlow';
+import { ActionFlow } from '@/module/item/flows/ActionFlow';
 import { PackItemFlow } from '@/module/item/flows/PackItemFlow';
 import { SR5Item } from '@/module/item/SR5Item';
 import { SR5TestFactory } from './utils';
@@ -822,6 +823,27 @@ export const itemSkillTesting = (context: QuenchBatchContext) => {
             assert.exists(actionByKey);
             assert.strictEqual(actionByName?.skill, 'heavy_weapons');
             assert.strictEqual(actionByKey?.skill, 'heavy_weapons');
+        });
+
+        it('returns canonical skill keys for active effect skill selectors', async () => {
+            const actor = await factory.createActor({ type: 'character' });
+
+            await actor.createEmbeddedDocuments('Item', [{
+                type: 'skill',
+                name: 'Heavy Weapons',
+                system: {
+                    type: 'skill',
+                    skill: {
+                        attribute: 'agility',
+                    },
+                },
+            }]);
+
+            const skills = ActionFlow.sortedActiveSkills(actor);
+
+            assert.property(skills, 'heavy_weapons');
+            assert.strictEqual(skills.heavy_weapons, 'Heavy Weapons');
+            assert.notProperty(skills, 'Heavy Weapons');
         });
     });
 };

--- a/src/unittests/Migrators.spec.ts
+++ b/src/unittests/Migrators.spec.ts
@@ -208,10 +208,11 @@ export const Migrators = (context: QuenchBatchContext) => {
     });
 
     describe('Version0_33_1 active effect key migration', () => {
-        it('migrates terminal .mods suffixe to .changes only', () => {
+        it('migrates terminal legacy .mod keys to .changes only', () => {
             const migrator = new Version0_33_1();
             const effect = {
                 changes: [
+                    { key: 'system.attributes.body.mod' },
                     { key: 'system.attributes.body.mods' },
                     { key: 'system.skills.active.pistols.mods' },
                     { key: 'system.modifiers.global' },
@@ -226,7 +227,8 @@ export const Migrators = (context: QuenchBatchContext) => {
 
             assert.deepEqual(effect.changes.map(change => change.key), [
                 'system.attributes.body.changes',
-                'system.skills.active.pistols.changes',
+                'system.attributes.body.mods',
+                'system.skills.active.pistols.mods',
                 'system.modifiers.global',
                 'system.foo.mod.bar',
                 'system.foo.mods.bar',
@@ -239,6 +241,40 @@ export const Migrators = (context: QuenchBatchContext) => {
                 changes: [
                     { key: 'system.modifiers.value' },
                     { key: 'system.foo.mod.bar' },
+                ],
+            };
+
+            assert.isFalse(migrator.handlesActiveEffect(effect));
+        });
+
+        it('migrates legacy test data.modifiers keys to data.pool', () => {
+            const migrator = new Version0_33_1();
+            const effect = {
+                system: { applyTo: 'test_all' },
+                changes: [
+                    { key: 'data.modifiers' },
+                    { key: 'data.modifiers.mod' },
+                    { key: 'data.threshold' },
+                ],
+            };
+
+            assert.isTrue(migrator.handlesActiveEffect(effect));
+
+            migrator.migrateActiveEffect(effect);
+
+            assert.deepEqual(effect.changes.map(change => change.key), [
+                'data.pool',
+                'data.pool',
+                'data.threshold',
+            ]);
+        });
+
+        it('does not migrate data.modifiers for non-test effects', () => {
+            const migrator = new Version0_33_1();
+            const effect = {
+                system: { applyTo: 'actor' },
+                changes: [
+                    { key: 'data.modifiers' },
                 ],
             };
 

--- a/src/unittests/Migrators.spec.ts
+++ b/src/unittests/Migrators.spec.ts
@@ -2,6 +2,7 @@ import { QuenchBatchContext } from '@ethaks/fvtt-quench';
 import { SR5TestFactory } from './utils';
 import { DataDefaults } from '@/module/data/DataDefaults';
 import { Migrator } from '@/module/migrator/Migrator';
+import { Version0_33_1 } from '@/module/migrator/versions/Version0_33_1';
 
 export const Migrators = (context: QuenchBatchContext) => {
     const factory = new SR5TestFactory();
@@ -203,6 +204,45 @@ export const Migrators = (context: QuenchBatchContext) => {
             assert.strictEqual(foundry.utils.getProperty(knowledge, 'system.skill.category'), 'knowledge');
             assert.strictEqual(foundry.utils.getProperty(knowledge, 'system.skill.knowledgeType'), 'street');
             assert.deepEqual(foundry.utils.getProperty(source, 'system.skills'), {});
+        });
+    });
+
+    describe('Version0_33_1 active effect key migration', () => {
+        it('migrates terminal .mods suffixe to .changes only', () => {
+            const migrator = new Version0_33_1();
+            const effect = {
+                changes: [
+                    { key: 'system.attributes.body.mods' },
+                    { key: 'system.skills.active.pistols.mods' },
+                    { key: 'system.modifiers.global' },
+                    { key: 'system.foo.mod.bar' },
+                    { key: 'system.foo.mods.bar' },
+                ],
+            };
+
+            assert.isTrue(migrator.handlesActiveEffect(effect));
+
+            migrator.migrateActiveEffect(effect);
+
+            assert.deepEqual(effect.changes.map(change => change.key), [
+                'system.attributes.body.changes',
+                'system.skills.active.pistols.changes',
+                'system.modifiers.global',
+                'system.foo.mod.bar',
+                'system.foo.mods.bar',
+            ]);
+        });
+
+        it('ignores keys where .mod is not the terminal segment', () => {
+            const migrator = new Version0_33_1();
+            const effect = {
+                changes: [
+                    { key: 'system.modifiers.value' },
+                    { key: 'system.foo.mod.bar' },
+                ],
+            };
+
+            assert.isFalse(migrator.handlesActiveEffect(effect));
         });
     });
 

--- a/src/unittests/sr5.ActiveEffect.spec.ts
+++ b/src/unittests/sr5.ActiveEffect.spec.ts
@@ -866,6 +866,30 @@ export const shadowrunSR5ActiveEffect = (context: QuenchBatchContext) => {
 
             assert.strictEqual(test.pool.value, 0);
         });
+
+        it('Should apply skill-filtered modifiers for canonical keys and legacy skill names', async () => {
+            const actor = await factory.createActor({ type: 'character' });
+            await actor.createEmbeddedDocuments('ActiveEffect', [
+                {
+                    name: 'Skill Effect',
+                    system: { applyTo: 'test_all', selection_skills: [{ value: 'Sneaking', id: 'sneaking' }] },
+                    changes: [{ key: 'data.pool', value: '2', mode: CONST.ACTIVE_EFFECT_MODES.ADD }]
+                }                
+            ]);
+
+            const action = DataDefaults.createData('action_roll', {
+                test: SkillTest.name,
+                skill: 'sneaking',
+                attribute: 'agility',
+            });
+            const test = await TestCreator.fromAction(action, actor, { showDialog: false, showMessage: false }) as SkillTest;
+            if (!test) throw new Error('Failed to create test from action.');
+
+            test.effects.applyAllEffects();
+            ModifiableValue.calcTotal(test.pool);
+
+            assert.strictEqual(test.pool.value, 1); // 2 - 1 (defaulted skill)
+        });
     });
 
     /**

--- a/system.json
+++ b/system.json
@@ -21,7 +21,7 @@
         }
     ],
     "url": "#{URL}#",
-    "version": "0.33.0",
+    "version": "0.33.1",
     "compatibility": {
         "minimum": "13",
         "verified": "13.351",


### PR DESCRIPTION
Fixes #1832

Includes changes for PR #1834 in Migrator for 0.33.1, that can be ignored here.

The issue is the tagify id using the skill name instead of id and the application then check with the name for the skill.