### PR TITLE
[BUG] Fix 0.36.0 sprite level active effect migration scope

### DIFF
--- a/src/module/migrator/versions/Version0_36_0.ts
+++ b/src/module/migrator/versions/Version0_36_0.ts
@@ -196,9 +196,8 @@ export class Version0_36_0 extends VersionMigration {
             );
         }
 
-        const items = Array.isArray(actor.items) ? actor.items : [];
-        for (const item of items) {
-            if (!item || typeof item !== 'object') continue;
+        const migrateItemEffects = (item: any): void => {
+            if (!item || typeof item !== 'object') return;
 
             const itemEffects = Array.isArray(item.effects) ? item.effects : [];
             for (const effect of itemEffects) {
@@ -209,6 +208,17 @@ export class Version0_36_0 extends VersionMigration {
                     {}
                 );
             }
+
+            const embeddedItems = getProperty(item, 'flags.shadowrun5e.embeddedItems');
+            const nestedItems = Array.isArray(embeddedItems) ? embeddedItems : Object.values(embeddedItems ?? {});
+            for (const nestedItem of nestedItems) {
+                migrateItemEffects(nestedItem);
+            }
+        };
+
+        const items = Array.isArray(actor.items) ? actor.items : [];
+        for (const item of items) {
+            migrateItemEffects(item);
         }
     }
 

