### PR TITLE
Option for reversed (not) filters for active effects

### DIFF
--- a/src/module/effect/SR5ActiveEffectConfig.ts
+++ b/src/module/effect/SR5ActiveEffectConfig.ts
@@ -321,6 +321,53 @@ export class SR5ActiveEffectConfig extends foundry.applications.sheets.ActiveEff
         return Object.entries(SR5.limits).map(([limit, label]) => ({ label, id: limit }));
     }
 
+    // Adding reverse (not) filtering options to active effects to rule out specific tests, categories, skills, attributes or limits.
+  _processFormData(formConfig, form, formData) {
+    const submitData = super._processFormData ? super._processFormData(formConfig, form, formData) : formData || {};
+    const fields = ["selection_tests", "selection_categories", "selection_skills", "selection_attributes", "selection_limits"];
+    for (const f of fields) {
+      try {
+        const neg = this.element.querySelector(`input[name="system.negate_${f}"]`);
+        if (!neg || !neg.checked) continue;
+        const raw = foundry.utils.getProperty(submitData, `system.${f}`);
+        let arr;
+        if (raw == null) {
+          arr = [];
+        } else if (Array.isArray(raw)) {
+          arr = raw;
+        } else if (typeof raw === "string") {
+          try {
+            const parsed = JSON.parse(raw);
+            arr = Array.isArray(parsed) ? parsed : [parsed];
+          } catch (e) {
+            arr = raw === "" ? [] : [raw];
+          }
+        } else if (typeof raw === "object") {
+          arr = [raw];
+        } else {
+          arr = [raw];
+        }
+        console.log("SR5ActiveEffectConfig | _processFormData called for", f, "(coerced)", arr);
+        const mapped = arr.map((item) => {
+          if (typeof item === "string") {
+            return { id: item, value: item, not: true };
+          }
+          if (item && typeof item === "object") {
+            const copy = Object.assign({}, item);
+            copy.not = true;
+            return copy;
+          }
+          return item;
+        });
+        foundry.utils.setProperty(submitData, `system.${f}`, mapped);
+        console.log("SR5ActiveEffectConfig | _processFormData set", f, "to", mapped);
+      } catch (err) {
+        console.error("Shadowrun5e | Error applying negate mapping for", f, err);
+      }
+    }
+    return submitData;
+  }
+    
     override _onChangeForm(formConfig, event) {
         super._onChangeForm(formConfig, event);
     

--- a/src/module/effect/flows/SuccessTestEffectsFlow.ts
+++ b/src/module/effect/flows/SuccessTestEffectsFlow.ts
@@ -78,41 +78,49 @@ export class SuccessTestEffectsFlow<T extends SuccessTest> {
      * @returns 
      */
     _skipEffectForTestLimitations(effect: SR5ActiveEffect) {
-        // Filter effects that don't apply to this test.
-        const tests = effect.system.selection_tests.map(test => test.id);
-        // Opposed tests use the same item as the success test but normally don't apply effects from it.
-        // However if an effect defines a test, it should apply to it.
-        if (tests.length === 0 && this.test.opposing) return true;
-        if (tests.length > 0 && !tests.includes(this.test.type)) return true;
+    // Changed to check also the reversed (not) filters that may have been set to rule out specific tests, categories, skills, attributes or limits - if any of those filters match the test, the effect should not be applied.
+    // 1. Tests / Opposing
+    const normalTests = effect.system.selection_tests.filter(test => !test.not).map(test => test.id);
+    const notTests = effect.system.selection_tests.filter(test => test.not).map(test => test.id);
+    if (normalTests.length === 0 && notTests.length === 0 && this.test.opposing) return true;
+    if (notTests.includes(this.test.type)) return true;
+    if (normalTests.length > 0 && !normalTests.includes(this.test.type)) return true;
 
-        // Check for action categories
-        // Both the effect and test can both define multiple categories.
-        // One match is enough.
-        const categories = effect.system.selection_categories.map(test => test.id) as Shadowrun.ActionCategories[];
-        const testCategories = this.test.data.categories;
-        if (categories.length > 0 && !categories.find(category => testCategories.includes(category))) return true;
+    // 2. Categories
+    const normalCategories = effect.system.selection_categories.filter(test => !test.not).map(test => test.id);
+    const notCategories = effect.system.selection_categories.filter(test => test.not).map(test => test.id);
+    const testCategories = this.test.data.categories;
+    if (notCategories.some(cat => testCategories.includes(cat))) return true;
+    if (normalCategories.length > 0 && !normalCategories.some(cat => testCategories.includes(cat))) return true;
 
-        // Check for test skill.
-        const skills = effect.system.selection_skills.map(test => test.id);
-        const skillId = this.test.data.action.skill;
-        const skillName = this.test.actor?.getSkill(skillId)?.name || skillId;
-        if (skills.length > 0 && !skills.includes(skillId) && !skills.includes(skillName)) return true;
+    // 3. Skills
+    const normalSkills = effect.system.selection_skills.filter(test => !test.not).map(test => test.id);
+    const notSkills = effect.system.selection_skills.filter(test => test.not).map(test => test.id);
+    const skillId = this.test.data.action.skill;
+    const skillName = this.test.actor?.getSkill(skillId)?.name || skillId;
+    if (notSkills.includes(skillId) || notSkills.includes(skillName)) return true;
+    if (normalSkills.length > 0 && !normalSkills.includes(skillId) && !normalSkills.includes(skillName)) return true;
 
-        // Check for test attributes used.
-        const attributes = effect.system.selection_attributes.map(test => test.id);
-        const attribute = this.test.data.action.attribute;
-        const attribute2 = this.test.data.action.attribute2;
-        if (attributes.length > 0 && attribute && !attributes.includes(attribute)) return true;
-        if (attributes.length > 0 && attribute2 && !attributes.includes(attribute2)) return true;
-        if (attributes.length > 0 && !attribute && !attribute2) return true;
-
-        // Check for test limits used.
-        const limits = effect.system.selection_limits.map(test => test.id);
-        const limit = this.test.data.action.limit.attribute;
-        if (limits.length > 0 && !limits.includes(limit)) return true;
-
-        return false;
+    // 4. Attributes
+    const normalAttributes = effect.system.selection_attributes.filter(test => !test.not).map(test => test.id);
+    const notAttributes = effect.system.selection_attributes.filter(test => test.not).map(test => test.id);
+    const attribute = this.test.data.action.attribute;
+    const attribute2 = this.test.data.action.attribute2;
+    if (notAttributes.includes(attribute) || notAttributes.includes(attribute2)) return true;
+    if (normalAttributes.length > 0) {
+        if (!attribute && !attribute2) return true;
+        if (!normalAttributes.includes(attribute) && !normalAttributes.includes(attribute2)) return true;
     }
+
+    // 5. Limits
+    const normalLimits = effect.system.selection_limits.filter(test => !test.not).map(test => test.id);
+    const notLimits = effect.system.selection_limits.filter(test => test.not).map(test => test.id);
+    const limit = this.test.data.action.limit.attribute;
+    if (notLimits.includes(limit)) return true;
+    if (normalLimits.length > 0 && !normalLimits.includes(limit)) return true;
+
+    return false;
+  }
 
     /**
      * Create Effects of applyTo 'test_all' after a success test has finished.

--- a/src/module/handlebars/ModifierHelpers.ts
+++ b/src/module/handlebars/ModifierHelpers.ts
@@ -23,12 +23,25 @@ export const registerModifierHelpers = () => {
     }
 
     const getChangeEffect = (change: ChangeType) => {
-        if (!LinksHelpers.isUuid(change?.source)) return null;
-
-        const effect = fromUuidSync(change.source) as unknown;
-        if (!(effect instanceof ActiveEffect)) return null;
-
-        return effect;
+    // Original native function: If the UUID is available (as in SuccessTest), it is used.
+    if (LinksHelpers.isUuid(change?.source)) {
+      const effect = fromUuidSync(change.source);
+      if (effect instanceof ActiveEffect) return effect;
+    }
+    // If the UUID is missing or has been cleared, look for the corresponding effect based on its name.
+    if (change?.name) {
+      // Retrieve the character currently performing this test, either from the active combat or from the selected token.
+      const activeActor = game.combat?.combatant?.actor || canvas.tokens.controlled?.[0]?.actor;     
+      if (activeActor) {
+        // Search the character's effect list for the one whose name matches or is contained in the variable name.
+        const foundEffect = activeActor.effects.find(e => change.name.includes(e.name) || e.name.includes(change.name));       
+        // Return the actual ActiveEffect instance! This fixes the broken data chain along the way.
+        if (foundEffect instanceof ActiveEffect) {
+          return foundEffect;
+        }
+      }
+    }
+    return null;
     }
 
     Handlebars.registerHelper('isBaseChange', (change: ChangeType) => {

--- a/src/module/types/effect/ActiveEffect.ts
+++ b/src/module/types/effect/ActiveEffect.ts
@@ -27,30 +27,35 @@ const SR5ActiveEffectData = {
         new SchemaField({
             value: new StringField({ required: true, nullable: false }),
             id: new StringField({ required: true, nullable: false }),
+            not: new BooleanField({ nullable: true }),
         })
     ),
     selection_categories: new TagifyField(
         new SchemaField({
             value: new StringField({ required: true, nullable: false }),
             id: new StringField({ required: true, nullable: false }),
+            not: new BooleanField({ nullable: true }),
         })
     ),
     selection_limits: new TagifyField(
         new SchemaField({
             value: new StringField({ required: true, nullable: false }),
             id: new StringField({ required: true, nullable: false }),
+            not: new BooleanField({ nullable: true }),
         })
     ),
     selection_skills: new TagifyField(
         new SchemaField({
             value: new StringField({ required: true, nullable: false }),
             id: new StringField({ required: true, nullable: false }),
+            not: new BooleanField({ nullable: true }),
         })
     ),
     selection_tests: new TagifyField(
         new SchemaField({
             value: new StringField({ required: true, nullable: false }),
             id: new StringField({ required: true, nullable: false }),
+            not: new BooleanField({ nullable: true }),
         })
     ),
 }

--- a/src/templates/effect/active-effect-apply-to.hbs
+++ b/src/templates/effect/active-effect-apply-to.hbs
@@ -2,11 +2,41 @@
     <!-- This select gets modified a little by the SR5ActiveEffectConfig class in _onRender -->
     {{formGroup systemFields.applyTo value=source.system.applyTo options=applyToOptions rootId=rootId}}
 {{#ife source.system.applyTo "test_all"}}
+        <div class="form-group negate-group">
+        <label class="inline-checkbox" style="flex: 0 0 auto; white-space: nowrap; display: inline-flex; align-items: center; gap: 0.25rem; margin-right: 0.35rem;">
+            <input type="checkbox" name="system.negate_selection_tests" {{#if source.system.negate_selection_tests}}checked{{/if}} />
+            NOT:
+        </label>
     {{formGroup systemFields.selection_tests value=source.system.selection_tests options=selection_test_options rootId=rootId}}
+            </div>
+    <div class="form-group negate-group">
+        <label class="inline-checkbox" style="flex: 0 0 auto; white-space: nowrap; display: inline-flex; align-items: center; gap: 0.25rem; margin-right: 0.35rem;">
+            <input type="checkbox" name="system.negate_selection_categories" {{#if source.system.negate_selection_categories}}checked{{/if}} />
+            NOT:
+        </label>
     {{formGroup systemFields.selection_categories value=source.system.selection_categories options=selection_category_options rootId=rootId}}
+        </div>
+    <div class="form-group negate-group">
+        <label class="inline-checkbox" style="flex: 0 0 auto; white-space: nowrap; display: inline-flex; align-items: center; gap: 0.25rem; margin-right: 0.35rem;">
+            <input type="checkbox" name="system.negate_selection_skills" {{#if source.system.negate_selection_skills}}checked{{/if}} />
+            NOT:
+        </label>
     {{formGroup systemFields.selection_skills value=source.system.selection_skills options=selection_skill_options rootId=rootId}}
+        </div>
+    <div class="form-group negate-group">
+        <label class="inline-checkbox" style="flex: 0 0 auto; white-space: nowrap; display: inline-flex; align-items: center; gap: 0.25rem; margin-right: 0.35rem;">
+            <input type="checkbox" name="system.negate_selection_attributes" {{#if source.system.negate_selection_attributes}}checked{{/if}} />
+            NOT:
+        </label>
     {{formGroup systemFields.selection_attributes value=source.system.selection_attributes options=selection_attribute_options rootId=rootId}}
+         </div>
+    <div class="form-group negate-group">
+        <label class="inline-checkbox" style="flex: 0 0 auto; white-space: nowrap; display: inline-flex; align-items: center; gap: 0.25rem; margin-right: 0.35rem;">
+            <input type="checkbox" name="system.negate_selection_limits" {{#if source.system.negate_selection_limits}}checked{{/if}} />
+            NOT:
+        </label>
     {{formGroup systemFields.selection_limits value=source.system.selection_limits options=selection_limit_options rootId=rootId}}
+        </div>
 {{/ife}}
 
 {{#ife source.system.applyTo "modifier"}}


### PR DESCRIPTION
There is also one change for missing or cleared uuid:s so that modifier icons would appear in e.g. in physical defense test.