### PR TITLE
Feature: Expose CharacterImporter global namespace

### DIFF
--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -19,6 +19,7 @@ import { HandlebarManager } from './handlebars/HandlebarManager';
 import { OverwatchScoreTracker } from './apps/gmtools/OverwatchScoreTracker';
 import { ActorImporter } from './apps/itemImport/apps/ActorImporter';
 import { BulkImporter } from './apps/itemImport/apps/BulkImporter';
+import { CharacterImporter } from './apps/actorImport/characterImporter/CharacterImporter';
 import { ChangelogApplication } from "./apps/ChangelogApplication";
 import { SituationModifiersApplication } from './apps/SituationModifiersApplication';
 import { SR5ICActorSheet } from "./actor/sheets/SR5ICActorSheet";
@@ -361,7 +362,13 @@ ___________________
             /**
              * The global data storage for the system.
              */
-            storage: SRStorage
+            storage: SRStorage,
+
+
+            /**
+             *The Character Importer for the SR5 system.
+             */
+            CharacterImporter
         };
 
         // Register document classes


### PR DESCRIPTION
## Expose `CharacterImporter` on global namespace `game.shadowrun5e`

### Description
This PR exposes the system's `CharacterImporter` class globally on the `game['shadowrun5e']` namespace during system initialization. This allows external modules (such as `sr5-marketplace`) to programmatically invoke the system's character/NPC importing logic from other tools or macros.

### Changes
* **`src/module/hooks.ts`**:
  * Imported `CharacterImporter` from `@/module/apps/actorImport/characterImporter/CharacterImporter`.
  * Added `CharacterImporter` to the `game['shadowrun5e']` namespace initialization block in `hooks.ts`.