### PR TITLE
[Bug] Fixes multiple matrix issues

### DIFF
--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -430,7 +430,13 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         // Assume each actor only has the one token.
         const deckerToken = this.getToken();
         const targetToken = persona.getToken();
-        if (!deckerToken || !targetToken) return false;
+        // No decker token, means sidebar actor is looking. Should see all token targets...
+        if (!deckerToken) return true;
+        // No target token, means somethig is broken, as we expect token personas here.
+        if (!targetToken) {
+            console.error(`Shadowrun5e | Persona ${persona.name} has no token, but is being checked for token visibility. This should not happen, as the persona parameter is expected to be taken from a token actor.`);
+            return false;
+        }
 
         // Compare host networks.
         if (persona.network?.isType('host') && persona.network.id !== this.network?.id) return false;
@@ -439,11 +445,8 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         const distance = Helpers.measureTokenDistance(deckerToken, targetToken);
         if (distance > 100) return false;
 
-        // TODO: Compare running silent with tokens that have been percieved through a matrix perception
-        // TODO: Compare running silent with tokens that have been found to have placed marks on this actor
-        return !targetMatrixData.running_silent;
+        return !persona.isRunningSilent();
     }
-
     getFullDefenseAttribute(this: SR5Actor): AttributeFieldType | undefined {
         if (this.isType('vehicle')) {
             return this.findVehicleStat('pilot');
@@ -685,6 +688,16 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         const matrixData = this.matrixData();
         if (!matrixData) return false;
         return matrixData.running_silent;
+    }
+
+    /**
+     * Is this technology item any kind of offline?
+     */
+    isOfflineIcon(): boolean {
+        // TODO: tamif - 1903 - vehicles, ic, technomancers, sprites
+        const matrixDevice = this.getMatrixDevice();
+        if (!matrixDevice) return true;
+        return matrixDevice.isOfflineIcon();
     }
 
     /**
@@ -1824,6 +1837,18 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
 
     hasWirelessDevices() {
         return this.wirelessDevices().length > 0;
+    }
+
+    /**
+     * Check if this persona has any other wireless devices outside of the main persona device.
+     */
+    hasNonPersonaWirelessDevices() {
+        const wirelessDevices = this.wirelessDevices();
+        if (!this.hasPersona) return false;
+        if (this.hasLivingPersona()) return wirelessDevices.length > 0;
+
+        const personaDevice = this.getMatrixDevice();
+        return wirelessDevices.some(device => device.id !== personaDevice?.id);
     }
 
     matrixData(this: SR5Actor) {

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -694,7 +694,8 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
      * Is this technology item any kind of offline?
      */
     isOfflineIcon(): boolean {
-        // TODO: tamif - 1903 - vehicles, ic, technomancers, sprites
+        if (this.isMatrixActor) return false;
+
         const matrixDevice = this.getMatrixDevice();
         if (!matrixDevice) return true;
         return matrixDevice.isOfflineIcon();

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -432,7 +432,7 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         const targetToken = persona.getToken();
         // No decker token, means sidebar actor is looking. Should see all token targets...
         if (!deckerToken) return true;
-        // No target token, means somethig is broken, as we expect token personas here.
+        // No target token, means something is broken, as we expect token personas here.
         if (!targetToken) {
             console.error(`Shadowrun5e | Persona ${persona.name} has no token, but is being checked for token visibility. This should not happen, as the persona parameter is expected to be taken from a token actor.`);
             return false;

--- a/src/module/flows/MatrixTargetingFlow.ts
+++ b/src/module/flows/MatrixTargetingFlow.ts
@@ -231,7 +231,7 @@ export const MatrixTargetingFlow = {
 
     /**
      * Given any icon, check if this icon is generally visible.
-     * @params icon The icon to check the visibility for.
+     * @param icon The icon to check the visibility for.
      */
     isIconVisible(icon: SR5Actor|SR5Item) {
         if (icon.isOfflineIcon()) return false;

--- a/src/module/flows/MatrixTargetingFlow.ts
+++ b/src/module/flows/MatrixTargetingFlow.ts
@@ -198,8 +198,8 @@ export const MatrixTargetingFlow = {
             }
         }
 
-        this._removeInvisibleIcons(targets);
         this._dedupeTargetsByDocumentUuid(targets);
+        this._removeInvisibleIcons(targets);
 
         // Sort all targets by grid name first and target name second.
         targets.sort((a, b) => {

--- a/src/module/flows/MatrixTargetingFlow.ts
+++ b/src/module/flows/MatrixTargetingFlow.ts
@@ -198,6 +198,7 @@ export const MatrixTargetingFlow = {
             }
         }
 
+        this._removeInvisibleIcons(targets);
         this._dedupeTargetsByDocumentUuid(targets);
 
         // Sort all targets by grid name first and target name second.
@@ -215,6 +216,28 @@ export const MatrixTargetingFlow = {
         });
 
         return targets;
+    },
+
+    /**
+     * Currently we show silent icons, whenever a persona has other online devices visible.
+     * @param targets List of any kind of icon targets.
+     */
+    _removeInvisibleIcons(targets: MatrixTargetDocument[]) {
+        for (let index = targets.length - 1; index >= 0; index -= 1) {
+            const target = targets[index].document;
+            if (!MatrixTargetingFlow.isIconVisible(target)) targets.splice(index, 1);
+        }
+    },
+
+    /**
+     * Given any icon, check if this icon is generally visible.
+     * @params icon The icon to check the visibility for.
+     */
+    isIconVisible(icon: SR5Actor|SR5Item) {
+        if (icon.isOfflineIcon()) return false;
+        if (icon instanceof SR5Actor && icon.isRunningSilent() && !icon.hasNonPersonaWirelessDevices()) return false;
+        if (icon instanceof SR5Item && icon.isRunningSilent()) return false;
+        return true;
     },
 
     /**

--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1291,6 +1291,12 @@ export class SR5Item<SubType extends Item.ConfiguredSubType = Item.ConfiguredSub
         return this.isType('host', 'grid');
     }
 
+    isOfflineIcon(): boolean {
+        const technologyData = this.getTechnologyData();
+        if (!technologyData) return false;
+        return technologyData.wireless === 'none' || technologyData.wireless === 'offline';
+    }
+
     /**
      * Determine if an item has taken Matrix Damage
      */


### PR DESCRIPTION
[BUG] Icons do not display for active matrix deckers when connected to grid. Might solve #1903
[BUG] Matrix persona icon list shows silent icons even if no other device icon is visible
 Fixes #1905
[BUG] Offline persone device is shown as displaying persona on character sheet indidactor Fixes #1906