### PR TITLE
Chummer Localization Support in Bulk Importer

### DIFF
--- a/src/module/apps/itemImport/apps/BulkImporter.ts
+++ b/src/module/apps/itemImport/apps/BulkImporter.ts
@@ -106,6 +106,7 @@ export class BulkImporter extends BaseClass {
      */
     private static overrideDocuments = true;
     private static deleteCompendiums = false;
+    private static useEnglishDefault = false;
     private static isImporting = false;
     private static importDone = false;
     private static zipFile: File | null = null;
@@ -165,6 +166,7 @@ export class BulkImporter extends BaseClass {
             zipFileName: BulkImporter.zipFile?.name,
             deleteCompendiums: BulkImporter.deleteCompendiums,
             overrideDocuments: BulkImporter.overrideDocuments,
+            useEnglishDefault: BulkImporter.useEnglishDefault,
 
             // GitHub version info
             info: {
@@ -233,6 +235,116 @@ export class BulkImporter extends BaseClass {
         // Load ZIP file if provided
         const ZIP = BulkImporter.zipFile ? await (new JSZip()).loadAsync(BulkImporter.zipFile) : null;
 
+        // Load localization file based on Foundry locale
+        const locale = game.i18n.lang;
+        const normLocale = locale.toLowerCase();
+        let langFile = "en-us.xml";
+        if (!BulkImporter.useEnglishDefault) {
+            if (normLocale === "de" || normLocale.startsWith("de-")) {
+                langFile = "de-de.xml";
+            } else if (normLocale === "fr" || normLocale.startsWith("fr-")) {
+                langFile = "fr-fr.xml";
+            } else if (normLocale === "pt" || normLocale.startsWith("pt-")) {
+                langFile = "pt-br.xml";
+            } else if (normLocale === "ru" || normLocale.startsWith("ru-")) {
+                langFile = "ru-ru.xml";
+            } else if (normLocale === "pl" || normLocale.startsWith("pl-")) {
+                langFile = "pl-pl.xml";
+            } else if (normLocale === "zh" || normLocale.startsWith("zh-")) {
+                langFile = "zh-cn.xml";
+            } else if (normLocale === "it" || normLocale.startsWith("it-")) {
+                langFile = "it-it.xml";
+            } else if (normLocale === "es" || normLocale.startsWith("es-")) {
+                langFile = "es-es.xml";
+            }
+        }
+
+        let langXml: string | undefined;
+        if (ZIP) {
+            langXml = await ZIP.file(`lang/${langFile}`)?.async("string")
+                   ?? await ZIP.file(`Chummer/lang/${langFile}`)?.async("string");
+        }
+        if (!langXml) {
+            try {
+                langXml = await BulkImporter.fetchGitHubFile(`Chummer/lang/${langFile}`);
+            } catch (e) {
+                console.error(`Failed to fetch language file ${langFile} from GitHub:`, e);
+            }
+        }
+
+        ImportHelper.translationMap = {};
+
+        if (langXml) {
+            try {
+                const parser = new DOMParser();
+                const xmlDoc = parser.parseFromString(langXml, "text/xml");
+                const stringNodes = xmlDoc.getElementsByTagName("string");
+                for (let i = 0; i < stringNodes.length; i++) {
+                    const node = stringNodes[i];
+                    const key = node.getElementsByTagName("key")[0]?.textContent;
+                    const text = node.getElementsByTagName("text")[0]?.textContent;
+                    if (key && text) {
+                        ImportHelper.translationMap[key] = text;
+                    }
+                }
+                console.log(`Loaded ${Object.keys(ImportHelper.translationMap).length} translations from Chummer ${langFile}`);
+            } catch (e) {
+                console.error(`Failed to parse language XML:`, e);
+            }
+        }
+
+        const dataLangFile = langFile.replace(".xml", "_data.xml");
+        let dataLangXml: string | undefined;
+        if (ZIP) {
+            dataLangXml = await ZIP.file(`lang/${dataLangFile}`)?.async("string")
+                       ?? await ZIP.file(`Chummer/lang/${dataLangFile}`)?.async("string");
+        }
+        if (!dataLangXml) {
+            try {
+                dataLangXml = await BulkImporter.fetchGitHubFile(`Chummer/lang/${dataLangFile}`);
+            } catch (e) {
+                console.debug(`No data language file ${dataLangFile} found on GitHub or it failed to fetch:`, e);
+            }
+        }
+
+        if (dataLangXml) {
+            try {
+                const parser = new DOMParser();
+                const xmlDoc = parser.parseFromString(dataLangXml, "text/xml");
+                const nameNodes = xmlDoc.getElementsByTagName("name");
+                let dataKeysCount = 0;
+                for (let i = 0; i < nameNodes.length; i++) {
+                    const nameNode = nameNodes[i];
+                    const parent = nameNode.parentElement;
+                    if (parent) {
+                        const translateNode = parent.getElementsByTagName("translate")[0];
+                        if (translateNode) {
+                            const key = nameNode.textContent?.trim();
+                            const text = translateNode.textContent?.trim();
+                            if (key && text) {
+                                ImportHelper.translationMap[key] = text;
+                                dataKeysCount++;
+                            }
+                        }
+                    }
+                }
+
+                const categoryNodes = xmlDoc.getElementsByTagName("category");
+                for (let i = 0; i < categoryNodes.length; i++) {
+                    const node = categoryNodes[i];
+                    const translateAttr = node.getAttribute("translate");
+                    const key = node.textContent?.trim();
+                    if (key && translateAttr) {
+                        ImportHelper.translationMap[key] = translateAttr;
+                        dataKeysCount++;
+                    }
+                }
+                console.log(`Loaded ${dataKeysCount} additional data translations from ${dataLangFile}`);
+            } catch (e) {
+                console.error(`Failed to parse data language XML:`, e);
+            }
+        }
+
         // Configure shared importer settings
         DataImporter.overrideDocuments = BulkImporter.overrideDocuments;
 
@@ -294,6 +406,7 @@ export class BulkImporter extends BaseClass {
         ImportHelper.categoryMap = {};
         ImportHelper.nameToId = {};
         ImportHelper.idToName = {};
+        ImportHelper.translationMap = {};
 
         console.debug(`Bulk import time: ${(performance.now() - start).toFixed(2)} ms`);
     }
@@ -319,6 +432,12 @@ export class BulkImporter extends BaseClass {
         const overrideDocuments = this.element.querySelector<HTMLSelectElement>("#overrideDocuments");
         overrideDocuments?.addEventListener("change", (event) => {
             BulkImporter.overrideDocuments = (event.currentTarget as HTMLInputElement).checked;
+        });
+
+        // Checkbox: Use English default
+        const useEnglishDefault = this.element.querySelector<HTMLSelectElement>("#useEnglishDefault");
+        useEnglishDefault?.addEventListener("change", (event) => {
+            BulkImporter.useEnglishDefault = (event.currentTarget as HTMLInputElement).checked;
         });
 
         // File input: Load ZIP file

--- a/src/module/apps/itemImport/helper/ImportHelper.ts
+++ b/src/module/apps/itemImport/helper/ImportHelper.ts
@@ -16,6 +16,13 @@ export class ImportHelper {
     static categoryMap: Partial<Record<ChummerFile, Record<string, string>>> = {};
     static nameToId: Partial<Record<CompendiumKey, Record<string, string>>> = {};
     static idToName: Partial<Record<CompendiumKey, Record<string, string>>> = {};
+    static translationMap: Record<string, string> = {};
+
+    public static translate(text: string | null | undefined): string {
+        if (!text) return "";
+        return this.translationMap[text] ?? text;
+    }
+
 
     /**
      * Ensures the provided value is returned as an array.

--- a/src/module/apps/itemImport/importer/DataImporter.ts
+++ b/src/module/apps/itemImport/importer/DataImporter.ts
@@ -116,7 +116,7 @@ export abstract class DataImporter {
                     continue;
                 }
 
-                const item = await parser.Parse(data, key);                
+                const item = await parser.Parse(data, key);
                 injectActionTests?.(item as Item.CreateData);
 
                 item._id = id;

--- a/src/module/apps/itemImport/parser/Parser.ts
+++ b/src/module/apps/itemImport/parser/Parser.ts
@@ -42,7 +42,7 @@ export abstract class Parser<SubType extends SystemEntityType> {
 
         const entity = {
             img: undefined as string | undefined | null,
-            name: IH.getArray(jsonData.translate)[0]?._TEXT ?? jsonData.name._TEXT,
+            name: IH.translate(IH.getArray(jsonData.translate)[0]?._TEXT ?? jsonData.name._TEXT),
             type: this.parseType as any,
             system: this.getSanitizedSystem(jsonData),
             folder: (await this.getFolder(jsonData, compendiumKey)).id,

--- a/src/templates/apps/bulk-importer.hbs
+++ b/src/templates/apps/bulk-importer.hbs
@@ -6,7 +6,8 @@
       Import data from Chummer5a using the <strong>Data Exporter</strong> format.<br />
       Upload your own package for full content (including translations and custom data),
       or let us download the latest supported version
-      (<strong><a href="{{info.versionLink}}" target="_blank" rel="noopener noreferrer">{{info.version}}</a></strong>) automatically.
+      (<strong><a href="{{info.versionLink}}" target="_blank" rel="noopener noreferrer">{{info.version}}</a></strong>)
+      automatically.
     </p>
 
     <div class="import-warning">
@@ -16,7 +17,10 @@
     </div>
 
     <p class="import-size">
-      Auto-download size: <strong>7&nbsp;MB</strong> (English only, standard data).
+      Auto-download size: <strong>7&nbsp;MB</strong> (English, default).
+    </p>
+    <p class="import-size">
+      use the german, portuguese, french or korean translations at your own risk.
     </p>
   </div>
 
@@ -24,76 +28,64 @@
   <fieldset class="import-settings">
     <legend>Import Settings</legend>
     <label class="import-setting">
-      <input
-        type="checkbox"
-        id="deleteCompendiums"
-        {{#if isImporting}}disabled{{else}}{{#if importDone}}disabled{{/if}}{{/if}}
-        {{#if deleteCompendiums}}checked{{/if}}
-      />
+      <input type="checkbox" id="deleteCompendiums" {{#if isImporting}}disabled{{else}}{{#if
+        importDone}}disabled{{/if}}{{/if}} {{#if deleteCompendiums}}checked{{/if}} />
       <span>Clear previously imported data before import</span>
     </label>
     <label class="import-setting">
-      <input
-        type="checkbox"
-        id="overrideDocuments"
-        {{#if isImporting}}disabled{{else}}{{#if importDone}}disabled{{/if}}{{/if}}
-        {{#if overrideDocuments}}checked{{/if}}
-      />
+      <input type="checkbox" id="overrideDocuments" {{#if isImporting}}disabled{{else}}{{#if
+        importDone}}disabled{{/if}}{{/if}} {{#if overrideDocuments}}checked{{/if}} />
       <span>Override previously imported documents in compendiums</span>
+    </label>
+    <label class="import-setting">
+      <input type="checkbox" id="useEnglishDefault" {{#if isImporting}}disabled{{else}}{{#if
+        importDone}}disabled{{/if}}{{/if}} {{#if useEnglishDefault}}checked{{/if}} />
+      <span>Use English default instead of system language</span>
     </label>
   </fieldset>
 
   <!-- File Input & Action Button -->
   <div class="import-actions">
     <div class="file-input-wrapper">
-      <input
-        type="file"
-        id="zipFileInput"
-        accept=".zip,application/zip"
-        aria-label="Select a Chummer data export .zip file"
-        {{#if isImporting}}disabled{{/if}}
-      />
+      <input type="file" id="zipFileInput" accept=".zip,application/zip"
+        aria-label="Select a Chummer data export .zip file" {{#if isImporting}}disabled{{/if}} />
       <label for="zipFileInput" class="file-input-label">
         {{#if zipFileName}}
-          <i class="fa-solid fa-folder"></i> <strong>{{zipFileName}}</strong>
+        <i class="fa-solid fa-folder"></i> <strong>{{zipFileName}}</strong>
         {{else}}
-          <i class="fa-solid fa-upload"></i> Select a .zip Package (Optional)
+        <i class="fa-solid fa-upload"></i> Select a .zip Package (Optional)
         {{/if}}
       </label>
     </div>
 
     <!-- Import Button / Progress Bar / Done State -->
     {{#if isImporting}}
-      <div class="import-progress-container">
-        <div class="import-progress-bar">
-          <div class="import-progress-fill" style="width: {{progress.pct}}%"></div>
-        </div>
-        <div class="import-progress-text">{{progress.pct}}% {{progress.message}}</div>
+    <div class="import-progress-container">
+      <div class="import-progress-bar">
+        <div class="import-progress-fill" style="width: {{progress.pct}}%"></div>
       </div>
+      <div class="import-progress-text">{{progress.pct}}% {{progress.message}}</div>
+    </div>
     {{else}}
-      {{#if importDone}}
-        <div class="import-done-container">
-          <div class="import-done-text">
-            <i class="fa-solid fa-check-circle"></i>
-            Import completed successfully!
-          </div>
-          <button type="button" id="resetImport" class="reset-button">
-            <i class="fa-solid fa-redo"></i> Import Again
-          </button>
-        </div>
+    {{#if importDone}}
+    <div class="import-done-container">
+      <div class="import-done-text">
+        <i class="fa-solid fa-check-circle"></i>
+        Import completed successfully!
+      </div>
+      <button type="button" id="resetImport" class="reset-button">
+        <i class="fa-solid fa-redo"></i> Import Again
+      </button>
+    </div>
+    {{else}}
+    <button type="button" id="importBtn" class="import-button">
+      {{#if zipFileName}}
+      <i class="fa-solid fa-folder"></i> Import from File
       {{else}}
-        <button
-          type="button"
-          id="importBtn"
-          class="import-button"
-        >
-          {{#if zipFileName}}
-            <i class="fa-solid fa-folder"></i> Import from File
-          {{else}}
-            <i class="fa-solid fa-download"></i> Download &amp; Import
-          {{/if}}
-        </button>
+      <i class="fa-solid fa-download"></i> Download &amp; Import
       {{/if}}
+    </button>
+    {{/if}}
     {{/if}}
   </div>
 


### PR DESCRIPTION
# Chummer Localization Support in Bulk Importer

## Description
This pull request adds support for full localization of imported items and actors when performing a bulk import. Previously, only the folder names were localized because the importer fetched only the primary UI localization file (e.g., `de-de.xml`). Now, the importer additionally fetches and parses the corresponding data-specific localization file (e.g., `de-de_data.xml`), translating item names (weapons, gear, qualities, spells, etc.) and categories into the active Foundry locale.

It also introduces an option to override the system language and default to English, along with updated disclaimers on translation stability.

---

## Proposed Changes

### Item Import System

#### 1. [ImportHelper.ts](file:///home/shadow/Documents/GitHub/SR5-FoundryVTT/src/module/apps/itemImport/helper/ImportHelper.ts)
- Added a static `translationMap` property to store translated strings.
- Added a static `translate` helper method that resolves localized strings using the loaded mapping, falling back to the original English text if missing.

#### 2. [Parser.ts](file:///home/shadow/Documents/GitHub/SR5-FoundryVTT/src/module/apps/itemImport/parser/Parser.ts)
- Updated item and actor parsing in `Parse` to wrap the entity name definition using `ImportHelper.translate(...)`.

#### 3. [BulkImporter.ts](file:///home/shadow/Documents/GitHub/SR5-FoundryVTT/src/module/apps/itemImport/apps/BulkImporter.ts)
- Added class variable `useEnglishDefault` to toggle forcing default English data.
- Updated `handleBulkImport` to check this setting before resolving active Foundry locale mapping.
- Added support for locating, fetching, and parsing data translation files (e.g., `de-de_data.xml`), merging translated item names and XML categories into `ImportHelper.translationMap`.
- Wired up context parameter and DOM checkbox listener for `useEnglishDefault` inside `_prepareContext` and `_onRender` respectively.
- Cleared the translation mapping on importer teardown to avoid memory leaks.

---

### UI & Templates

#### 4. [bulk-importer.hbs](file:///home/shadow/Documents/GitHub/SR5-FoundryVTT/src/templates/apps/bulk-importer.hbs)
- Updated download size disclaimer text and added translation warnings.
- Added a checkbox option to force the default English translation instead of using the system language.
