### PR TITLE
Add Interrupt action type and initiative modifier field

### DIFF
--- a/public/locale/de/config.json
+++ b/public/locale/de/config.json
@@ -115,12 +115,15 @@
             "SpellRitual": "Spruchzauberei Ritual",
             "Summoning": "BeschwörungsHandlungen"
         },
-        "ActionType": "Handlung",
-        "ActionTypeComplex": "Komplexe",
-        "ActionTypeFree": "Freie",
-        "ActionTypeNone": "Keine",
-        "ActionTypeSimple": "Einfache",
-        "ActionTypeVaries": "Variiert",
+        "ActionType": {
+            "Label": "Handlung",
+            "Complex": "Komplexe",
+            "Free": "Freie",
+            "Interrupt": "Interrupt",
+            "None": "Keine",
+            "Simple": "Einfache",
+            "Varies": "Variiert"
+        },
         "Actions": "Aktionen",
         "Active": "Aktiv",
         "ActiveDefense": "Unterbrechungsh.",
@@ -1280,6 +1283,7 @@
         "InitCatMeatspace": "Fleischwelt-Initiative",
         "Initiation": "Initiation",
         "Initiative": "Initiative",
+        "InitiativeMod": "Initiativmodifikator",
         "Internal": "Intern",
         "InventoryRename": {
             "Cancel": "Abbrechen",
@@ -1361,6 +1365,10 @@
                     "extended": {
                         "hint": "Ist diese Aktion Teil einer Ausgedehnten Probe?",
                         "label": "Ausgedehnte Probe"
+                    },
+                    "initiative_mod": {
+                        "hint": "Initiativmodifikator, der beim Ausführen dieser Aktion angewendet wird",
+                        "label": "Initiativmodifikator"
                     },
                     "limit": {
                         "attribute": {

--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -117,12 +117,15 @@
             "SpellRitual": "Spellcasting Ritual",
             "Summoning": "Summoning Actions"
         },
-        "ActionType": "Type",
-        "ActionTypeComplex": "Complex",
-        "ActionTypeFree": "Free",
-        "ActionTypeNone": "None",
-        "ActionTypeSimple": "Simple",
-        "ActionTypeVaries": "Varies",
+        "ActionType": {
+            "Label": "Type",
+            "Complex": "Complex",
+            "Free": "Free",
+            "Interrupt": "Interrupt",
+            "None": "None",
+            "Simple": "Simple",
+            "Varies": "Varies"
+        },
         "Actions": "Actions",
         "Active": "Active",
         "ActiveDefense": "Active Defense",
@@ -1281,6 +1284,7 @@
         "InitCatMeatspace": "Meatspace",
         "Initiation": "Initiation",
         "Initiative": "Initiative",
+        "InitiativeMod": "Initiative Modifier",
         "Internal": "Internal",
         "InventoryRename": {
             "Cancel": "Cancel",
@@ -1362,6 +1366,10 @@
                     "extended": {
                         "hint": "If this is an Extended Test",
                         "label": "Extended Test"
+                    },
+                    "initiative_mod": {
+                        "hint": "Initiative modifier applied when taking this action",
+                        "label": "Initiative Modifier"
                     },
                     "limit": {
                         "attribute": {

--- a/public/locale/fr/config.json
+++ b/public/locale/fr/config.json
@@ -37,12 +37,15 @@
         "Accessory": "Accessoire",
         "Accuracy": "Précision",
         "Action": "Action",
-        "ActionType": "Type",
-        "ActionTypeComplex": "Complexe",
-        "ActionTypeFree": "Gratuite",
-        "ActionTypeNone": "Aucune",
-        "ActionTypeSimple": "Simple",
-        "ActionTypeVaries": "Variée",
+        "ActionType": {
+            "Label": "Type",
+            "Complex": "Complexe",
+            "Free": "Gratuite",
+            "Interrupt": "Interrupt",
+            "None": "Aucune",
+            "Simple": "Simple",
+            "Varies": "Variée"
+        },
         "Actions": "Actions",
         "Active": "Active",
         "ActiveDefense": "Défense active",
@@ -398,6 +401,7 @@
         "InitCatMatrix": "Matrice",
         "InitCatMeatspace": "Terrestre",
         "Initiative": "Initiative",
+        "InitiativeMod": "Modificateur d'Initiative",
         "Internal": "Interne",
         "IsCritter": "Créature",
         "IsGrunt": "Brute",
@@ -410,6 +414,10 @@
                             "hint": "If this damage is considered a normal (non-magical) weapon attack",
                             "label": "Normal Weapon"
                         }
+                    },
+                    "initiative_mod": {
+                        "hint": "Modificateur d'initiative appliqué lors de l'exécution de cette action",
+                        "label": "Modificateur d'Initiative"
                     }
                 }
             }

--- a/public/locale/ko/config.json
+++ b/public/locale/ko/config.json
@@ -115,12 +115,15 @@
             "SpellRitual": "주문시전 의식",
             "Summoning": "소환 행동"
         },
