### PR TITLE
[BUG] Targeting a missing effect change key on a test will cause the test dialog to not open

### DIFF
--- a/src/module/effect/SR5ActiveEffect.ts
+++ b/src/module/effect/SR5ActiveEffect.ts
@@ -259,7 +259,7 @@ export class SR5ActiveEffect extends ActiveEffect {
             return undefined;
         }
 
-        // In case of non-existant change.key targets, catch errors and log it, but still allow the overall process to continue.
+        // In case of non-existent change.key targets, catch errors and log it, but still allow the overall process to continue.
         // An example could be applying test effect changes, and a single misconfigured effect change shouldn't stop the test dialog 
         // from showing up.
         try {

--- a/src/module/effect/SR5ActiveEffect.ts
+++ b/src/module/effect/SR5ActiveEffect.ts
@@ -259,7 +259,15 @@ export class SR5ActiveEffect extends ActiveEffect {
             return undefined;
         }
 
-        return super.apply(object, change);
+        // In case of non-existant change.key targets, catch errors and log it, but still allow the overall process to continue.
+        // An example could be applying test effect changes, and a single misconfigured effect change shouldn't stop the test dialog 
+        // from showing up.
+        try {
+            return super.apply(object, change);
+        } catch (err) {
+            console.error(`Test [${object.constructor.name}] | Failed to apply active effect change for ${change.key}: "${change.value}"`, err);
+            return undefined;
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #1836

Prevent any effect change application to prevent the overall application blocking the surround process.

In this case the test dialog wasn't opening, due to a single misconfigured effect change pointing at the wrong key.