### PR TITLE
[Code] Increase Quench timeout and group test-created documents in #Quench folders

### DIFF
--- a/src/module/apps/itemImport/helper/ImportHelper.ts
+++ b/src/module/apps/itemImport/helper/ImportHelper.ts
@@ -161,7 +161,7 @@ export class ImportHelper {
      * @returns {Promise<Folder>} A promise that resolves with the folder object when the folder is created.
      */
     private static async getCompendiumFolder(name: string, parent: Folder | null = null): Promise<Folder<'Compendium'>> {
-        let folder = game.folders?.find(f => f.name === name && f.type === "Compendium" && f.folder === parent);
+        let folder = game.folders.find(f => f.name === name && f.type === "Compendium" && f.folder === parent);
         if (!folder)
             folder = await Folder.create({ name, color: "#00cc00", folder: parent?.id ?? null, type: "Compendium" });
         return folder as Folder<'Compendium'>;

--- a/src/unittests/actorImport/sr5.CharacterImporter.spec.ts
+++ b/src/unittests/actorImport/sr5.CharacterImporter.spec.ts
@@ -36,7 +36,10 @@ export const characterImporterTesting = (context: QuenchBatchContext) => {
 
     describe('Character Importer', () => {
         it('Should import a chummer character', async () => {
-            [actor, ...vehicles] = await CI.import(character, importOptions);
+            [actor, ...vehicles] = await CI.import(character, {
+                ...importOptions,
+                folderId: await factory.getOrCreateFolderId('Actor'),
+            });
             assert.notEqual(actor, null, 'Actor not created');
             factory.actors.push(actor as Actor.Stored<'character'>, ...vehicles as Actor.Stored<'vehicle'>[]);
             assert.lengthOf(vehicles, 1, 'Vehicle not created');

--- a/src/unittests/actorImport/sr5.SpiritImporter.spec.ts
+++ b/src/unittests/actorImport/sr5.SpiritImporter.spec.ts
@@ -53,14 +53,20 @@ export const spiritImporterTesting = (context: QuenchBatchContext) => {
                 }
             });
 
-            spirit = await SpiritImporter.import(character, template, importOptions);
+            spirit = await SpiritImporter.import(character, template, {
+                ...importOptions,
+                folderId: await factory.getOrCreateFolderId('Actor'),
+            });
             assert.notEqual(spirit, null, 'Spirit not created');
             factory.actors.push(spirit as Actor.Stored<'spirit'>);
             assert.strictEqual(spirit!.system.spiritType, 'fire_template');
         });
 
         it('imports a spirit using preset profile fallback without template', async () => {
-            const fallbackSpirit = await SpiritImporter.importFromPresetProfile(character, importOptions);
+            const fallbackSpirit = await SpiritImporter.importFromPresetProfile(character, {
+                ...importOptions,
+                folderId: await factory.getOrCreateFolderId('Actor'),
+            });
             assert.notEqual(fallbackSpirit, null, 'Spirit fallback import failed');
             factory.actors.push(fallbackSpirit as Actor.Stored<'spirit'>);
 
@@ -117,4 +123,3 @@ export const spiritImporterTesting = (context: QuenchBatchContext) => {
         });
     });
 };
-

--- a/src/unittests/actorImport/sr5.SpriteImporter.spec.ts
+++ b/src/unittests/actorImport/sr5.SpriteImporter.spec.ts
@@ -50,7 +50,10 @@ export const spriteImporterTesting = (context: QuenchBatchContext) => {
                 }
             });
 
-            sprite = await SpriteImporter.import(character, template, importOptions);
+            sprite = await SpriteImporter.import(character, template, {
+                ...importOptions,
+                folderId: await factory.getOrCreateFolderId('Actor'),
+            });
             assert.notEqual(sprite, null, 'sprite not created');
             factory.actors.push(sprite as Actor.Stored<'sprite'>);
             assert.strictEqual(sprite!.system.spriteType, 'companion_template');
@@ -62,7 +65,10 @@ export const spriteImporterTesting = (context: QuenchBatchContext) => {
         });
 
         it('imports a sprite using preset profile fallback without template', async () => {
-            const fallbackSprite = await SpriteImporter.importFromPresetProfile(character, importOptions);
+            const fallbackSprite = await SpriteImporter.importFromPresetProfile(character, {
+                ...importOptions,
+                folderId: await factory.getOrCreateFolderId('Actor'),
+            });
             assert.notEqual(fallbackSprite, null, 'Sprite fallback import failed');
             factory.actors.push(fallbackSprite as Actor.Stored<'sprite'>);
 
@@ -96,4 +102,3 @@ export const spriteImporterTesting = (context: QuenchBatchContext) => {
         });
     });
 };