-        "ActionType": "유형",
-        "ActionTypeComplex": "복잡",
-        "ActionTypeFree": "자유",
-        "ActionTypeNone": "없음",
-        "ActionTypeSimple": "단순",
-        "ActionTypeVaries": "다양",
+        "ActionType": {
+            "Label": "유형",
+            "Complex": "복잡",
+            "Free": "자유",
+            "Interrupt": "Interrupt",
+            "None": "없음",
+            "Simple": "단순",
+            "Varies": "다양"
+        },
         "Actions": "행동",
         "Active": "활성형",
         "ActiveDefense": "능동 방어",
@@ -1279,6 +1282,7 @@
         "InitCatMeatspace": "현실",
         "Initiation": "입회",
         "Initiative": "우선권",
+        "InitiativeMod": "우선권 수정치",
         "Internal": "내부",
         "InventoryRename": {
             "Cancel": "취소",
@@ -1360,6 +1364,10 @@
                     "extended": {
                         "hint": "연장 판정일 경우 선택",
                         "label": "연장 판정"
+                    },
+                    "initiative_mod": {
+                        "hint": "이 행동을 수행할 때 적용되는 우선권 수정치",
+                        "label": "우선권 수정치"
                     },
                     "limit": {
                         "attribute": {

--- a/public/locale/pt-BR/config.json
+++ b/public/locale/pt-BR/config.json
@@ -106,12 +106,15 @@
             "SpellRitual": "Magia Ritual",
             "Summoning": "Ações de Invocação"
         },
-        "ActionType": "Tipo",
-        "ActionTypeComplex": "Complexa",
-        "ActionTypeFree": "Livre",
-        "ActionTypeNone": "Nenhuma",
-        "ActionTypeSimple": "Simples",
-        "ActionTypeVaries": "Variada",
+        "ActionType": {
+            "Label": "Tipo",
+            "Complex": "Complexa",
+            "Free": "Livre",
+            "Interrupt": "Interrupt",
+            "None": "Nenhuma",
+            "Simple": "Simples",
+            "Varies": "Variada"
+        },
         "Actions": "Ações",
         "Active": "Ativo",
         "ActiveDefense": "Defesa Ativa",
@@ -641,6 +644,7 @@
         "InitCatMeatspace": "Espaço Real",
         "Initiation": "Iniciação",
         "Initiative": "Iniciativa",
+        "InitiativeMod": "Modificador de Iniciativa",
         "Internal": "Interno",
         "IsCritter": "Criatura",
         "IsFreshImport": "Este item foi importado do Chummer e precisa de revisão manual.",
@@ -654,6 +658,10 @@
                             "hint": "If this damage is considered a normal (non-magical) weapon attack",
                             "label": "Normal Weapon"
                         }
+                    },
+                    "initiative_mod": {
+                        "hint": "Modificador de iniciativa aplicado ao realizar esta ação",
+                        "label": "Modificador de Iniciativa"
                     }
                 }
             }

