### PR TITLE
[BUG] Action roll modes after Foundry V14 migration

### DIFF
--- a/src/module/apps/dialogs/TestDialog.ts
+++ b/src/module/apps/dialogs/TestDialog.ts
@@ -26,7 +26,7 @@ export interface TestDialogListener {
 interface TestDialogContext extends HandlebarsApplicationMixin.RenderContext {
     test: any;
     rollMode: string;
-    rollModes: CONFIG.Dice.RollModes;
+    rollModes: CONFIG.ChatMessage.modes;
     config: typeof SR5;
     expandedPaths: string[];
     dialogContent: string;
@@ -165,8 +165,8 @@ export class TestDialog extends HandlebarsApplicationMixin(ApplicationV2)<TestDi
         context.test = this.test;
         // @ts-expect-error TODO: fvtt - v14 - missing messageMode setting
         context.rollMode = this.test.data.options?.rollMode ?? game.settings.get('core', 'messageMode');
-        // TODO: fvtt - v14 - missing types for ChatMessage.modes
-        context.rollModes = (CONFIG.ChatMessage as unknown as { modes: typeof CONFIG.Dice.rollModes }).modes;
+        // TODO: fvtt-types - type CONFIG.ChatMessage.modes upstream once available
+        context.rollModes = (CONFIG.ChatMessage as unknown as { modes: CONFIG.ChatMessage.modes }).modes;
         context.config = SR5;
         context.expandedPaths = Array.from(this._expandedList);
         context.dialogContent = await foundry.applications.handlebars.renderTemplate(this.test._dialogTemplate, context as unknown as Record<string, unknown>);

--- a/src/module/combat/SR5Combat.ts
+++ b/src/module/combat/SR5Combat.ts
@@ -5,6 +5,7 @@ import { Migrator } from "../migrator/Migrator";
 import { CombatRules } from "../rules/CombatRules";
 import { FLAGS, SR, SYSTEM_NAME } from "../constants";
 import { SR5Die } from "../rolls/SR5Die";
+import { ChatMessageMode } from "../types/global";
 import SocketMessageData = Shadowrun.SocketMessageData;
 import BaseCombat = foundry.documents.BaseCombat;
 
@@ -387,9 +388,9 @@ export class SR5Combat extends Combat<"base"> {
         const combatantIds = Array.isArray(ids) ? ids : [ids];
         const updates: Combatant.UpdateData[] = [];
         const messageGroups = {
-            [CONST.DICE_ROLL_MODES.PUBLIC]: [] as InitiativeSummaryRow[],
-            [CONST.DICE_ROLL_MODES.PRIVATE]: [] as InitiativeSummaryRow[],
-        } satisfies Partial<Record<foundry.dice.Roll.Mode, InitiativeSummaryRow[]>>;
+            public: [] as InitiativeSummaryRow[],
+            gm: [] as InitiativeSummaryRow[],
+        } satisfies Partial<Record<ChatMessageMode, InitiativeSummaryRow[]>>;
 
         for (const id of combatantIds) {
             const combatant = this.combatants.get(id) as SR5Combatant | undefined;
@@ -404,7 +405,7 @@ export class SR5Combat extends Combat<"base"> {
 
             updates.push({ _id: id, initiative, system: { initiative: { blitz, last: lastInitiative } } });
 
-            const rollMode = CONST.DICE_ROLL_MODES[combatant.hidden ? 'PRIVATE' : 'PUBLIC'];
+            const rollMode: ChatMessageMode = combatant.hidden ? 'gm' : 'public';
             messageGroups[rollMode].push(this._buildInitiativeRow(combatant, initiative, roll));
         }
 
@@ -564,7 +565,7 @@ export class SR5Combat extends Combat<"base"> {
      * @param messageOptions - Base configuration options for the created ChatMessage documents.
      */
     private async _createInitiativeMessages(
-        messageGroups: Partial<Record<foundry.dice.Roll.Mode, InitiativeSummaryRow[]>>,
+        messageGroups: Partial<Record<ChatMessageMode, InitiativeSummaryRow[]>>,
         messageOptions: ChatMessage.CreateData,
     ) {
         let hasPlayedSound = false;

--- a/src/module/combat/SR5Combat.ts
+++ b/src/module/combat/SR5Combat.ts
@@ -405,7 +405,7 @@ export class SR5Combat extends Combat<"base"> {
 
             updates.push({ _id: id, initiative, system: { initiative: { blitz, last: lastInitiative } } });
 
-            const rollMode: ChatMessageMode = combatant.hidden ? 'gm' : 'public';
+            const rollMode = combatant.hidden ? 'gm' : 'public';
             messageGroups[rollMode].push(this._buildInitiativeRow(combatant, initiative, roll));
         }
 

--- a/src/module/combat/SR5Combatant.ts
+++ b/src/module/combat/SR5Combatant.ts
@@ -4,6 +4,7 @@ import { SR5Roll } from "../rolls/SR5Roll";
 import { Migrator } from "../migrator/Migrator";
 import { CombatRules } from "../rules/CombatRules";
 import { FLAGS, SR, SYSTEM_NAME } from "../constants";
+import { ChatMessageMode } from "../types/global";
 
 export type InitiativeModeOptions = 'meatspace' | 'astral' | 'cold_sim' | 'hot_sim';
 
@@ -180,7 +181,7 @@ export class SR5Combatant extends Combatant<"base"> {
             sound: hasDiceRoll ? CONFIG.sounds.dice : undefined,
         } as ChatMessage.CreateData;
 
-        const rollMode = CONST.DICE_ROLL_MODES[this.hidden ? 'PRIVATE' : 'PUBLIC'];
+        const rollMode: ChatMessageMode = this.hidden ? 'gm' : 'public';
         // @ts-expect-error - TODO: fvtt - v14 - missing settings typing
         ChatMessage.applyMode(messageData, rollMode);
 
@@ -191,7 +192,7 @@ export class SR5Combatant extends Combatant<"base"> {
 
     async playDSNInitiativeAnimation(
         roll: Roll,
-        rollMode: foundry.dice.Roll.Mode,
+        rollMode: ChatMessageMode,
         message: Pick<ChatMessage, 'id' | 'speaker' | 'whisper'>,
     ): Promise<boolean> {
         if (!game.modules.get('dice-so-nice')?.active || !game.dice3d) return false;
@@ -200,8 +201,8 @@ export class SR5Combatant extends Combatant<"base"> {
 
         const users = (message.whisper ?? []).filter((w): w is string => !!w);
         const whisper = users.length > 0 ? users : null;
-        const synchronize = rollMode === CONST.DICE_ROLL_MODES.PUBLIC || !!whisper;
-        const blind = rollMode === CONST.DICE_ROLL_MODES.BLIND;
+        const synchronize = rollMode === 'public' || !!whisper;
+        const blind = rollMode === 'blind';
         const activePlayers = this.players.find((user) => user.active);
         const rollUser = activePlayers ?? this.players[0] ?? game.user;
 

--- a/src/module/combat/SR5Combatant.ts
+++ b/src/module/combat/SR5Combatant.ts
@@ -181,7 +181,7 @@ export class SR5Combatant extends Combatant<"base"> {
             sound: hasDiceRoll ? CONFIG.sounds.dice : undefined,
         } as ChatMessage.CreateData;
 
-        const rollMode: ChatMessageMode = this.hidden ? 'gm' : 'public';
+        const rollMode = this.hidden ? 'gm' : 'public';
         // @ts-expect-error - TODO: fvtt - v14 - missing settings typing
         ChatMessage.applyMode(messageData, rollMode);
 

--- a/src/module/item/SR5ItemSheet.ts
+++ b/src/module/item/SR5ItemSheet.ts
@@ -460,8 +460,8 @@ export class SR5ItemSheet<T extends SR5BaseItemSheetData = SR5ItemSheetData> ext
             }
         }
 
-        // TODO: fvtt - v14 - missing types for ChatMessage.modes
-        data.rollModes = (CONFIG.ChatMessage as unknown as { modes: typeof CONFIG.Dice.rollModes }).modes;
+        // TODO: fvtt-types - type CONFIG.ChatMessage.modes upstream once available
+        data.rollModes = (CONFIG.ChatMessage as unknown as { modes: CONFIG.ChatMessage.modes }).modes;
 
         data.item = this.item;
 

--- a/src/module/migrator/Migrator.ts
+++ b/src/module/migrator/Migrator.ts
@@ -16,6 +16,7 @@ import { Version0_33_0 } from './versions/Version0_33_0';
 import { Version0_33_1 } from './versions/Version0_33_1';
 import { Version0_34_0 } from './versions/Version0_34_0';
 import { Version0_34_1 } from './versions/Version0_34_1';
+import { Version0_35_1 } from './versions/Version0_35_1';
 import { VersionMigration, MigratableDocument, MigratableDocumentName, MigratableDocumentType } from "./VersionMigration";
 
 const { deepClone, setProperty } = foundry.utils;
@@ -60,6 +61,7 @@ export class Migrator {
         new Version0_33_1(),
         new Version0_34_0(),
         new Version0_34_1(),
+        new Version0_35_1(),
     ] as const;
 
     private static documentsToBeMigrated = 0;

--- a/src/module/migrator/versions/Version0_35_1.ts
+++ b/src/module/migrator/versions/Version0_35_1.ts
@@ -27,7 +27,7 @@ export class Version0_35_1 extends VersionMigration {
         const rollMode = getProperty(item, 'system.action.roll_mode') as string;
 
         if (rollMode in LEGACY_ROLL_MODE_MAP) {
-            setProperty(item, 'system.action.roll_mode', LEGACY_ROLL_MODE_MAP[rollMode] || '');
+            setProperty(item, 'system.action.roll_mode', LEGACY_ROLL_MODE_MAP[rollMode]);
         }
     }
 }

--- a/src/module/migrator/versions/Version0_35_1.ts
+++ b/src/module/migrator/versions/Version0_35_1.ts
@@ -1,0 +1,33 @@
+import { VersionMigration } from '../VersionMigration';
+
+const { setProperty, getProperty } = foundry.utils;
+
+const LEGACY_ROLL_MODE_MAP = {
+    publicroll: 'public',
+    gmroll: 'gm',
+    blindroll: 'blind',
+    selfroll: 'self',
+} as const;
+
+/**
+ * Migration for version 0.35.1:
+ *
+ * Fix action `system.action.roll_mode` values that still use legacy
+ * Foundry roll mode keys after the V14 chat mode migration.
+ */
+export class Version0_35_1 extends VersionMigration {
+    readonly TargetVersion = '0.35.1';
+
+    override handlesItem(item: Readonly<any>): boolean {
+        const rollMode = getProperty(item, 'system.action.roll_mode');
+        return typeof rollMode === 'string' && rollMode in LEGACY_ROLL_MODE_MAP;
+    }
+
+    override migrateItem(item: any): void {
+        const rollMode = getProperty(item, 'system.action.roll_mode') as string;
+
+        if (rollMode in LEGACY_ROLL_MODE_MAP) {
+            setProperty(item, 'system.action.roll_mode', LEGACY_ROLL_MODE_MAP[rollMode] || '');
+        }
+    }
+}

--- a/src/module/tests/SuccessTest.ts
+++ b/src/module/tests/SuccessTest.ts
@@ -24,6 +24,7 @@ import { Translation } from '../utils/strings';
 import { GmOnlyMessageContentFlow } from '../actor/flows/GmOnlyMessageContentFlow';
 import { ActionResultType, ActionRollType, DamageType, MinimalActionType, OpposedTestType, ResultActionType } from '../types/item/Action';
 import { ValueFieldType } from '../types/template/Base';
+import { ChatMessageMode } from '../types/global';
 import { DeepPartial } from "fvtt-types/utils";
 export interface TestDocuments {
     // Legacy field that used be the source document.
@@ -130,7 +131,7 @@ export interface SuccessTestData extends TestData {
 export interface TestOptions {
     showDialog?: boolean // Show dialog when defined as true.
     showMessage?: boolean // Show message when defined as true.
-    rollMode?: foundry.dice.Roll.Mode
+    rollMode?: ChatMessageMode
 }
 
 export interface SuccessTestMessageData {
@@ -289,11 +290,11 @@ export class SuccessTest<T extends SuccessTestData = SuccessTestData> {
      * The tests roll mode can be given by specific option, action setting or global configuration.
      * @param options The test options for the whole test
      */
-    _prepareRollMode(data, options: TestOptions): foundry.dice.Roll.Mode {
+    _prepareRollMode(data, options: TestOptions): ChatMessageMode {
         if (options.rollMode != null) return options.rollMode;
-        if (data?.action?.roll_mode) return data.action.roll_mode;
+        if (data?.action?.roll_mode) return data.action.roll_mode as ChatMessageMode;
         // @ts-expect-error TODO: fvtt - v14 - missing settings typing
-        else return game.settings.get(CORE_NAME, 'messageMode') as foundry.dice.Roll.Mode;
+        else return game.settings.get(CORE_NAME, 'messageMode') as ChatMessageMode;
     }
 
     /**
@@ -1738,14 +1739,16 @@ export class SuccessTest<T extends SuccessTestData = SuccessTestData> {
             whisper = game.users.filter(user => this.actor?.testUserPermission(user, 'OWNER') === true);
         }
 
+        const rollMode = this.data.options?.rollMode;
+
         // ...for rollMode include GM when GM roll
-        if (this.data.options?.rollMode === 'gmroll' || this.data.options?.rollMode === "blindroll") {
+        if (rollMode === 'gm' || rollMode === "blind") {
             whisper = [...game.users.filter(user => user.isGM), ...(whisper || [])];
         }
 
         // Don't show dice to a user casting blind.
-        const blind = this.data.options?.rollMode === 'blindroll';
-        const synchronize = this.data.options?.rollMode === 'publicroll';
+        const blind = rollMode === 'blind';
+        const synchronize = rollMode === 'public';
 
         void dice3d.showForRoll(roll, game.user, synchronize, whisper, blind, this.data.messageUuid);
     }
@@ -1909,9 +1912,9 @@ export class SuccessTest<T extends SuccessTestData = SuccessTestData> {
     /**
      * What ChatMessage rollMode is this test supposed to use?
      */
-    get _rollMode(): string {
+    get _rollMode(): ChatMessageMode {
         // @ts-expect-error - TODO: fvtt - v14 - missing settings typing
-        return this.data.options?.rollMode as string ?? game.settings.get('core', 'messageMode');
+        return this.data.options?.rollMode ?? game.settings.get('core', 'messageMode') as ChatMessageMode;
     }
 
     /**

--- a/src/module/tests/SuccessTest.ts
+++ b/src/module/tests/SuccessTest.ts
@@ -1748,7 +1748,7 @@ export class SuccessTest<T extends SuccessTestData = SuccessTestData> {
 
         // Don't show dice to a user casting blind.
         const blind = rollMode === 'blind';
-        const synchronize = rollMode === 'public';
+        const synchronize = rollMode === 'public' || rollMode === 'ic';
 
         void dice3d.showForRoll(roll, game.user, synchronize, whisper, blind, this.data.messageUuid);
     }

--- a/src/module/types/global.ts
+++ b/src/module/types/global.ts
@@ -58,11 +58,24 @@ import ThermographicVisionDetectionMode from "../vision/thermographicVision/ther
 import { DiceSoNice } from "../rolls/DiceSoNice";
 import { Skill } from "./item/Skill";
 
+export type ChatMessageMode = keyof CONFIG.ChatMessage.modes;
+
 declare module "fvtt-types/configuration" {
     namespace CONFIG {
-        // TODO: fvtt - v14 - missing types for ChatMessage.modes
+        interface ChatMessageModeConfig {
+            label: string;
+            icon: string;
+            handler?: (chatData: object) => unknown;
+        }
+
         namespace ChatMessage {
-            type modes = CONFIG.Dice.RollModes;
+            type modes = {
+                public: CONFIG.ChatMessageModeConfig;
+                gm: CONFIG.ChatMessageModeConfig;
+                blind: CONFIG.ChatMessageModeConfig;
+                self: CONFIG.ChatMessageModeConfig;
+                ic: CONFIG.ChatMessageModeConfig;
+            };
         }
     }
 

--- a/src/module/types/item/Action.ts
+++ b/src/module/types/item/Action.ts
@@ -173,8 +173,8 @@ export const ActionRollData = (
     roll_mode: new StringField({
         blank: true,
         required: true,
-        // TODO: fvtt - v14 - missing types for ChatMessage.modes
-        choices: (CONFIG.ChatMessage as unknown as { modes: typeof CONFIG.Dice.rollModes }).modes,
+        // TODO: fvtt-types - type CONFIG.ChatMessage.modes upstream once available
+        choices: (CONFIG.ChatMessage as unknown as { modes: CONFIG.ChatMessage.modes }).modes,
     }),
 });
 

--- a/system.json
+++ b/system.json
@@ -21,7 +21,7 @@
         }
     ],
     "url": "#{URL}#",
-    "version": "0.35.0",
+    "version": "0.35.1",
     "compatibility": {
         "minimum": "14",
         "verified": "14.363",


### PR DESCRIPTION
## Summary
- Add a 0.35.1 migration for action `system.action.roll_mode`
- Remap legacy roll mode keys to Foundry V14 chat message mode keys
- Update V14 roll mode typings and remaining runtime checks to use `public`, `gm`, `blind`, `self`, and `ic`
- Bump the system version to 0.35.1

## Details
Foundry V14 replaced legacy dice roll mode keys like `publicroll`, `gmroll`, `blindroll`, and `selfroll` with chat message mode keys like `public`, `gm`, `blind`, and `self`.

The previous migration updated the schema choices to `CONFIG.ChatMessage.modes`, but existing action data could still contain the old keys. This caused `action.roll_mode` values to no longer match the Action DataSchema choices.