### PR TITLE
[BUG] Reduce initiative label horizontal padding

### DIFF
--- a/src/css/foundry-chat-message.scss
+++ b/src/css/foundry-chat-message.scss
@@ -796,7 +796,7 @@
                 width: 25px;
                 text-align: center;
                 font-weight: 700;
-                padding: 0.1rem 0.4rem;
+                padding: 0.1rem;
                 border-radius: 0.25rem;
                 background: var(--sr5-card-surface-soft);
 


### PR DESCRIPTION
See:
<img width="302" height="429" alt="image" src="https://github.com/user-attachments/assets/00143fcd-3277-45cf-bd3b-36af305ec545" />
