### PR TITLE
[BUG] Skill icons do not show up anymore with 0.34.0

### DIFF
--- a/src/module/migrator/Migrator.ts
+++ b/src/module/migrator/Migrator.ts
@@ -15,6 +15,7 @@ import { Version0_32_4 } from './versions/Version0_32_4';
 import { Version0_33_0 } from './versions/Version0_33_0';
 import { Version0_33_1 } from './versions/Version0_33_1';
 import { Version0_34_0 } from './versions/Version0_34_0';
+import { Version0_34_1 } from './versions/Version0_34_1';
 import { VersionMigration, MigratableDocument, MigratableDocumentName } from "./VersionMigration";
 const { deepClone } = foundry.utils;
 
@@ -56,6 +57,7 @@ export class Migrator {
         new Version0_33_0(),
         new Version0_33_1(),
         new Version0_34_0(),
+        new Version0_34_1(),
     ] as const;
 
     private static documentsToBeMigrated = 0;

--- a/src/module/migrator/Migrator.ts
+++ b/src/module/migrator/Migrator.ts
@@ -1,8 +1,8 @@
 import { FLAGS } from "../constants";
 import { Sanitizer } from "../sanitizer/Sanitizer";
 import { Version0_8_0 } from "./versions/Version0_8_0";
-import { Version0_18_0 } from './versions/Version0_18_0';
 import { Version0_16_0 } from './versions/Version0_16_0';
+import { Version0_18_0 } from './versions/Version0_18_0';
 import { Version0_27_0 } from './versions/Version0_27_0';
 import { Version0_30_0 } from './versions/Version0_30_0';
 import { Version0_30_3 } from './versions/Version0_30_3';
@@ -43,8 +43,8 @@ export class Migrator {
     // ⚠️ Keep this list sorted in ascending order by version number (oldest → newest).
     private static readonly s_Versions = [
         new Version0_8_0(),
-        new Version0_18_0(),
         new Version0_16_0(),
+        new Version0_18_0(),
         new Version0_27_0(),
         new Version0_30_0(),
         new Version0_30_3(),

--- a/src/module/migrator/versions/Version0_34_1.ts
+++ b/src/module/migrator/versions/Version0_34_1.ts
@@ -1,0 +1,57 @@
+import { VersionMigration } from '../VersionMigration';
+
+const SYSTEM_SKILL_ICON_DIRECTORIES = [
+    'systems/shadowrun5e/dist/icons/skills/',
+    'systems/shadowrun5e/dist/icons/groups/',
+] as const;
+
+type MigratingSkillItem = {
+    type?: unknown;
+    img?: unknown;
+    system?: {
+        type?: unknown;
+        source?: {
+            uuid?: unknown;
+        };
+    };
+};
+
+export class Version0_34_1 extends VersionMigration {
+    readonly TargetVersion = '0.34.1';
+
+    override handlesItem(item: Readonly<MigratingSkillItem>): boolean {
+        // Migration A) svg => webp
+        return this.shouldMigrateOwnedSkillIcon(item);
+    }
+
+    override migrateItem(item: MigratingSkillItem): void {
+        // Migration A) svg => webp
+        if (!this.shouldMigrateOwnedSkillIcon(item)) return;
+        item.img = this.migrateLegacyIconPath(item.img);
+    }
+
+    /**
+     * Migration A) svg => webp
+     * 
+     * Migrate actor-owned skill and skill-group icons sourced from system skill sets
+     * from legacy svg paths to webp.
+     */
+    private shouldMigrateOwnedSkillIcon(item: unknown): item is MigratingSkillItem & { img: string } {
+        if (!item || typeof item !== 'object') return false;
+
+        const candidate = item as MigratingSkillItem;
+        if (candidate.type !== 'skill') return false;
+
+        const skillType = candidate.system?.type;
+        if (skillType !== 'skill' && skillType !== 'group') return false;
+
+        const img = candidate.img;
+        if (typeof img !== 'string' || !img.endsWith('.svg')) return false;
+
+        return SYSTEM_SKILL_ICON_DIRECTORIES.some(directory => img.startsWith(directory));
+    }
+
+    private migrateLegacyIconPath(img: string): string {
+        return img.replace(/\.svg$/, '.webp');
+    }
+}

--- a/system.json
+++ b/system.json
@@ -21,7 +21,7 @@
         }
     ],
     "url": "#{URL}#",
-    "version": "0.34.0",
+    "version": "0.34.1",
     "compatibility": {
         "minimum": "13",
         "verified": "13.351",


### PR DESCRIPTION
Fixes #1884

Actors already migrated on 0.33.x still used svg icons, instead of the new webp icons added with 0.34.0