### PR TITLE
Fix bulk importer skill/skillgroup handling for critters & spirits

### DIFF
--- a/src/module/actor/prep/SpiritPrep.ts
+++ b/src/module/actor/prep/SpiritPrep.ts
@@ -360,7 +360,7 @@ export class SpiritPrep {
                 overrides.attributes.strength = -2;
                 overrides.attributes.intuition = 1;
                 overrides.init = 2;
-                overrides.skills.push('assensing', 'astral_combat', 'perception', 'spell_casting', 'unarmed_combat');
+                overrides.skills.push('assensing', 'astral_combat', 'perception', 'spellcasting', 'unarmed_combat');
                 break;
             case 'sludge':
                 overrides.attributes.body = 1;
@@ -582,7 +582,7 @@ export class SpiritPrep {
                 overrides.attributes.body = +2;
                 overrides.attributes.strength = 1;
                 overrides.attributes.essence = -2;
-                overrides.skills.push("assensing", "astral_combat", "blade", "clubs", "unarmed_combat", "exotic_ranged_weapon", "perception");
+                overrides.skills.push("assensing", "astral_combat", "blades", "clubs", "unarmed_combat", "exotic_ranged_weapon", "perception");
                 break;
 
             case "blackjack":

--- a/src/module/actor/prep/SpiritPrep.ts
+++ b/src/module/actor/prep/SpiritPrep.ts
@@ -46,7 +46,6 @@ export class SpiritPrep {
 
     static prepareSpiritValues(system: Actor.SystemOfType<'spirit'>) {
         const overrides = this.getSpiritStatModifiers(system.spiritType);
-        // if (!system.skills?.active) return;
 
         if (overrides) {
             const { attributes, skills, initiative, modifiers } = system;

--- a/src/module/apps/itemImport/apps/BulkImporter.ts
+++ b/src/module/apps/itemImport/apps/BulkImporter.ts
@@ -97,8 +97,8 @@ export class BulkImporter extends BaseClass {
     private static readonly githubConfig = {
         owner: "chummer5a",
         repo: "chummer5a",
-        version: "v5.225.1049",
-        branch: "3e0520c06b8e393b500cfac8c951e8be28a24046",
+        version: "v5.226.0",
+        branch: "0c354ec2b81da5ccd2c93648f93ec8f6831c030e",
     } as const;
 
     /**
@@ -133,13 +133,13 @@ export class BulkImporter extends BaseClass {
         new WareImporter(),
         new QualityImporter(),
         new CritterPowerImporter(),
+        new SkillImporter(),
         new CritterImporter(),
         new EchoesImporter(),
         new AdeptPowerImporter(),
         new ArmorModImporter(),
         new ArmorImporter(),
         new ActionImporter(),
-        new SkillImporter(),
     ] as const satisfies readonly DataImporter[];
 
     /**

--- a/src/module/apps/itemImport/helper/ImportHelper.ts
+++ b/src/module/apps/itemImport/helper/ImportHelper.ts
@@ -42,6 +42,15 @@ export class ImportHelper {
             .replace(/^-+|-+$/g, '');        // trim hyphens
     }
 
+    /**
+     * Convert Chummer GUID text to stable Foundry `_id`.
+     * Steps: strip `-`, parse hex as BigInt, encode base62, normalize to 16 chars.
+     * Used by `DataImporter.ParseItems` for all imports, including generated
+     * skill-group GUIDs from `SkillImporter.generateGroupGuid`.
+     * Deterministic input GUID means deterministic Foundry `_id`.
+     * If upstream GUID generation inputs change (e.g. renamed skill group), `_id`
+     * also changes and import matching will treat it as a different document.
+     */
     public static guidToId(guid: string): string {
         const cleanGuid = guid.replace(/-/g, '');
         const big = BigInt('0x' + cleanGuid);

--- a/src/module/apps/itemImport/importer/SkillImporter.ts
+++ b/src/module/apps/itemImport/importer/SkillImporter.ts
@@ -4,8 +4,13 @@ import { SkillParser } from '../parser/misc/SkillParser';
 import { Skill, SkillsSchema } from '../schema/SkillsSchema';
 import { SkillGroupParser } from '../parser/misc/SkillGroupParser';
 
+/**
+ * Stable normalization used by mapping and GUID generation.
+ * Changing this changes generated GUIDs, which changes Foundry `_id` values.
+ */
 const formatGroupName = (name: string) => name.trim().toLowerCase();
 
+/** Deterministic 32-bit FNV-1a-style hash for ID seeding (non-cryptographic). */
 const generateHash = (value: string): number => {
     let hash = 0x811c9dc5;
     for (let i = 0; i < value.length; i++)
@@ -13,13 +18,22 @@ const generateHash = (value: string): number => {
     return hash >>> 0;
 };
 
+/** Format 32 hex chars as GUID text (8-4-4-4-12). */
 const formatAsGuid = (hex: string) => `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
 
+/**
+ * Deterministic GUID for Chummer skill groups without source GUIDs.
+ * Seeds: `sr5-skill-group`, normalized name, `id`, `source`.
+ * Converted to Foundry `_id` later via `DataImporter.ParseItems` -> `ImportHelper.guidToId`.
+ * Same normalized group name always maps to same Foundry `_id` across imports;
+ * renaming a group creates a different ID (new document path).
+ */
 export const generateGroupGuid = (groupName: string): string => formatAsGuid(
     ['sr5-skill-group', formatGroupName(groupName), 'id', 'source']
         .map(seed => generateHash(seed).toString(16).padStart(8, '0')).join('')
 );
 
+/** Build a normalized group-name -> member skill names map from parsed skills. */
 export const mapSkillsToGroups = (skills: Skill[]): Map<string, string[]> => {
     const byGroup = new Map<string, Set<string>>();
     for (const { name, skillgroup } of skills) {
@@ -41,8 +55,10 @@ export class SkillImporter extends DataImporter {
         const skillGroups = await game.packs.get('shadowrun5e.sr5e-skill-groups')?.getDocuments() ?? [];
         const skillsToGroups = mapSkillsToGroups(parsedSkills);
 
-        // Since names are unique, we just filter out empties and map directly
-        const parsedGroups: SkillGroup[] = jsonObject.skillgroups.name.flatMap(g => {
+        // skills.xml skill groups are name-only. Create deterministic GUIDs so
+        // ParseItems/guidToId generates stable `_id` values across re-imports.
+        // If the group name/normalization changes, the resulting `_id` changes too.
+        const parsedGroups = jsonObject.skillgroups.name.flatMap(g => {
             const name = g._TEXT?.trim();
             if (!name) return [];
 
@@ -50,7 +66,7 @@ export class SkillImporter extends DataImporter {
                 id: { _TEXT: generateGroupGuid(name) },
                 name: { _TEXT: name },
                 ...(g.$?.translate && { translate: { _TEXT: g.$.translate } })
-            }];
+            } satisfies SkillGroup as SkillGroup];
         });
 
         await SkillImporter.ParseItems<SkillGroup>(parsedGroups, {

--- a/src/module/apps/itemImport/importer/SkillImporter.ts
+++ b/src/module/apps/itemImport/importer/SkillImporter.ts
@@ -1,20 +1,68 @@
+import { SkillGroup } from '../parser/Types';
 import { DataImporter } from './DataImporter';
 import { SkillParser } from '../parser/misc/SkillParser';
 import { Skill, SkillsSchema } from '../schema/SkillsSchema';
+import { SkillGroupParser } from '../parser/misc/SkillGroupParser';
+
+const formatGroupName = (name: string) => name.trim().toLowerCase();
+
+const generateHash = (value: string): number => {
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < value.length; i++)
+        hash = Math.imul(hash ^ value.charCodeAt(i), 0x01000193);
+    return hash >>> 0;
+};
+
+const formatAsGuid = (hex: string) => `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+
+export const generateGroupGuid = (groupName: string): string => formatAsGuid(
+    ['sr5-skill-group', formatGroupName(groupName), 'id', 'source']
+        .map(seed => generateHash(seed).toString(16).padStart(8, '0')).join('')
+);
+
+export const mapSkillsToGroups = (skills: Skill[]): Map<string, string[]> => {
+    const byGroup = new Map<string, Set<string>>();
+    for (const { name, skillgroup } of skills) {
+        const groupName = skillgroup?._TEXT?.trim();
+        if (groupName) {
+            const key = formatGroupName(groupName);
+            byGroup.set(key, (byGroup.get(key) || new Set()).add(name._TEXT));
+        }
+    }
+    return new Map([...byGroup].map(([k, v]) => [k, [...v]]));
+};
 
 export class SkillImporter extends DataImporter {
     public readonly files = ['skills.xml'] as const;
 
     async _parse(jsonObject: SkillsSchema): Promise<void> {
+        const parsedSkills = [...jsonObject.skills.skill, ...jsonObject.knowledgeskills.skill];
         const skills = await game.packs.get('shadowrun5e.sr5e-skills')?.getDocuments() ?? [];
+        const skillGroups = await game.packs.get('shadowrun5e.sr5e-skill-groups')?.getDocuments() ?? [];
+        const skillsToGroups = mapSkillsToGroups(parsedSkills);
 
-        return SkillImporter.ParseItems<Skill>(
-            [...jsonObject.skills.skill, ...jsonObject.knowledgeskills.skill],
-            {
-                compendiumKey: () => "Skill",
-                parser: new SkillParser(skills as Item.Stored<'skill'>[]),
-                documentType: "Skill"
-            }
-        );
+        // Since names are unique, we just filter out empties and map directly
+        const parsedGroups: SkillGroup[] = jsonObject.skillgroups.name.flatMap(g => {
+            const name = g._TEXT?.trim();
+            if (!name) return [];
+
+            return [{
+                id: { _TEXT: generateGroupGuid(name) },
+                name: { _TEXT: name },
+                ...(g.$?.translate && { translate: { _TEXT: g.$.translate } })
+            }];
+        });
+
+        await SkillImporter.ParseItems<SkillGroup>(parsedGroups, {
+            compendiumKey: () => "Skill",
+            parser: new SkillGroupParser(skillsToGroups, skillGroups as Item.Stored<'skill'>[]),
+            documentType: "Skill Group"
+        });
+
+        return SkillImporter.ParseItems<Skill>(parsedSkills, {
+            compendiumKey: () => "Skill",
+            parser: new SkillParser(skills as Item.Stored<'skill'>[]),
+            documentType: "Skill"
+        });
     }
 }

--- a/src/module/apps/itemImport/parser/Types.ts
+++ b/src/module/apps/itemImport/parser/Types.ts
@@ -1,3 +1,4 @@
+import { OneOrMany } from "../schema/Types";
 import { ActionsSchema, Action } from "../schema/ActionsSchema";
 import { ArmorSchema, Armor, Mod as ArmorMod } from "../schema/ArmorSchema";
 import { Bioware, BiowareSchema } from "../schema/BiowareSchema";
@@ -14,10 +15,18 @@ import { Spell, SpellsSchema } from "../schema/SpellsSchema";
 import { Vehicle, Mod as VehicleMod, Weaponmount, VehiclesSchema } from "../schema/VehiclesSchema";
 import { Accessory, Weapon, WeaponsSchema } from "../schema/WeaponsSchema";
 
+export type SkillGroup = {
+    id: { _TEXT: string; };
+    name: { _TEXT: string; };
+    translate?: OneOrMany<{ _TEXT: string; }>;
+    page?: undefined;
+    source?: undefined;
+};
+
 export type Schemas =
     ActionsSchema | ArmorSchema | BiowareSchema | CritterpowersSchema | CyberwareSchema | ComplexformsSchema | EchoesSchema |
     GearSchema | MetatypeSchema | PowersSchema | QualitiesSchema | SkillsSchema | SpellsSchema | VehiclesSchema | WeaponsSchema;
 
 export type ParseData =
     Action | Armor | ArmorMod | Bioware | CritterPower | Cyberware | Complexform | Echo | Gear | Metatype |
-    Power | Enhancement | Quality | Skill | Spell | Vehicle | VehicleMod | Weaponmount | Weapon | Accessory;
+    Power | Enhancement | Quality | Skill | SkillGroup | Spell | Vehicle | VehicleMod | Weaponmount | Weapon | Accessory;

--- a/src/module/apps/itemImport/parser/metatype/CritterParser.ts
+++ b/src/module/apps/itemImport/parser/metatype/CritterParser.ts
@@ -1,58 +1,42 @@
-import { SystemType } from "../Parser";
+import { Constants } from '../../importer/Constants';
 import { Metatype } from "../../schema/MetatypeSchema";
 import { CompendiumKey } from "../../importer/Constants";
 import { MetatypeParserBase } from './MetatypeParserBase';
-import { DataDefaults } from "src/module/data/DataDefaults";
+import { DataDefaults } from 'src/module/data/DataDefaults';
 import { ImportHelper as IH } from '../../helper/ImportHelper';
+import { KnowledgeSkillCategory } from "src/module/types/template/Skills";
 
 export class CritterParser extends MetatypeParserBase<'character'> {
     protected readonly parseType = 'character';
 
-    private normalizeSkillName(rawName: string): string {
-        return rawName.trim().toLowerCase().replace(/[\s-]/g, '_');
-    }
+    private createKnowledgeSkillItems(knowledgeList: NonNullable<Metatype['skills']>['knowledge']): Item.Source[] {
+        const result: Item.Source[] = [];
 
-    private setSkills(system: SystemType<'character'>, jsonData: Metatype): void {
-        const skills = jsonData.skills;
-        if (!skills) return;
+        for (const skill of IH.getArray(knowledgeList)) {
+            const name = skill._TEXT.trim();
+            const category = skill.$.category.toLowerCase() as KnowledgeSkillCategory | 'interest';
+            const knowledgeType = category === 'interest' ? 'interests' : category;
 
-        for (const skill of skills.skill) {
-            const name = this.normalizeSkillName(skill._TEXT);
-            const skillValue = +(skill.$?.rating ?? 0);
-    
-            const parsedSkill = system.skills.active[name];
-            if (parsedSkill) {
-                parsedSkill.base = skillValue;
-                if (skill?.$?.spec) parsedSkill.specs.push(skill.$.spec);
-            } else if (name === 'flight') {
-                system.skills.active[name] = DataDefaults.createData('skill_field', { attribute: "agility", base: skillValue });
-            } else {
-                console.warn(`[Skill Missing] Actor: ${jsonData.name._TEXT}\nSkill: ${name}`);
-            }
-        };
+            const item: Item.CreateData<'skill'> = {
+                _id: foundry.utils.randomID(),
+                name: name,
+                type: 'skill',
+                img: `systems/shadowrun5e/dist/icons/skills/knowledge-${knowledgeType}.svg`,
+                system: DataDefaults.baseSystemData('skill', {
+                    type: 'skill',
+                    skill: {
+                        category: 'knowledge',
+                        knowledgeType,
+                        attribute: Constants.attributeTable[skill.$.attribute],
+                        rating: Number(skill.$.rating ?? 0) || 0,
+                    }
+                }),
+            };
 
-        if (skills.group) {
-            const groups = IH.getArray(skills.group).reduce<Record<string, number>>((acc, item) => {
-                acc[item._TEXT] = +(item.$?.rating ?? 0);
-                return acc;
-            }, {});
-
-            Object.entries(system.skills.active).forEach(([_, skill]) => {
-                if (Object.keys(groups).includes(skill.group)) {
-                    skill.base = (skill.base ?? 0) + groups[skill.group];
-                }
-            });
+            result.push(item as Item.Source);
         }
 
-        if (skills.knowledge) {
-            IH.getArray(skills.knowledge).forEach((skill) => {
-                const name = this.normalizeSkillName(skill._TEXT);
-                const skillValue = Number(skill.$.rating) || 0;
-                const skillCategory = skill.$.category.toLowerCase();
-
-                system.skills.knowledge[skillCategory].value[name] = DataDefaults.createData('skill_field', { name: skill._TEXT, base: skillValue });
-            });
-        }
+        return result;
     }
 
     protected override getSystem(jsonData: Metatype) {
@@ -77,15 +61,7 @@ export class CritterParser extends MetatypeParserBase<'character'> {
 
         system.karma.value = Number(jsonData.karma?._TEXT || 0);
 
-        if (jsonData.walk)
-            system.movement.walk.base = Number(jsonData.walk._TEXT.split('/')[0] ?? 0);
-
-        if (jsonData.run)
-            system.movement.run.base = Number(jsonData.run._TEXT.split('/')[0] ?? 0);
-
-        system.movement.sprint = Number(jsonData.sprint?._TEXT.split('/')[0] ?? 0);
-
-        this.setSkills(system, jsonData);
+        this.applyMovement(system, jsonData);
 
         system.is_npc = true;
         system.is_critter = true;
@@ -94,40 +70,47 @@ export class CritterParser extends MetatypeParserBase<'character'> {
     }
 
     protected override async getItems(jsonData: Metatype): Promise<Item.Source[]> {
-        const optionalpowers = jsonData.optionalpowers || undefined;
-        const qualities = jsonData.qualities || undefined;
+        const { name, powers, skills, biowares, complexforms } = jsonData;
+
+        const qualities = this.mergeLists(
+            jsonData.qualities?.positive?.quality,
+            jsonData.qualities?.negative?.quality
+        );
+        const optionalPowers = this.mergeLists(
+            jsonData.optionalpowers?.optionalpower,
+            jsonData.bonus?.optionalpowers?.optionalpower
+        );
 
         const spellsData = IH.getArray(jsonData.powers?.power)
             .filter(s => s._TEXT === "Innate Spell" && s.$?.select)
             .map(s => ({ _TEXT: s.$?.select })) as { _TEXT: string }[];
 
-        const bioware = IH.getArray(jsonData.biowares?.bioware).map(v => v._TEXT);
-        const complex = IH.getArray(jsonData.complexforms?.complexform).map(v => v._TEXT);
-        const spells = spellsData.map(v => v._TEXT);
-        const power = [
-            ...IH.getArray(jsonData.powers?.power),
-            ...IH.getArray(optionalpowers?.optionalpower)
-        ].map(v => v._TEXT);
-        const quality = [
-            ...IH.getArray(qualities?.positive?.quality),
-            ...IH.getArray(qualities?.negative?.quality)
-        ].map(v => v._TEXT);
+        const spellList = this.getNamedList(spellsData);
+        const qualitiesList = this.getNamedList(qualities);
+        const biowareList = this.getNamedList(biowares?.bioware);
+        const complexList = this.getNamedList(complexforms?.complexform);
+        const powerList = this.getNamedList(powers?.power, optionalPowers);
+        const skillList = this.getNamedList(skills?.skill, skills?.group);
 
-        const allComplexForm = await IH.findItems('Complex_Form', complex);
-        const allSpells = await IH.findItems('Spell', spells);
-        const allPowers = await IH.findItems('Critter_Power', power);
-        const allQualities = await IH.findItems('Quality', [...quality, ...bioware]);
-        const allBiowares = await IH.findItems('Ware', bioware);
+        const allSpells = await IH.findItems('Spell', spellList);
+        const allSkills = await IH.findItems('Skill', skillList);
+        const allBiowares = await IH.findItems('Ware', biowareList);
+        const allPowers = await IH.findItems('Critter_Power', powerList);
+        const allComplexForm = await IH.findItems('Complex_Form', complexList);
+        const knowledgeSkillItems = this.createKnowledgeSkillItems(skills?.knowledge);
+        const allQualities = await IH.findItems('Quality', [...qualitiesList, ...biowareList]);
 
-        const name = jsonData.name._TEXT;
+        const critterName = name._TEXT;
         return [
-            ...this.getMetatypeItems(allSpells, spellsData, { type: 'Spell', critter: name }),
-            ...this.getMetatypeItems(allPowers, jsonData.powers?.power, { type: 'Power', critter: name }),
-            ...this.getMetatypeItems(allBiowares, jsonData.biowares?.bioware, { type: 'Bioware', critter: name }),
-            ...this.getMetatypeItems(allPowers, optionalpowers?.optionalpower, { type: 'Power', critter: name }),
-            ...this.getMetatypeItems(allQualities, qualities?.positive?.quality, { type: 'Quality', critter: name }),
-            ...this.getMetatypeItems(allQualities, qualities?.negative?.quality, { type: 'Quality', critter: name }),
-            ...this.getMetatypeItems(allComplexForm, jsonData.complexforms?.complexform, { type: 'Complex Form', critter: name }),
+            ...knowledgeSkillItems,
+            ...this.getMetatypeItems(allSpells, spellsData, { type: 'Spell', critter: critterName }),
+            ...this.getMetatypeItems(allPowers, optionalPowers, { type: 'Power', critter: critterName }),
+            ...this.getMetatypeItems(allQualities, qualities, { type: 'Quality', critter: critterName }),
+            ...this.getMetatypeItems(allPowers, powers?.power, { type: 'Power', critter: critterName }),
+            ...this.getMetatypeItems(allSkills, skills?.skill, { type: 'Skill', critter: critterName }),
+            ...this.getMetatypeItems(allSkills, skills?.group, { type: 'Skill Group', critter: critterName }),
+            ...this.getMetatypeItems(allBiowares, biowares?.bioware, { type: 'Bioware', critter: critterName }),
+            ...this.getMetatypeItems(allComplexForm, complexforms?.complexform, { type: 'Complex Form', critter: critterName }),
         ];
     }
 

--- a/src/module/apps/itemImport/parser/metatype/MetatypeParserBase.ts
+++ b/src/module/apps/itemImport/parser/metatype/MetatypeParserBase.ts
@@ -1,10 +1,48 @@
 import { Parser } from '../Parser';
+import { Metatype } from '../../schema/MetatypeSchema';
 import { ImportHelper as IH, OneOrMany, RetrievedItem } from '../../helper/ImportHelper';
 
+type MetatypeItemData = {
+    _TEXT: string;
+    $?: { select?: string; rating?: string; spec?: string };
+};
+
 export abstract class MetatypeParserBase<TResult extends ('character' | 'spirit' | 'sprite')> extends Parser<TResult> {
+    /**
+     * Merges many optional one-or-many arrays into a single non-null list.
+     */
+    protected mergeLists<T>(...lists: Array<OneOrMany<T | undefined>>): Array<NonNullable<T>> {
+        return lists.flatMap(list => IH.getArray(list)).filter((v): v is NonNullable<T> => v != null);
+    }
+
+    /**
+     * Converts one-or-many `_TEXT` collections into a flat name list.
+     */
+    protected getNamedList(...collections: Array<undefined | OneOrMany<{ _TEXT: string }>>) {
+        return collections.flatMap(collection => IH.getArray(collection).map(entry => entry._TEXT));
+    }
+
+    /**
+     * Applies movement values from metatype walk/run/sprint fields to actor movement base values.
+     */
+    protected applyMovement(
+        system: ReturnType<typeof this.getBaseSystem>,
+        jsonData: Pick<Metatype, 'walk' | 'run' | 'sprint'>,
+    ) {
+        if (!('movement' in system)) return;
+
+        if (jsonData.walk)
+            system.movement.walk.base = Number(jsonData.walk._TEXT.split('/')[0] ?? 0);
+
+        if (jsonData.run)
+            system.movement.run.base = Number(jsonData.run._TEXT.split('/')[0] ?? 0);
+
+        system.movement.sprint = Number(jsonData.sprint?._TEXT.split('/')[0] ?? 0);
+    }
+
     getMetatypeItems(
         items: RetrievedItem[],
-        itemsData: undefined | OneOrMany<{$?: { select?: string; rating?: string; removable?: string; }; _TEXT: string }>,
+        itemsData: OneOrMany<MetatypeItemData> | undefined,
         msg_field: {type: string; critter: string},
     ): Item.Source[] {
         const itemMap = new Map(items.map(({name_english, ...i}) => [name_english, i]));
@@ -33,8 +71,13 @@ export abstract class MetatypeParserBase<TResult extends ('character' | 'spirit'
                 const rating = Number(itemData.$.rating) || 0;
                 if ('rating' in system)
                     system.rating = rating;
-                else if ('technology' in system && system.technology)
+                else if ('technology' in system)
                     system.technology.rating = rating;
+                else if ('skill' in system) {
+                    system.group.rating = itemData.$.rating.includes('F') ? 1 : rating;
+                    system.skill.rating = itemData.$.rating.includes('F') ? 1 : rating;
+                    if (itemData.$.spec) system.skill.specializations.push({ name: itemData.$.spec });
+                }
             }
 
             result.push(item);

--- a/src/module/apps/itemImport/parser/metatype/MetatypeParserBase.ts
+++ b/src/module/apps/itemImport/parser/metatype/MetatypeParserBase.ts
@@ -11,8 +11,8 @@ export abstract class MetatypeParserBase<TResult extends ('character' | 'spirit'
     /**
      * Merges many optional one-or-many arrays into a single non-null list.
      */
-    protected mergeLists<T>(...lists: Array<OneOrMany<T | undefined>>): Array<NonNullable<T>> {
-        return lists.flatMap(list => IH.getArray(list)).filter((v): v is NonNullable<T> => v != null);
+    protected mergeLists<T>(...lists: Array<OneOrMany<T> | undefined>): Array<T> {
+        return lists.flatMap(list => IH.getArray(list)).filter(v => v != null);
     }
 
     /**

--- a/src/module/apps/itemImport/parser/metatype/SpiritParser.ts
+++ b/src/module/apps/itemImport/parser/metatype/SpiritParser.ts
@@ -37,37 +37,37 @@ export class SpiritParser extends MetatypeParserBase<'spirit'> {
                     .split("/")[0].toLowerCase() as any;
         }
 
-        if (jsonData.walk)
-            system.movement.walk.base = Number(jsonData.walk._TEXT.split('/')[0] ?? 0);
-
-        if (jsonData.run)
-            system.movement.run.base = Number(jsonData.run._TEXT.split('/')[0] ?? 0);
-
-        system.movement.sprint = Number(jsonData.sprint?._TEXT.split('/')[0] ?? 0);
+        this.applyMovement(system, jsonData);
 
         return system;
     }
 
     protected override async getItems(jsonData: Metatype): Promise<Item.Source[]> {
-        const { name, powers } = jsonData;
-        const qualities = jsonData.qualities || undefined;
-        const optionalpowers = jsonData.optionalpowers || jsonData.bonus?.optionalpowers;
+        const { name, powers, skills } = jsonData;
+        const qualities = this.mergeLists(
+            jsonData.qualities?.positive?.quality,
+            jsonData.qualities?.negative?.quality
+        );
+        const optionalPowers = this.mergeLists(
+            jsonData.optionalpowers?.optionalpower,
+            jsonData.bonus?.optionalpowers?.optionalpower
+        );
 
-        const powerList = [...IH.getArray(powers?.power), ...IH.getArray(optionalpowers?.optionalpower)].map(i => i._TEXT);
-        const qualityList = [
-            ...IH.getArray(qualities?.positive?.quality),
-            ...IH.getArray(qualities?.negative?.quality),
-        ].map(i => i._TEXT);
+        const qualityList = this.getNamedList(qualities);
+        const skillList = this.getNamedList(skills?.skill, skills?.group);
+        const powerList = this.getNamedList(powers?.power, optionalPowers);
 
-        const allPowers = await IH.findItems('Critter_Power', powerList);
+        const allSkills = await IH.findItems('Skill', skillList);
         const allQualities = await IH.findItems('Quality', qualityList);
-        const spiritName = name._TEXT;
+        const allPowers = await IH.findItems('Critter_Power', powerList);
 
+        const spiritName = name._TEXT;
         return [
+            ...this.getMetatypeItems(allSkills, skills?.skill, { type: 'Skill', critter: spiritName }),
             ...this.getMetatypeItems(allPowers, powers?.power, { type: 'Power', critter: spiritName }),
-            ...this.getMetatypeItems(allQualities, qualities?.positive?.quality, { type: 'Power', critter: spiritName }),
-            ...this.getMetatypeItems(allQualities, qualities?.negative?.quality, { type: 'Power', critter: spiritName }),
-            ...this.getMetatypeItems(allPowers, optionalpowers?.optionalpower, { type: 'Optional Power', critter: spiritName }),
+            ...this.getMetatypeItems(allQualities, qualities, { type: 'Quality', critter: spiritName }),
+            ...this.getMetatypeItems(allSkills, skills?.group, { type: 'Skill Group', critter: spiritName }),
+            ...this.getMetatypeItems(allPowers, optionalPowers, { type: 'Optional Power', critter: spiritName }),
         ];
     }
 

--- a/src/module/apps/itemImport/parser/metatype/SpriteParser.ts
+++ b/src/module/apps/itemImport/parser/metatype/SpriteParser.ts
@@ -15,15 +15,24 @@ export class SpriteParser extends MetatypeParserBase<'sprite'> {
     }
 
     protected override async getItems(jsonData: Metatype): Promise<Item.Source[]> {
-        const optionalpowers = jsonData.bonus?.optionalpowers;
-        const powers = [...IH.getArray(jsonData.powers?.power), ...IH.getArray(optionalpowers?.optionalpower)].map(i => i._TEXT);
+        const { skills, name, powers } = jsonData;
+        const optionalPowers = this.mergeLists(
+            jsonData.optionalpowers?.optionalpower,
+            jsonData.bonus?.optionalpowers?.optionalpower
+        );
 
-        const allPowers = await IH.findItems('Critter_Power', powers);
-        const name = jsonData.name._TEXT;
+        const powerList = this.getNamedList(powers?.power, optionalPowers);
+        const skillList = this.getNamedList(skills?.skill, skills?.group);
 
+        const allSkills = await IH.findItems('Skill', skillList);
+        const allPowers = await IH.findItems('Critter_Power', powerList);
+
+        const spriteName = name._TEXT;
         return [
-            ...this.getMetatypeItems(allPowers, jsonData.powers?.power, { type: 'Power', critter: name }),
-            ...this.getMetatypeItems(allPowers, optionalpowers?.optionalpower, { type: 'Optional Power', critter: name }),
+            ...this.getMetatypeItems(allSkills, skills?.skill, { type: 'Skill', critter: spriteName }),
+            ...this.getMetatypeItems(allPowers, powers?.power, { type: 'Power', critter: spriteName }),
+            ...this.getMetatypeItems(allSkills, skills?.group, { type: 'Skill Group', critter: spriteName }),
+            ...this.getMetatypeItems(allPowers, optionalPowers, { type: 'Optional Power', critter: spriteName }),
         ];
     }
 

--- a/src/module/apps/itemImport/parser/misc/SkillGroupParser.ts
+++ b/src/module/apps/itemImport/parser/misc/SkillGroupParser.ts
@@ -1,0 +1,44 @@
+import { Parser } from '../Parser';
+import { SkillGroup } from '../Types';
+import { CompendiumKey } from '../../importer/Constants';
+import { ImportHelper as IH } from '../../helper/ImportHelper';
+
+const normalizeGroupName = (name: string) => name.trim().toLowerCase();
+
+export class SkillGroupParser extends Parser<'skill'> {
+    protected readonly parseType = 'skill';
+
+    constructor(
+        private readonly groupMembersByName: Map<string, string[]>,
+        private readonly existingGroups: Item.Stored<'skill'>[]
+    ) {
+        super();
+    }
+
+    override async Parse(jsonData: SkillGroup, compendiumKey: CompendiumKey) {
+        const item = await super.Parse(jsonData, compendiumKey) as Item.Stored<'skill'>;
+
+        const existing = this.existingGroups.find(i => i.name === jsonData.name._TEXT);
+
+        if (existing) {
+            item.img = existing.img;
+        }
+
+        return item as Item.CreateData;
+    }
+
+    protected override getSystem(jsonData: SkillGroup) {
+        const system = this.getBaseSystem();
+        const groupName = jsonData.name._TEXT;
+        const groupKey = normalizeGroupName(groupName);
+
+        system.type = 'group';
+        system.group.skills = [...(this.groupMembersByName.get(groupKey) ?? [])];
+
+        return system;
+    }
+
+    protected override async getFolder(_jsonData: SkillGroup, compendiumKey: CompendiumKey): Promise<Folder> {
+        return IH.getFolder(compendiumKey, 'Skills (Group)');
+    }
+}

--- a/src/module/apps/itemImport/schema/SkillsSchema.ts
+++ b/src/module/apps/itemImport/schema/SkillsSchema.ts
@@ -32,7 +32,7 @@ export interface SkillsSchema {
         skill: Many<Skill>;
     };
     skillgroups: {
-        name: Many<{ _TEXT: string; }>;
+        name: Many<{ _TEXT: string; $?: { translate: string; }; }>;
     };
     skills: {
         skill: Many<Skill>;

--- a/src/unittests/sr5.AttackTests.spec.ts
+++ b/src/unittests/sr5.AttackTests.spec.ts
@@ -470,27 +470,6 @@ export const shadowrunAttackTesting = (context: QuenchBatchContext) => {
                 assert.strictEqual(normalArmor?.value, 6);
                 assert.strictEqual(hardenedArmor?.value, 16);
             });
-
-            it("does not add zero-value normal or hardened pool contributors", async () => {
-                const actor = await factory.createActor({ type: 'character' });
-                const action = DataDefaults.createData('action_roll', {
-                    test: 'PhysicalResistTest',
-                    armor: true,
-                    attribute: 'body',
-                });
-
-                const test = await TestCreator.fromAction(action, actor, { showDialog: false, showMessage: false });
-                if (!test) return assert.fail('Failed to create PhysicalResistTest');
-
-                test.prepareBaseValues();
-                test.calculateBaseValues();
-
-                const normalArmor = test.pool.changes.find(change => change.name === 'SR5.Armor.label');
-                const hardenedArmor = test.pool.changes.find(change => change.name === 'SR5.HardenedArmor');
-
-                assert.isUndefined(normalArmor);
-                assert.isUndefined(hardenedArmor);
-            });
         });
     });
 };

--- a/src/unittests/sr5.Testing.spec.ts
+++ b/src/unittests/sr5.Testing.spec.ts
@@ -109,6 +109,7 @@ export const shadowrunTesting = (context: QuenchBatchContext) => {
         });
 
         it('stores code term traces for labeled pool and limit parts', async () => {
+            window.doNotPopulateDefaultSkills = true;
             const actor = await factory.createActor({
                 type: 'character',
                 system: {
@@ -118,13 +119,25 @@ export const shadowrunTesting = (context: QuenchBatchContext) => {
                         strength: { base: 3 },
                         reaction: { base: 3 }
                     },
-                    skills: {
-                        active: {
-                            archery: { base: 4 }
+                }
+            });
+
+            await actor.createEmbeddedDocuments('Item', [
+                {
+                    type: 'skill',
+                    name: 'Archery',
+                    system: {
+                        type: 'skill',
+                        skill: {
+                            attribute: 'agility',
+                            rating: 4
                         }
                     }
                 }
-            });
+            ]);
+            
+            delete window.doNotPopulateDefaultSkills;
+
 
             const action = DataDefaults.createData('action_roll', {
                 test: 'SuccessTest',
@@ -148,7 +161,7 @@ export const shadowrunTesting = (context: QuenchBatchContext) => {
             if (!traces) assert.fail('Expected code term traces to be present');
             if (!traces) return;
 
-            assert.isAtLeast(traces.length, 4);
+            assert.isAtLeast(traces.length, 3);
 
             assert.isTrue(traces.every(trace => {
                 return typeof trace.tooltipSource === 'string'

--- a/utils/generate_schemas.py
+++ b/utils/generate_schemas.py
@@ -19,7 +19,7 @@ from io import BytesIO
 # Repository details for fetching XML files if no local path is provided
 OWNER = "chummer5a"
 REPO = "chummer5a"
-BRANCH = "3e0520c06b8e393b500cfac8c951e8be28a24046"  # v5.255.1049
+BRANCH = "0c354ec2b81da5ccd2c93648f93ec8f6831c030e"  # v5.256.0
 
 # String length threshold for inline union literals
 STRING_LIMIT = 100
@@ -192,7 +192,7 @@ def qname(el: etree._Element) -> str:
 def add_custom_fields(struct: Structure) -> None:
     """Adds synthetic fields like 'translate' to specific elements."""
     for path, info in struct.items():
-        if path.endswith("/categories/category") or path.endswith("/modcategories/category"):
+        if path.endswith("/categories/category") or path.endswith("/skillgroups/name") or path.endswith("/modcategories/category"):
             if 'translate' not in info.attrs:
                 info.attrs['translate'] = (0, [])  # (count, samples)
 


### PR DESCRIPTION
## Summary
- Bulk-imported critters, spirits, and sprites now receive their active skills, skill groups, and knowledge skills as actual skill items. The metatype parsers previously wrote to `system.skills`, which is no longer the source of truth, so nothing landed on the imported actor.
- Skill groups are now generated as `system.type = 'group'` items in the misc compendium via a new `SkillGroupParser`, with members populated from each skill's `<skillgroup>` reference.
- `SkillImporter` now runs before `CritterImporter` so critter/spirit/sprite name lookups against `IH.nameToId.Skill` actually resolve.
- `MetatypeParserBase` gains shared `mergeLists` / `getNamedList` / `applyMovement` helpers and a `'skill' in system` branch in `getMetatypeItems` so rating + spec metadata from `<skill>` / `<group>` entries is applied to the cloned skill item.
- Critter knowledge skills are emitted as standalone skill items keyed off the Chummer `category`/`attribute` attributes.
- Drive-bys: fix spirit `SpiritPrep` skill keys (`spell_casting` → `spellcasting`, `blade` → `blades`)
- bump the bulk chummer5a snapshot to `v5.226.0`, there is not a significant difference in data, but it's a milestone.