-

--- a/src/unittests/quench.ts
+++ b/src/unittests/quench.ts
@@ -44,8 +44,7 @@ const registerBatch = (
     options?: QuenchRegisterBatchOptions,
 ) => {
     quench.registerBatch(key, async function (context) {
-        const batchRoot = this as Mocha.Suite & { timeout: (ms: number) => Mocha.Suite };
-        batchRoot.timeout(QUENCH_TIMEOUT_MS);
+        this.timeout(QUENCH_TIMEOUT_MS);
 
         return fn.call(this, context);
     }, options);

--- a/src/unittests/quench.ts
+++ b/src/unittests/quench.ts
@@ -31,9 +31,25 @@ import { shadowrunOpposedCompileSpriteTesting } from './sr5.OpposedCompileSprite
 import { shadowrunOpposedCallInMessageActionTesting } from './sr5.OpposedCallInMessageAction.spec';
 import { actorArmorFlowTesting } from './sr5.ActorArmorFlow.spec';
 
-import { Quench } from '@ethaks/fvtt-quench';
+import { Quench, QuenchRegisterBatchFunction, QuenchRegisterBatchOptions } from '@ethaks/fvtt-quench';
 import { shadowrunRiggerTesting } from '@/unittests/sr5.RiggerTesting.spec';
 import { shadowrunMatrixDamageResist } from '@/unittests/sr5.MatrixDamageResist.spec';
+
+const QUENCH_TIMEOUT_MS = 5000;
+
+const registerBatch = (
+    quench: Quench,
+    key: Parameters<Quench['registerBatch']>[0],
+    fn: QuenchRegisterBatchFunction,
+    options?: QuenchRegisterBatchOptions,
+) => {
+    quench.registerBatch(key, async function (context) {
+        const batchRoot = this as Mocha.Suite & { timeout: (ms: number) => Mocha.Suite };
+        batchRoot.timeout(QUENCH_TIMEOUT_MS);
+
+        return fn.call(this, context);
+    }, options);
+};
 
 /**
  * Register FoundryVTT Quench test batches...
@@ -46,99 +62,99 @@ export const quenchRegister = (quench: Quench) => {
 
     console.info('Shadowrun 5e | Registering quench unittests');
     console.warn(
-        'Shadowrun 5e | Be aware that FoundryVTT will tank in update performance when a lot of documents are in collections. This is the case if you have all Chummer items imported and might cause tests to cross the 2000ms quench timeout threshold. Clear those collections in a test world. :)',
+        'Shadowrun 5e | Be aware that FoundryVTT will tank in update performance when a lot of documents are in collections. This is the case if you have all Chummer items imported and might cause tests to cross the 5000ms quench timeout threshold. Clear those collections in a test world. :)',
     );
 
-    quench.registerBatch('shadowrun5e.rules.matrix', shadowrunMatrix, {
+    registerBatch(quench, 'shadowrun5e.rules.matrix', shadowrunMatrix, {
         displayName: 'SHADOWRUN5e: Matrix Rules Test',
     });
-    quench.registerBatch('shadowrun5e.apps.matrix_opposed_device_dialog', shadowrunMatrixOpposedDeviceDialog, {
+    registerBatch(quench, 'shadowrun5e.apps.matrix_opposed_device_dialog', shadowrunMatrixOpposedDeviceDialog, {
         displayName: 'SHADOWRUN5e: Matrix Opposed Device Dialog Test',
     });
-    quench.registerBatch('shadowrun5e.rules.modifiers', shadowrunRulesModifiers, {
+    registerBatch(quench, 'shadowrun5e.rules.modifiers', shadowrunRulesModifiers, {
         displayName: 'SHADOWRUN5e: Modifiers Rules Test',
     });
-    quench.registerBatch('shadowrun5e.rules.ranged_weapon', shadowrunSR5RangedWeaponRules, {
+    registerBatch(quench, 'shadowrun5e.rules.ranged_weapon', shadowrunSR5RangedWeaponRules, {
         displayName: 'SHADOWRUN5e: Ranged Weapon Rules Test',
     });
-    quench.registerBatch('shadowrun5e.characterImporter', characterImporterTesting, {
+    registerBatch(quench, 'shadowrun5e.characterImporter', characterImporterTesting, {
         displayName: 'SHADOWRUN5e: Chummer Character Importer',
     });
-    quench.registerBatch('shadowrun5e.spiritImporter', spiritImporterTesting, {
+    registerBatch(quench, 'shadowrun5e.spiritImporter', spiritImporterTesting, {
         displayName: 'SHADOWRUN5e: Chummer Spirit Importer',
     });
-    quench.registerBatch('shadowrun5e.spriteImporter', spriteImporterTesting, {
+    registerBatch(quench, 'shadowrun5e.spriteImporter', spriteImporterTesting, {
         displayName: 'SHADOWRUN5e: Chummer Sprite Importer',
     });
-    quench.registerBatch('shadowrun5e.entities.items', shadowrunSR5Item, { displayName: 'SHADOWRUN5e: SR5Item Test' });
-    quench.registerBatch('shadowrun5e.entities.effects', shadowrunSR5ActiveEffect, {
+    registerBatch(quench, 'shadowrun5e.entities.items', shadowrunSR5Item, { displayName: 'SHADOWRUN5e: SR5Item Test' });
+    registerBatch(quench, 'shadowrun5e.entities.effects', shadowrunSR5ActiveEffect, {
         displayName: 'SHADOWRUN5e: SR5ActiveEffect Test',
     });
-    quench.registerBatch('shadowrun5e.data_prep.character', shadowrunSR5CharacterDataPrep, {
+    registerBatch(quench, 'shadowrun5e.data_prep.character', shadowrunSR5CharacterDataPrep, {
         displayName: 'SHADOWRUN5e: SR5CharacterDataPreparation Test',
     });
-    quench.registerBatch('shadowrun5e.data_prep.sprite', shadowrunSR5SpriteDataPrep, {
+    registerBatch(quench, 'shadowrun5e.data_prep.sprite', shadowrunSR5SpriteDataPrep, {
         displayName: 'SHADOWRUN5e: SR5CSpriteDataPreparation Test',
     });
-    quench.registerBatch('shadowrun5e.data_prep.spirit', shadowrunSR5SpiritDataPrep, {
+    registerBatch(quench, 'shadowrun5e.data_prep.spirit', shadowrunSR5SpiritDataPrep, {
         displayName: 'SHADOWRUN5e: SR5SpiritDataPreparation Test',
     });
-    quench.registerBatch('shadowrun5e.data_prep.ic', shadowrunSR5ICDataPrep, {
+    registerBatch(quench, 'shadowrun5e.data_prep.ic', shadowrunSR5ICDataPrep, {
         displayName: 'SHADOWRUN5e: SR5ICDataPreparation Test',
     });
-    quench.registerBatch('shadowrun5e.data_prep.vehicle', shadowrunSR5VehicleDataPrep, {
+    registerBatch(quench, 'shadowrun5e.data_prep.vehicle', shadowrunSR5VehicleDataPrep, {
         displayName: 'SHADOWRUN5e: SR5VehicleDataPreparation Test',
     });
-    quench.registerBatch('shadowrun5e.data_prep.item', shadowrunSR5ItemDataPrep, {
+    registerBatch(quench, 'shadowrun5e.data_prep.item', shadowrunSR5ItemDataPrep, {
         displayName: 'SHADOWRUN5e: SR5ItemDataPreparation Test',
     });
-    quench.registerBatch('shadowrun5e.flow.marks', shadowrunMarks, {
+    registerBatch(quench, 'shadowrun5e.flow.marks', shadowrunMarks, {
         displayName: 'SHADOWRUN5e: Matrix Marks Test',
     });
-    quench.registerBatch('shadowrun5e.flow.inventory', shadowrunInventoryFlow, {
+    registerBatch(quench, 'shadowrun5e.flow.inventory', shadowrunInventoryFlow, {
         displayName: 'SHADOWRUN5e: InventoryFlow Test',
     });
-    quench.registerBatch('shadowrun5e.flow.driver', shadowrunDriver, {
+    registerBatch(quench, 'shadowrun5e.flow.driver', shadowrunDriver, {
         displayName: 'SHADOWRUN5e: Driver Flow Test',
-    })
-    quench.registerBatch('shadowrun5e.flow.combat_modifiers', shadowrunCombatModifierFlow, {
+    });
+    registerBatch(quench, 'shadowrun5e.flow.combat_modifiers', shadowrunCombatModifierFlow, {
         displayName: 'SHADOWRUN5e: CombatModifierFlow Test',
     });
-    quench.registerBatch('shadowrun5e.flow.rigger', shadowrunRiggerTesting, {
+    registerBatch(quench, 'shadowrun5e.flow.rigger', shadowrunRiggerTesting, {
         displayName: 'SHADOWRUN5e: Rigger Flow Testing',
-    })
-    quench.registerBatch('shadowrun5e.flow.tests', shadowrunTesting, { displayName: 'SHADOWRUN5e: SuccessTest Test' });
-    quench.registerBatch('shadowrun5e.flow.tests_attack', shadowrunAttackTesting, {
+    });
+    registerBatch(quench, 'shadowrun5e.flow.tests', shadowrunTesting, { displayName: 'SHADOWRUN5e: SuccessTest Test' });
+    registerBatch(quench, 'shadowrun5e.flow.tests_attack', shadowrunAttackTesting, {
         displayName: 'SHADOWRUN5e: Attack Test',
     });
-    quench.registerBatch('shadowrun5e.flow.test_value_resolution', shadowrunTestValueResolution, { displayName: 'SHADOWRUN5e: Test Value Resolution' });
-    quench.registerBatch('shadowrun5e.flow.tests_matrix', shadowrunMatrixTesting, { displayName: 'SHADOWRUN5e: Matrix Test' });
-    quench.registerBatch('shadowrun5e.flow.tests_resist_matrix', shadowrunMatrixDamageResist, {
+    registerBatch(quench, 'shadowrun5e.flow.test_value_resolution', shadowrunTestValueResolution, { displayName: 'SHADOWRUN5e: Test Value Resolution' });
+    registerBatch(quench, 'shadowrun5e.flow.tests_matrix', shadowrunMatrixTesting, { displayName: 'SHADOWRUN5e: Matrix Test' });
+    registerBatch(quench, 'shadowrun5e.flow.tests_resist_matrix', shadowrunMatrixDamageResist, {
         displayName: 'SHADOWRUN5e: Resist Matrix Test'
     });
-    quench.registerBatch('shadowrun5e.flow.sr5roll', shadowrunRolling, { displayName: 'SHADOWRUN5e: SR5Roll' });
-    quench.registerBatch('shadowrun5e.parser.weapon', weaponParserBaseTesting, {
+    registerBatch(quench, 'shadowrun5e.flow.sr5roll', shadowrunRolling, { displayName: 'SHADOWRUN5e: SR5Roll' });
+    registerBatch(quench, 'shadowrun5e.parser.weapon', weaponParserBaseTesting, {
         displayName: 'SHADOWRUN5e: Data Importer Weapon Parsing',
     });
-    quench.registerBatch('shadowrun5e.flow.damage', shadowrunDamage, {
+    registerBatch(quench, 'shadowrun5e.flow.damage', shadowrunDamage, {
         displayName: 'SHADOWRUN5e: Damage Application',
     });
-    quench.registerBatch('shadowrun5e.actor.npc', shadowrunNPC, {
+    registerBatch(quench, 'shadowrun5e.actor.npc', shadowrunNPC, {
         displayName: 'SHADOWRUN5e: NPC Character Test',
     });
-    quench.registerBatch('shadowrun5e.item.skill', itemSkillTesting, {
+    registerBatch(quench, 'shadowrun5e.item.skill', itemSkillTesting, {
         displayName: 'SHADOWRUN5e: Item Skill Flow Test',
     });
-    quench.registerBatch('shadowrun5e.opposed.compile_sprite', shadowrunOpposedCompileSpriteTesting, {
+    registerBatch(quench, 'shadowrun5e.opposed.compile_sprite', shadowrunOpposedCompileSpriteTesting, {
         displayName: 'SHADOWRUN5e: Opposed Compile Sprite Flow',
     });
-    quench.registerBatch('shadowrun5e.opposed.call_in_message_action', shadowrunOpposedCallInMessageActionTesting, {
+    registerBatch(quench, 'shadowrun5e.opposed.call_in_message_action', shadowrunOpposedCallInMessageActionTesting, {
         displayName: 'SHADOWRUN5e: Opposed Call-In Message Action Flow',
     });
-    quench.registerBatch('shadowrun5e.actor.armor_flow', actorArmorFlowTesting, {
+    registerBatch(quench, 'shadowrun5e.actor.armor_flow', actorArmorFlowTesting, {
         displayName: 'SHADOWRUN5e: Actor Armor Flow Test',
     });
-    quench.registerBatch('shadowrun5e.migrators', Migrators, {
+    registerBatch(quench, 'shadowrun5e.migrators', Migrators, {
         displayName: 'SHADOWRUN5e: Migrators Test',
     });
 };

--- a/src/unittests/utils.ts
+++ b/src/unittests/utils.ts
@@ -2,15 +2,29 @@ import { SR5Actor } from "src/module/actor/SR5Actor";
 import { SR5Item } from "src/module/item/SR5Item";
 
 export class SR5TestFactory {
+    static readonly folderName = '#Quench';
+
     readonly actors: Actor.Stored[] = [];
     readonly items: Item.Stored[] = [];
-    readonly scenes: Scene[] = [];
+    readonly scenes: Scene.Stored[] = [];
+    readonly createdFolder = new Map<string, string>();
+
+    async getOrCreateFolderId(type: 'Actor' | 'Item' | 'Scene'): Promise<string> {
+        if (this.createdFolder.has(type)) return this.createdFolder.get(type)!;
+
+        const folder = await Folder.create({ name: SR5TestFactory.folderName, type });
+        if (!folder) throw new Error(`Shadowrun 5e | Failed to create ${SR5TestFactory.folderName} folder for ${type} documents`);
+
+        this.createdFolder.set(type, folder.id);
+        return folder.id;
+    }
 
     async createActor<T extends Actor.ConfiguredSubType>(
         data: Omit<Actor.CreateData, "name"> & { name?: string, type: T },
         context?: Actor.ConstructionContext
     ) {
-        const actor = await SR5Actor.create({ name: `#QUENCH`, ...data }, context) as Actor.Stored<T>;
+        const folder = await this.getOrCreateFolderId('Actor');
+        const actor = await SR5Actor.create({ name: `#QUENCH`, folder: folder, ...data }, context) as Actor.Stored<T>;
         this.actors.push(actor);
         return actor;
     }
@@ -19,7 +33,8 @@ export class SR5TestFactory {
         data: Omit<Item.CreateData, "name"> & { name?: string, type: T },
         context?: Item.ConstructionContext
     ) {
-        const item = await SR5Item.create({ name: `#QUENCH`, ...data }, context) as Item.Stored<T>;
+        const folder = await this.getOrCreateFolderId('Item');
+        const item = await SR5Item.create({ name: `#QUENCH`, folder: folder, ...data }, context) as Item.Stored<T>;
         this.items.push(item);
         return item;
     }
@@ -27,19 +42,22 @@ export class SR5TestFactory {
     async createScene(
         data: Omit<Scene.CreateData, "name"> & { name?: string },
         context?: Scene.ConstructionContext
-    ): Promise<Scene> {
-        const scene = await Scene.create({ name: `#QUENCH`, ...data }, context) as Scene;
+    ): Promise<Scene.Stored> {
+        const folder = await this.getOrCreateFolderId('Scene');
+        const scene = await Scene.create({ name: `#QUENCH`, folder: folder, ...data }, context) as Scene.Stored;
         this.scenes.push(scene);
         return scene;
     }
 
     async destroy() {
-        await Actor.deleteDocuments(this.actors.map(actor => actor.id!));
-        await Item.deleteDocuments(this.items.map(item => item.id!));
-        await Scene.deleteDocuments(this.scenes.map(scene => scene.id!));
+        await Actor.deleteDocuments(this.actors.map(actor => actor.id));
+        await Item.deleteDocuments(this.items.map(item => item.id));
+        await Scene.deleteDocuments(this.scenes.map(scene => scene.id));
+        await Folder.deleteDocuments(Array.from(this.createdFolder.values()));
 
         this.actors.length = 0;
         this.items.length = 0;
         this.scenes.length = 0;
+        this.createdFolder.clear();
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
         "moduleResolution": "bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
         "types": [
             "fvtt-types",
-            "@ethaks/fvtt-quench"
+            "@ethaks/fvtt-quench",
+            "mocha",
         ] /* Specify type package names to be included without being referenced in a source file. */,
         "resolveJsonModule": true /* Enable importing .json files. */,
 


### PR DESCRIPTION
### Summary
This PR improves Quench test stability and keeps test-generated world content isolated.

### Changes
- Increase the Quench batch timeout from `2000ms` to `5000ms` by wrapping system batch registration in a shared helper.
- Add `mocha` to `tsconfig.json` so Quench/Mocha types resolve correctly in the workspace.
- Route test-created Actors, Items, and Scenes into `#Quench` folders through `SR5TestFactory`.

### Why
- Some Quench tests were timing out on slower machines, keep documents alive after tests.
- Test runs were leaving world documents mixed into normal folders.