--- a/src/module/migrator/versions/Version0_36_0.ts
+++ b/src/module/migrator/versions/Version0_36_0.ts
@@ -120,6 +120,8 @@ export class Version0_36_0 extends VersionMigration {
     }
 
     private migrateSprite(actor: any): void {
+        this.migrateLevel(actor);
+
         const system = actor.system;
         if (!system || typeof system !== 'object') return;
         setProperty(system, 'attributes.level.base', getProperty(system, 'level'));
@@ -183,9 +185,35 @@ export class Version0_36_0 extends VersionMigration {
         return undefined;
     }
 
+    // Migrate legacy level field to new attributes.level.base and update related active effect changes and formula paths
+    private migrateLevel(actor: any): void {
+        const actorEffects = Array.isArray(actor.effects) ? actor.effects : [];
+        for (const effect of actorEffects) {
+            this.migrateEffectChanges(
+                effect,
+                { 'system.level': 'system.attributes.level' },
+                { 'system.level': 'system.attributes.level.value' },
+            );
+        }
+
+        const items = Array.isArray(actor.items) ? actor.items : [];
+        for (const item of items) {
+            if (!item || typeof item !== 'object') continue;
+
+            const itemEffects = Array.isArray(item.effects) ? item.effects : [];
+            for (const effect of itemEffects) {
+                // Item schema still owns system.level, so only migrate keys targeting the actor.
+                this.migrateEffectChanges(
+                    effect,
+                    { 'system.level': 'system.attributes.level' },
+                    {}
+                );
+            }
+        }
+    }
+
     override migrateActiveEffect(effect: any): void {
         const keyMap: Record<string, string> = {
-            'system.level': 'system.attributes.level',
             'system.initiative.meatspace.base': 'system.initiative.meatspace.constant',
             'system.initiative.meatspace.base.base': 'system.initiative.meatspace.constant.base',
             'system.initiative.meatspace.base.value': 'system.initiative.meatspace.constant.value',
@@ -207,7 +235,6 @@ export class Version0_36_0 extends VersionMigration {
         };
 
         const valueMap: Record<string, string> = {
-            'system.level': 'system.attributes.level.value',
             'system.initiative.meatspace.base': 'system.initiative.meatspace.constant',
             'system.initiative.meatspace.base.base': 'system.initiative.meatspace.constant.base',
             'system.initiative.meatspace.base.value': 'system.initiative.meatspace.constant.value',

--- a/src/unittests/Migrators.spec.ts
+++ b/src/unittests/Migrators.spec.ts
@@ -697,7 +697,6 @@ export const Migrators = (context: QuenchBatchContext) => {
             const effect = {
                 system: {
                     changes: [
-                        { key: 'system.level', value: 2, mode: CONST.ACTIVE_EFFECT_MODES.ADD },
                         { key: 'system.modifiers.matrix_initiative', value: 1, mode: CONST.ACTIVE_EFFECT_MODES.ADD },
                         { key: 'system.modifiers.matrix_initiative_dice', value: 1, mode: CONST.ACTIVE_EFFECT_MODES.ADD },
                         { key: 'system.attributes.reaction', value: 1, mode: CONST.ACTIVE_EFFECT_MODES.ADD },
@@ -706,10 +705,60 @@ export const Migrators = (context: QuenchBatchContext) => {
             };
             migrator.migrateActiveEffect(effect);
 
-            assert.strictEqual(effect.system.changes[0].key, 'system.attributes.level');
-            assert.strictEqual(effect.system.changes[1].key, 'system.initiative.matrix.constant.base');
-            assert.strictEqual(effect.system.changes[2].key, 'system.initiative.matrix.dice.base');
-            assert.strictEqual(effect.system.changes[3].key, 'system.attributes.reaction');
+            assert.strictEqual(effect.system.changes[0].key, 'system.initiative.matrix.constant.base');
+            assert.strictEqual(effect.system.changes[1].key, 'system.initiative.matrix.dice.base');
+            assert.strictEqual(effect.system.changes[2].key, 'system.attributes.reaction');
+        });
+
+        it('migrates nested item active effect keys without changing item-scoped level formulas', () => {
+            const migrator = new Version0_36_0();
+            const actor = createSprite('unknown', 6);
+            actor.system.level = 6;
+
+            actor.items.push({
+                _id: foundry.utils.randomID(16),
+                name: 'Parent Weapon',
+                type: 'weapon',
+                effects: [],
+                flags: {
+                    shadowrun5e: {
+                        embeddedItems: [{
+                            _id: foundry.utils.randomID(16),
+                            name: 'Nested Mod',
+                            type: 'modification',
+                            effects: [],
+                            flags: {
+                                shadowrun5e: {
+                                    embeddedItems: [{
+                                        _id: foundry.utils.randomID(16),
+                                        name: 'Deep Nested Mod',
+                                        type: 'modification',
+                                        effects: [{
+                                            system: {
+                                                changes: [
+                                                    { key: 'system.level', value: '@system.level + 1', mode: CONST.ACTIVE_EFFECT_MODES.ADD },
+                                                ],
+                                            },
+                                        }],
+                                        system: DataDefaults.baseSystemData('modification'),
+                                    }],
+                                },
+                            },
+                            system: DataDefaults.baseSystemData('modification'),
+                        }],
+                    },
+                },
+                system: DataDefaults.baseSystemData('weapon'),
+            } as any);
+
+            migrator.migrateActor(actor);
+
+            const nestedItems = foundry.utils.getProperty(actor.items[0], 'flags.shadowrun5e.embeddedItems') as any[];
+            const deepNestedItems = foundry.utils.getProperty(nestedItems[0], 'flags.shadowrun5e.embeddedItems') as any[];
+            const deepEffect = deepNestedItems[0].effects[0];
+
+            assert.strictEqual(deepEffect.system.changes[0].key, 'system.attributes.level');
+            assert.strictEqual(deepEffect.system.changes[0].value, '@system.level + 1');
         });
 
     });


### PR DESCRIPTION
## Summary

Fix the `0.36.0` migration for legacy sprite `system.level` references in active effects.

The original migration moved sprite actor `system.level` into `system.attributes.level`, but that same path also exists on items such as adept powers. A broad remap would corrupt valid item-scoped references, while a naive string replacement could also rewrite longer paths incorrectly.

## What changed

- Keep sprite actor level migration in `migrateSprite()`
- Migrate sprite actor-owned active effect keys and formula values from:
  - `system.level`
  - to `system.attributes.level`
- Migrate sprite item-owned active effect keys targeting actor data from:
  - `system.level`
  - to `system.attributes.level`
- Leave item effect formula values unchanged, since item schemas still legitimately own `system.level`

## Why

This preserves the intended sprite migration without breaking item-scoped effects such as adept powers.

In particular:
- actor effect formulas like `@system.level` must follow the sprite actor schema move
- item effect formulas must keep referencing the item’s own `system.level`
