### PR TITLE
[System] Fix remaining broken unittests due to legacy skill usage on actor creation

### DIFF
--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -1178,13 +1178,15 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         const spec = options.specialization || false;
         const skillKey = SkillNamingFlow.nameToKey(skill.name) || name;
 
+        // NOTE: Using id here might be an issue, as getSkill can inject other actors skills, causing neither
+        //       the skill id to not be found on this actor. This can happen for vehicle / driver relationships.
         const getOpposedAction = (id: string) => {
             const item = this.items.get(id) as SR5Item<'skill'> | undefined;
             if (!item?.isType('skill')) return;
             return item.system.skill.action.opposed;
         }
 
-        return DataDefaults.createData('action_roll', {
+        const action = DataDefaults.createData('action_roll', {
             skill: skillKey,
             spec,
             attribute: skill.attribute,
@@ -1192,10 +1194,15 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
                 attribute: limit,
                 base_formula_operator: 'add',
             },
-            opposed: getOpposedAction(skill.id),
 
             test: 'SkillTest'
         });
+
+        // Retrieve opposed from skill item, making sure not to break on missing skill id
+        const opposed = getOpposedAction(skill.id);
+        if (opposed) action.opposed = opposed;
+
+        return action;
     }
 
     /**

--- a/src/unittests/sr5.Driver.spec.ts
+++ b/src/unittests/sr5.Driver.spec.ts
@@ -25,9 +25,9 @@ export const shadowrunDriver = (context: QuenchBatchContext) => {
         });
 
         const gunnery = actor.items.get(actor.system.skills.active.gunnery?.id);
-        await gunnery?.update({ system: { rating: 5 } });
+        await gunnery?.update({ system: { skill: { rating: 5 }}});
         const pilot_ground_craft = actor.items.get(actor.system.skills.active.pilot_ground_craft?.id);
-        await pilot_ground_craft?.update({ system: { rating: 5 } });
+        await pilot_ground_craft?.update({ system: { skill: { rating: 5 }} });
 
         return actor;
     }

--- a/src/unittests/sr5.Driver.spec.ts
+++ b/src/unittests/sr5.Driver.spec.ts
@@ -13,22 +13,23 @@ export const shadowrunDriver = (context: QuenchBatchContext) => {
     const testOptions = { showDialog: false, showMessage: false };
 
     const createDriver = async () => {
-        return await factory.createActor({ type: 'character',
+        const actor = await factory.createActor({ type: 'character',
             system: {
                 attributes: {
                     intuition: { base: 5, },
                     reaction: { base: 3, },
                     agility: { base: 3, },
                     logic: { base: 5, }
-                },
-                skills: {
-                    active: {
-                        gunnery: { base: 5, attribute: 'agility' },
-                        pilot_ground_craft: { base: 5, attribute: 'reaction' }
-                    }
                 }
             }
         });
+
+        const gunnery = actor.items.get(actor.system.skills.active.gunnery?.id);
+        await gunnery?.update({ system: { rating: 5 } });
+        const pilot_ground_craft = actor.items.get(actor.system.skills.active.pilot_ground_craft?.id);
+        await pilot_ground_craft?.update({ system: { rating: 5 } });
+
+        return actor;
     }
 
     const createVehicle = async () => {

--- a/src/unittests/sr5.RiggerTesting.spec.ts
+++ b/src/unittests/sr5.RiggerTesting.spec.ts
@@ -13,7 +13,7 @@ export const shadowrunRiggerTesting = (context: QuenchBatchContext) => {
     const testOptions = { showDialog: false, showMessage: false };
 
     const createDriver = async () => {
-        return await factory.createActor({ type: 'character',
+        const actor = await factory.createActor({ type: 'character',
             system: {
                 attributes: {
                     intuition: { base: 5, },
@@ -38,6 +38,15 @@ export const shadowrunRiggerTesting = (context: QuenchBatchContext) => {
                 }
             }
         });
+
+        const gunnery = actor.items.get(actor.system.skills.active.gunnery?.id);
+        await gunnery?.update({ system: { skill: { rating: 5 }}});
+        const pilot_ground_craft = actor.items.get(actor.system.skills.active.pilot_ground_craft?.id);
+        await pilot_ground_craft?.update({ system: { skill: { rating: 5 }} });
+        const perception = actor.items.get(actor.system.skills.active.perception?.id);
+        await perception?.update({ system: { skill: { rating: 4 }} });
+        
+        return actor;
     }
 
     const createVehicle = async () => {
@@ -54,7 +63,7 @@ export const shadowrunRiggerTesting = (context: QuenchBatchContext) => {
         });
     }
 
-    describe('Rigger Testing around Being jumped in and Control Rig', () => {
+    describe('Rigger Testing', () => {
         it('Jump into a Vehicle and Perform Driving Test', async () => {
             const vehicle = await createVehicle();
             const driver = await createDriver();


### PR DESCRIPTION
Also found an issue with skill action resolution when multiple documents are involved within SR5Actor.getRollData (vehicle with rigger), documente it [here ](https://github.com/SR5-FoundryVTT/SR5-FoundryVTT/issues/1848) for later. 