### PR TITLE
[BUG] Fix direct combat spell resist tests

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -885,7 +885,7 @@ export const SR5 = {
     },
 
     /**
-     * Using different resist tests for the oppositing depending on active tests details
+     * Using different resist tests for the opposing depending on active tests details
      *  Structure: {
      *  [item.type]: {[item.system.type]}: 'OpposedTest'
      * }

--- a/src/module/item/flows/UpdateActionFlow.ts
+++ b/src/module/item/flows/UpdateActionFlow.ts
@@ -134,9 +134,11 @@ export const UpdateActionFlow = {
 
         // Based on category switch out active, opposed and resist test.
         const test = SR5.activeTests[type];
-        const opposedTest = SR5.opposedTests[type][changeData.system.category] || 'OpposedTest';
-        const resistTest = SR5.opposedResistTests[type][changeData.system.category] || '';
         const drainTest = SR5.followedTests[test] ?? '';
+        const opposedTest = SR5.opposedTests[type][changeData.system.category] || 'OpposedTest';
+
+        const isDirectCombatSpell = changeData.system.category === 'combat' && changeData.system.combat?.type === 'direct';
+        const resistTest = isDirectCombatSpell ? '' : SR5.opposedResistTests[type][changeData.system.category] || '';
 
         foundry.utils.setProperty(applyData, 'system.action.test', test);
         foundry.utils.setProperty(applyData, 'system.action.opposed.test', opposedTest);

--- a/src/module/migrator/Migrator.ts
+++ b/src/module/migrator/Migrator.ts
@@ -17,6 +17,7 @@ import { Version0_33_1 } from './versions/Version0_33_1';
 import { Version0_34_0 } from './versions/Version0_34_0';
 import { Version0_34_1 } from './versions/Version0_34_1';
 import { Version0_35_1 } from './versions/Version0_35_1';
+import { Version0_35_2 } from './versions/Version0_35_2';
 import { VersionMigration, MigratableDocument, MigratableDocumentName, MigratableDocumentType } from "./VersionMigration";
 
 const { deepClone, setProperty } = foundry.utils;
@@ -62,6 +63,7 @@ export class Migrator {
         new Version0_34_0(),
         new Version0_34_1(),
         new Version0_35_1(),
+        new Version0_35_2(),
     ] as const;
 
     private static documentsToBeMigrated = 0;

--- a/src/module/migrator/versions/Version0_35_2.ts
+++ b/src/module/migrator/versions/Version0_35_2.ts
@@ -1,0 +1,23 @@
+import { VersionMigration } from '../VersionMigration';
+
+const { getProperty, setProperty } = foundry.utils;
+
+/**
+ * Migration for version 0.35.2:
+ *
+ * Direct combat spells should not configure an opposed resist test.
+ */
+export class Version0_35_2 extends VersionMigration {
+    readonly TargetVersion = '0.35.2';
+
+    override handlesItem(item: Readonly<any>): boolean {
+        return item.type === 'spell'
+            && getProperty(item, 'system.category') === 'combat'
+            && getProperty(item, 'system.combat.type') === 'direct'
+            && getProperty(item, 'system.action.opposed.resist.test') !== '';
+    }
+
+    override migrateItem(item: any): void {
+        setProperty(item, 'system.action.opposed.resist.test', '');
+    }
+}

--- a/src/unittests/sr5.SR5Item.spec.ts
+++ b/src/unittests/sr5.SR5Item.spec.ts
@@ -45,11 +45,11 @@ export const shadowrunSR5Item = (context: QuenchBatchContext) => {
             it('Correctly add defense tests to spells', async () => {
                 const item = await factory.createItem({type: 'spell'});
 
-                await item.update({ system: { category: 'combat' } });
+                await item.update({ system: { category: 'combat', combat: { type: 'direct' } } });
                 assert.equal(item.system.action.test, 'SpellCastingTest');
                 assert.equal(item.system.action.followed.test, 'DrainTest');
                 assert.equal(item.system.action.opposed.test, 'CombatSpellDefenseTest');
-                assert.equal(item.system.action.opposed.resist.test, 'PhysicalResistTest');
+                assert.equal(item.system.action.opposed.resist.test, '');
 
                 await item.update({ system: { category: 'detection' } });
                 assert.equal(item.system.action.test, 'SpellCastingTest');

--- a/src/unittests/sr5.SR5Item.spec.ts
+++ b/src/unittests/sr5.SR5Item.spec.ts
@@ -42,7 +42,7 @@ export const shadowrunSR5Item = (context: QuenchBatchContext) => {
         });
 
         describe('Testing related data injection', () => {
-            it('Correctly add defense tests to spells', async () => {
+            it('Correctly adds defense tests without resist tests to direct combat spells', async () => {
                 const item = await factory.createItem({type: 'spell'});
 
                 await item.update({ system: { category: 'combat', combat: { type: 'direct' } } });
@@ -50,12 +50,24 @@ export const shadowrunSR5Item = (context: QuenchBatchContext) => {
                 assert.equal(item.system.action.followed.test, 'DrainTest');
                 assert.equal(item.system.action.opposed.test, 'CombatSpellDefenseTest');
                 assert.equal(item.system.action.opposed.resist.test, '');
+            });
+            it('Correctly adds default opposed tests to detection spells', async () => {
+                const item = await factory.createItem({type: 'spell'});
 
                 await item.update({ system: { category: 'detection' } });
                 assert.equal(item.system.action.test, 'SpellCastingTest');
                 assert.equal(item.system.action.followed.test, 'DrainTest');
                 assert.equal(item.system.action.opposed.test, 'OpposedTest');
                 assert.equal(item.system.action.opposed.resist.test, '');
+            });
+            it('Correctly keeps resist tests for indirect combat spells', async () => {
+                const item = await factory.createItem({type: 'spell'});
+
+                await item.update({ system: { category: 'combat', combat: { type: 'indirect' } } });
+                assert.equal(item.system.action.test, 'SpellCastingTest');
+                assert.equal(item.system.action.followed.test, 'DrainTest');
+                assert.equal(item.system.action.opposed.test, 'CombatSpellDefenseTest');
+                assert.equal(item.system.action.opposed.resist.test, 'PhysicalResistTest');
             });
             it('Correctly add default tests to melee weapons', async () => {
                 const item = await factory.createItem({type: 'weapon'});

--- a/system.json
+++ b/system.json
@@ -21,7 +21,7 @@
         }
     ],
     "url": "#{URL}#",
-    "version": "0.35.1",
+    "version": "0.35.2",
     "compatibility": {
         "minimum": "14",
         "verified": "14.363",


### PR DESCRIPTION
## Summary
- Prevent direct combat spells from receiving an opposed damage resist test
- Migrate existing direct combat spells to clear stale `system.action.opposed.resist.test`
- Add regression coverage for direct combat spell action data and migration behavior
