### PR TITLE
[Internal] Fix SR5Item action test injection on create

### DIFF
--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -1543,13 +1543,13 @@ export class SR5Item<SubType extends Item.ConfiguredSubType = Item.ConfiguredSub
         return ItemRollDataFlow.getRollData(this, rollData, options);
     }
 
-    override async _onCreate(changed, options, user) {
-        const applyData = {};
-        UpdateActionFlow.injectActionTestsIntoChangeData(this.type, changed, applyData, this);
-        await super._preCreate(changed, options, user);
+    override async _preCreate(...args: Parameters<Item['_preCreate']>) {
+        const [data] = args;
+        const result = await super._preCreate(...args);
+        if (result === false) return false;
 
-        // Don't kill DocumentData by applying empty objects. Also performance.
-        if (!foundry.utils.isEmpty(applyData)) await this.update(applyData);
+        UpdateActionFlow.injectActionTestsIntoChangeData(this.type, data, data, this);
+        return result;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Replaces the incorrect `SR5Item._onCreate` override with `_preCreate`
- Injects action test data into create data before the item is persisted
- Avoids the extra post-create `this.update()` call
