### PR TITLE
[BUG] When placing a matrix mark on a grid connected device, the grid is marked instead

### DIFF
--- a/src/module/actor/flows/ActorMarksFlow.ts
+++ b/src/module/actor/flows/ActorMarksFlow.ts
@@ -68,6 +68,7 @@ export const ActorMarksFlow = {
         // CASES - TARGET IS AN ITEM
 
         // If the targeted devices is within a WAN, place mark on the host as well.
+        // See SR5#233 'PANS and WANS'
         if (target instanceof SR5Item && target.isSlave && !target.master?.isType('grid')) {
             const host = target.master;
             // taM Check this

--- a/src/module/actor/flows/ActorMarksFlow.ts
+++ b/src/module/actor/flows/ActorMarksFlow.ts
@@ -68,7 +68,7 @@ export const ActorMarksFlow = {
         // CASES - TARGET IS AN ITEM
 
         // If the targeted devices is within a WAN, place mark on the host as well.
-        if (target instanceof SR5Item && target.isSlave) {
+        if (target instanceof SR5Item && target.isSlave && !target.master?.isType('grid')) {
             const host = target.master;
             // taM Check this
             await persona.setMarks(host!, marks, options);

--- a/src/module/actor/sheets/SR5MatrixActorSheet.ts
+++ b/src/module/actor/sheets/SR5MatrixActorSheet.ts
@@ -568,7 +568,12 @@ export class SR5MatrixActorSheet<T extends MatrixActorSheetData = MatrixActorShe
                         selected: this.selectedMatrixTarget === persona.uuid,
                     });
                 }
+
+                continue;
             }
+
+            // Keep standalone marked icons visible even when they also add a network mark.
+            targets.push(target);
         }
 
         // Add additional sub-icons based on user wanting to see them.

--- a/src/module/item/flows/ItemMarksFlow.ts
+++ b/src/module/item/flows/ItemMarksFlow.ts
@@ -52,7 +52,7 @@ export const ItemMarksFlow = {
 
         if (!target?.uuid) return;
 
-        if (target.hasMaster) {
+        if (target.hasMaster && !target.master?.isType('grid')) {
             const master = target.master;
             if (master) await host.setMarks(master, marks, options);
         }

--- a/src/module/item/flows/ItemMarksFlow.ts
+++ b/src/module/item/flows/ItemMarksFlow.ts
@@ -37,6 +37,8 @@ export const ItemMarksFlow = {
 
     /**
      * Place a Matrix Mark for this Item.
+     * 
+     * See SR5#233 'PANS and WANS'
      *
      * @param host The matrix device that places the marks.
      * @param target The Document the marks are placed on. This can be an actor (character, technomancer, IC) OR an item (Host)

--- a/src/unittests/sr5.Marks.spec.ts
+++ b/src/unittests/sr5.Marks.spec.ts
@@ -71,5 +71,20 @@ export const shadowrunMarks = (context: QuenchBatchContext) => {
             correctMarks = decker.getMarksPlaced(device.uuid);
             assert.equal(correctMarks, 2);
         });
+
+        it('Should NOT mark the grid as well when placing marks on grid connected devices', async () => {
+            const decker = await factory.createActor({ type: 'character' });
+            const target = await factory.createItem({ type: 'equipment' });
+            const grid = await factory.createItem({ type: 'grid' });
+
+            await grid.addSlave(target);
+            await decker.setMarks(target, 2);
+
+            let correctMarks = decker.getMarksPlaced(target.uuid);
+            assert.equal(correctMarks, 2);
+
+            correctMarks = decker.getMarksPlaced(grid.uuid);
+            assert.equal(correctMarks, 0);
+        });
     });
 };


### PR DESCRIPTION
Fixes #1900

Issue was that network / device and master/slave have been mixed, however grids aren't masters of their slaves but only network providers. Marking a grid device won't mark the grid, while marking a host device will, as the host has a master / slave relation ship, while the grid doesn't.