### PR TITLE
[BUG] Vehicle category icon assignment in ActorImporter imports

### DIFF
--- a/src/module/apps/actorImport/itemImporter/vehicleImport/VehicleParser.ts
+++ b/src/module/apps/actorImport/itemImporter/vehicleImport/VehicleParser.ts
@@ -36,6 +36,10 @@ export class VehicleParser {
             const system = vehicleActorData.system;
             system.driver = actor.id!;
             system.isDrone = vehicle.isdrone === "True";
+            const categoryName = vehicle.category_english || vehicle.category || '';
+
+            if (system.isDrone)
+                system.category = categoryName.replace("Drones: ", "").toLowerCase() as typeof system.category;
 
             vehicleActorData.items = [
                 ...await new WeaponParser().parseWeapons(vehicle),
@@ -67,6 +71,13 @@ export class VehicleParser {
             system.attributes.body.base = Number(vehicle.body) || 0;
             system.armor.rating.base = Number(vehicle.armor) || 0;
             system.availability = vehicle.avail || '';
+
+            system.importFlags = {
+                isFreshImport: true,
+                sourceid: vehicle.sourceid || vehicle.guid || '',
+                category: categoryName,
+                name: vehicle.name || vehicle.name_english || vehicleActorData.name,
+            };
 
             const consoleLogs = Sanitizer.sanitize(CONFIG.Actor.dataModels.vehicle.schema, system);
             if (consoleLogs) {

--- a/src/unittests/actorImport/sr5.CharacterImporter.spec.ts
+++ b/src/unittests/actorImport/sr5.CharacterImporter.spec.ts
@@ -231,6 +231,8 @@ export const characterImporterTesting = (context: QuenchBatchContext) => {
             assert.strictEqual(vehicle.system.vehicle_stats.seats.value, 2, 'Seats');
             assert.strictEqual(vehicle.system.availability, '0', 'Availability');
             assert.strictEqual(vehicle.system.cost, 10000, 'Cost');
+            assert.strictEqual(vehicle.system.importFlags?.isFreshImport, true, 'Vehicle import flag');
+            assert.strictEqual(vehicle.system.importFlags?.category, 'Bikes', 'Vehicle category import flag');
 
             const nonSkillItems = vehicle.items.filter(item => !item.isType('skill'));
             assert.strictEqual(nonSkillItems.length, 2, 'Non-skill item count');


### PR DESCRIPTION
This fixes a mismatch where vehicles imported through `ActorImporter` were getting the default vehicle icon instead of their category-specific icon (while Bulk Importer behaved correctly).

## What changed
- Updated actor-import vehicle parsing to populate `system.importFlags` for imported vehicles.
- Added drone category normalization/mapping so imported drone categories align with expected internal values.
- Explicitly runs icon resolution for imported vehicle actor create data before creation.