### PR TITLE
[BUG] Wrap document migration updates in try/catch

### DIFF
--- a/src/module/migrator/Migrator.ts
+++ b/src/module/migrator/Migrator.ts
@@ -264,7 +264,7 @@ export class Migrator {
     ) {
         this.updateProgressbar();
         try {
-            return cls.implementation.updateDocuments(
+            return await cls.implementation.updateDocuments(
                 docs.filter(d => d._stats?.systemVersion === this._migrationMark) as any,
                 { diff: false, recursive: false, parent: parent as any }
             );

--- a/src/module/migrator/Migrator.ts
+++ b/src/module/migrator/Migrator.ts
@@ -263,10 +263,15 @@ export class Migrator {
         parent: NonNullable<Parameters<Doc['implementation']['updateDocuments']>[1]>['parent'] = null
     ) {
         this.updateProgressbar();
-        return cls.implementation.updateDocuments(
-            docs.filter(d => d._stats?.systemVersion === this._migrationMark) as any,
-            { diff: false, recursive: false, parent: parent as any }
-        );
+        try {
+            return cls.implementation.updateDocuments(
+                docs.filter(d => d._stats?.systemVersion === this._migrationMark) as any,
+                { diff: false, recursive: false, parent: parent as any }
+            );
+        } catch (error) {
+            console.error(`Failed migration update for ${cls.documentName} documents (parent: ${parent?.uuid ?? 'none'}).`, error);
+            return [];
+        }
     }
 
     /**
@@ -309,10 +314,14 @@ export class Migrator {
         /* Tokens */
         for (const scene of game.scenes) {
             this.updateProgressbar();
-            await TokenDocument.implementation.updateDocuments(
-                scene.tokens.map(t => t.toObject()),
-                { diff: false, recursive: false, parent: scene }
-            );
+            try {
+                await TokenDocument.implementation.updateDocuments(
+                    scene.tokens.map(t => t.toObject()),
+                    { diff: false, recursive: false, parent: scene }
+                );
+            } catch (error) {
+                console.error(`Failed migration update for Token documents in ${scene.uuid}.`, error);
+            }
         }
 
         /* Finalize Migration */

--- a/src/module/migrator/Migrator.ts
+++ b/src/module/migrator/Migrator.ts
@@ -270,7 +270,6 @@ export class Migrator {
             );
         } catch (error) {
             console.error(`Failed migration update for ${cls.documentName} documents (parent: ${parent?.uuid ?? 'none'}).`, error);
-            return [];
         }
     }
 


### PR DESCRIPTION
So, if a documents fail to migrate for whatever reason, it doesn't stop the migration for others