--- a/src/module/apps/itemImport/parser/misc/ActionParser.ts
+++ b/src/module/apps/itemImport/parser/misc/ActionParser.ts
@@ -53,6 +53,8 @@ export class ActionParser extends Parser<'action'> {
         action.type = jsonData.type._TEXT.toLowerCase() as ActionRollType['type'];
         action.extended = jsonData.type._TEXT === "Extended";
         description.value = jsonData.test?.bonusstring?._TEXT ?? "";
+        if (jsonData.initiativecost?._TEXT)
+            action.initiative_mod = -Number(jsonData.initiativecost._TEXT);
 
         // 2. Parse the test dice pools if they exist
         if (jsonData.test) {

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -714,11 +714,12 @@ export const SR5 = {
     },
 
     actionTypes: {
-        none: 'SR5.ActionTypeNone',
-        free: 'SR5.ActionTypeFree',
-        simple: 'SR5.ActionTypeSimple',
-        complex: 'SR5.ActionTypeComplex',
-        varies: 'SR5.ActionTypeVaries',
+        none: 'SR5.ActionType.None',
+        free: 'SR5.ActionType.Free',
+        simple: 'SR5.ActionType.Simple',
+        complex: 'SR5.ActionType.Complex',
+        interrupt: 'SR5.ActionType.Interrupt',
+        varies: 'SR5.ActionType.Varies',
     },
 
     // Use within action damage calculation (base <operator> attribute) => value

--- a/src/module/item/flows/ActionResultFlow.ts
+++ b/src/module/item/flows/ActionResultFlow.ts
@@ -56,10 +56,15 @@ export class ActionResultFlow {
         if (!test) return;
 
         await test.populateDocuments();
-        // NOTE: Use test data typing here, as including PhysicalDefenseTest would cause circular dependencies, breaking SuccessTest/OpposedTest import order.
+        // NOTE: Use test data typing here, as including PhysicalDefenseTest would
+        // cause circular dependencies, breaking SuccessTest/OpposedTest import order.
         const data = test.data as PhysicalDefenseTestData;
-        if (!data.iniMod) return;
-        await test.actor?.changeCombatInitiative(data.iniMod);
+
+        // DefenseTests store the active defense modifier in iniMod,
+        // while Interrupt/Varies actions store it on the action itself.
+        const iniMod = data.iniMod ?? data.action?.initiative_mod;
+        if (!iniMod) return;
+        await test.actor?.changeCombatInitiative(iniMod);
     }
 
     /**

--- a/src/module/tests/DefenseTest.ts
+++ b/src/module/tests/DefenseTest.ts
@@ -145,7 +145,7 @@ export class DefenseTest<T extends DefenseTestData = DefenseTestData> extends Op
 
         actions.push({
             action: 'modifyCombatantInit',
-            label: 'SR5.Initiative',
+            label: 'SR5.InitiativeMod',
             value: String(activeDefense.initMod)
         });
 

--- a/src/module/tests/SuccessTest.ts
+++ b/src/module/tests/SuccessTest.ts
@@ -1903,6 +1903,18 @@ export class SuccessTest<T extends SuccessTestData = SuccessTestData> {
      */
     _prepareResultActionsTemplateData(): ResultActionType[] {
         const actions: ResultActionType[] = [];
+
+        // Interrupt/Varies actions carry an initiative modifier that can be applied to the combatant.
+        const actionType = this.data.action?.type;
+        const initiativeMod = this.data.action?.initiative_mod;
+        if (initiativeMod && (actionType === 'interrupt' || actionType === 'varies')) {
+            actions.push({
+                action: 'modifyCombatantInit',
+                label: 'SR5.InitiativeMod',
+                value: String(initiativeMod)
+            });
+        }
+
         const actionResultData = this.results;
         if (!actionResultData) return actions;
 

--- a/src/module/types/item/Action.ts
+++ b/src/module/types/item/Action.ts
@@ -143,6 +143,7 @@ export const ActionRollData = (
     ...MinimalActionData(),
     test: new StringField({ required: true, initial: test }),
     type: new StringField({ required: true, initial: type, blank: true, choices: SR5.actionTypes }),
+    initiative_mod: new NumberField({ required: true, nullable: false, integer: true, initial: 0 }),
     category: new SchemaField(ActionCategory()),
     categories: new TagifyAltField(new StringField({ required: true })),
     spec: new BooleanField(),

--- a/src/templates/rolls/success-test-message.hbs
+++ b/src/templates/rolls/success-test-message.hbs
@@ -352,12 +352,11 @@
             <div class="test-value metric-row">
                 <span class="value">{{localize this.label}}:</span>
                 <span class="value-result">
-                    <span class="button result-action" data-action="{{this.action}}">{{this.value}}</span>
+                    <span class="button result-action" data-action="{{this.action}}">{{signedValue this.value}}</span>
                 </span>
             </div>
             {{/each}}
         </div>
-        <div class="right-side"></div>
     </div>
     {{/if}}
 </div>

--- a/src/templates/v2/item/tabs/details.hbs
+++ b/src/templates/v2/item/tabs/details.hbs
@@ -559,6 +559,17 @@
                             </label>
                         </div>
                     </div>
+                    {{#if (or (eq system.action.type 'interrupt') (eq system.action.type 'varies'))}}
+                        <div class="list-item">
+                            <div class="list-item-start skinny">
+                                <label data-tooltip="{{systemFields.action.fields.initiative_mod.hint}}">{{systemFields.action.fields.initiative_mod.label}}</label>
+                            </div>
+                            <div class="list-item-col">
+                                {{formInput systemFields.action.fields.initiative_mod value=source.system.action.initiative_mod
+                                            classes="short" rootId=@root.rootId disabled=@root.isPlayMode}}
+                            </div>
+                        </div>
+                    {{/if}}
                     {{#if (isType item 'action' 'critter_power')}}
                         <div class="list-item">
                             <div class="list-item-start skinny">

--- a/src/templates/v2/list-items/action/header.hbs
+++ b/src/templates/v2/list-items/action/header.hbs
@@ -13,7 +13,7 @@
 
     <div class="list-item-col">
         <label>
-            {{localize "SR5.ActionType"}}
+            {{localize "SR5.ActionType.Label"}}
         </label>
     </div>
 


### PR DESCRIPTION
## Summary

- Adds **Interrupt** action type alongside the existing ones
- Adds **Initiative Modifier** field (`system.action.initiative_mod`) to actions, shown in the item sheet when type is `interrupt` or `varies`
- Roll cards show a clickable Initiative Modifier button (same pattern as active defense) that applies the modifier to the combat tracker
- `ActionResultFlow` reads `action.initiative_mod` as the initiative change source for interrupt/varies actions
- Bulk importer maps `<initiativecost>` from `actions.xml` to `initiative_mod` (negated)
- Restructured `SR5.ActionType` locale keys into a nested object

### Image
<img width="651" height="252" alt="image" src="https://github.com/user-attachments/assets/3055eae3-5284-43af-91f3-c09fe7106ee2" />
