### PR TITLE
[Bug] Dice Icon for simple success test is missing

### DIFF
--- a/src/css/foundry-chat-message.scss
+++ b/src/css/foundry-chat-message.scss
@@ -18,39 +18,6 @@
     }
 }
 
-.chat-sidebar {
-    /** Style changes to suport the added roll dice icon on the icon row above the chat message input 
-    *   If not made, the chat messages will shrink, due to the icon added.
-    */
-    .chat-log {
-        width: 100%;
-        max-width: none;
-        padding-inline-start: 0;
-
-        > li.chat-message {
-            width: 100%;
-            max-width: none;
-            margin: 0 0 var(--chat-message-spacing);
-            padding: 8px;
-            box-sizing: border-box;
-        }
-
-        .message-content {
-            width: 100%;
-            max-width: none;
-            min-width: 0;
-            padding: 0;
-        }
-
-        .sr5.chat-card.roll-card {
-            width: 100%;
-            max-width: none;
-            margin-inline: 0;
-            box-sizing: border-box;
-        }
-    }
-}
-
 
 .sr5 {
     &.chat-card {
@@ -149,13 +116,11 @@
         --sr5-card-glitch-a: var(--sr5-theme-glitch-a);
         --sr5-card-glitch-b: var(--sr5-theme-glitch-b);
 
-        margin: 0;
+        margin: 0.2rem 0.1rem;
         font-size: 12px;
         color: var(--sr5-theme-text-primary);
         color: var(--sr5-card-text);
         border-color: var(--sr5-card-border);
-        width: 100%;
-        box-sizing: border-box;
 
         .card-title {
             display: flex;

--- a/src/css/foundry-chat-message.scss
+++ b/src/css/foundry-chat-message.scss
@@ -18,6 +18,39 @@
     }
 }
 
+.chat-sidebar {
+    /** Style changes to suport the added roll dice icon on the icon row above the chat message input 
+    *   If not made, the chat messages will shrink, due to the icon added.
+    */
+    .chat-log {
+        width: 100%;
+        max-width: none;
+        padding-inline-start: 0;
+
+        > li.chat-message {
+            width: 100%;
+            max-width: none;
+            margin: 0 0 var(--chat-message-spacing);
+            padding: 8px;
+            box-sizing: border-box;
+        }
+
+        .message-content {
+            width: 100%;
+            max-width: none;
+            min-width: 0;
+            padding: 0;
+        }
+
+        .sr5.chat-card.roll-card {
+            width: 100%;
+            max-width: none;
+            margin-inline: 0;
+            box-sizing: border-box;
+        }
+    }
+}
+
 
 .sr5 {
     &.chat-card {
@@ -116,11 +149,13 @@
         --sr5-card-glitch-a: var(--sr5-theme-glitch-a);
         --sr5-card-glitch-b: var(--sr5-theme-glitch-b);
 
-        margin: 0.2rem 0.1rem;
+        margin: 0;
         font-size: 12px;
         color: var(--sr5-theme-text-primary);
         color: var(--sr5-card-text);
         border-color: var(--sr5-card-border);
+        width: 100%;
+        box-sizing: border-box;
 
         .card-title {
             display: flex;

--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -175,7 +175,8 @@ export class HooksManager {
         Hooks.on('deleteItem', (item) => { void HooksManager.syncSkillGroupMembership(item); });
         Hooks.on('getChatMessageContextOptions', SuccessTest.chatMessageContextOptions.bind(SuccessTest));
 
-        Hooks.on("renderChatLog", HooksManager.chatLogListeners.bind(HooksManager));
+        (Hooks as any).on('renderChatInput', HooksManager.renderSuccessTestPromptButton.bind(HooksManager));
+        Hooks.on('renderChatLog', HooksManager.chatLogListeners.bind(HooksManager));
 
         MatrixHooks.registerHooks();
         RiggingHooks.registerHooks();
@@ -706,28 +707,42 @@ ___________________
     /**
      * Add a button to Prompt for a Success Test
      */
-    static renderSuccessTestPromptButton() {
+    static renderSuccessTestPromptButton(...args: unknown[]) {
+        const elements = args[1] as Record<string, HTMLElement> | undefined;
         const id = 'sr5e-success-test-button-prompt';
-        const inner = `<i class="fas fa-dice"></i>`;
-        // look for an already rendered button and update the innerHTML of it just in case it changed (I'm not sure this is necessary)
+        const inner = '<i class="fas fa-dice"></i>';
+
         const rendered = document.getElementById(id);
+        const container = elements?.['#chat-controls']
+            ?? elements?.['#message-modes']
+            ?? document.getElementById('chat-controls')
+            ?? document.getElementById('roll-privacy');
+
         if (rendered) {
             rendered.innerHTML = inner;
+            if (container && rendered.parentElement !== container) {
+                container.prepend(rendered);
+            }
+            return;
+        }
+
+        if (!container) return;
+
+        const button = document.createElement('button');
+        button.setAttribute('type', 'button');
+        button.setAttribute('id', id);
+        button.setAttribute('data-tooltip', 'SR5.Tests.SuccessTest');
+        button.setAttribute('aria-label', game.i18n.localize('SR5.Tests.SuccessTest'));
+        button.setAttribute('class', 'ui-control icon');
+        button.innerHTML = inner;
+        button.addEventListener('click', () => {
+            void TestCreator.promptSuccessTest();
+        });
+
+        if (container.firstElementChild && container.firstElementChild.id !== id) {
+            container.insertBefore(button, container.firstElementChild);
         } else {
-            // create the button using custom attributes 
-            const button = document.createElement('button');
-            button.setAttribute('type', 'button');
-            button.setAttribute('id', id);
-            button.setAttribute('data-tooltip', 'SR5.Tests.SuccessTest');
-            // this class matches what the existing icons use
-            button.setAttribute('class', 'ui-control icon');
-            button.innerHTML = inner;
-            button.addEventListener('click', () => {
-                TestCreator.promptSuccessTest();
-            })
-            // target the roll-privacy div that holds the different Roll options (Public/Self/etc)
-            const element = document.getElementById('roll-privacy');
-            element?.prepend(button);
+            container.prepend(button);
         }
     }
 }

--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -175,7 +175,6 @@ export class HooksManager {
         Hooks.on('deleteItem', (item) => { void HooksManager.syncSkillGroupMembership(item); });
         Hooks.on('getChatMessageContextOptions', SuccessTest.chatMessageContextOptions.bind(SuccessTest));
 
-        (Hooks as any).on('renderChatInput', HooksManager.renderSuccessTestPromptButton.bind(HooksManager));
         Hooks.on('renderChatLog', HooksManager.chatLogListeners.bind(HooksManager));
 
         MatrixHooks.registerHooks();
@@ -572,6 +571,18 @@ ___________________
 
         const situationModifiersControl = SituationModifiersApplication.getControl();
         controls.tokens.tools[situationModifiersControl.name] = situationModifiersControl;
+
+        const successTestControl = {
+            name: 'sr5-success-test',
+            title: 'SR5.Tests.SuccessTest',
+            icon: 'fas fa-dice',
+            button: true,
+            onChange: (_event: Event, active: boolean) => {
+                if (!active) return;
+                void TestCreator.promptSuccessTest();
+            },
+        };
+        controls.tokens.tools[successTestControl.name] = successTestControl;
     }
 
     /**
@@ -688,8 +699,6 @@ ___________________
         await ActionFollowupFlow.chatLogListeners(chatLog, html, data);
         await TeamworkTest.chatLogListeners(chatLog, html);
         await JournalEnrichers.chatlogRequestHooks(html);
-
-        this.renderSuccessTestPromptButton();
     }
 
     static configureVision() {
@@ -704,45 +713,4 @@ ___________________
         JournalEnrichers.setEnrichers();
     }
 
-    /**
-     * Add a button to Prompt for a Success Test
-     */
-    static renderSuccessTestPromptButton(...args: unknown[]) {
-        const elements = args[1] as Record<string, HTMLElement> | undefined;
-        const id = 'sr5e-success-test-button-prompt';
-        const inner = '<i class="fas fa-dice"></i>';
-
-        const rendered = document.getElementById(id);
-        const container = elements?.['#chat-controls']
-            ?? elements?.['#message-modes']
-            ?? document.getElementById('chat-controls')
-            ?? document.getElementById('roll-privacy');
-
-        if (rendered) {
-            rendered.innerHTML = inner;
-            if (container && rendered.parentElement !== container) {
-                container.prepend(rendered);
-            }
-            return;
-        }
-
-        if (!container) return;
-
-        const button = document.createElement('button');
-        button.setAttribute('type', 'button');
-        button.setAttribute('id', id);
-        button.setAttribute('data-tooltip', 'SR5.Tests.SuccessTest');
-        button.setAttribute('aria-label', game.i18n.localize('SR5.Tests.SuccessTest'));
-        button.setAttribute('class', 'ui-control icon');
-        button.innerHTML = inner;
-        button.addEventListener('click', () => {
-            void TestCreator.promptSuccessTest();
-        });
-
-        if (container.firstElementChild && container.firstElementChild.id !== id) {
-            container.insertBefore(button, container.firstElementChild);
-        } else {
-            container.prepend(button);
-        }
-    }
 }


### PR DESCRIPTION
The dice icon for rolling a simple success test has been missing from the chat message area for v14, as Foundry changed their HTML structure.

Adding it back in as its own icon next to the message mode icons causes layout issues with the overall chat log message sizing. Instead of introducing additional css, altering Foundry styling, I added the icon to the Token sidebar, next to the other two system apps:

<img width="316" height="471" alt="image" src="https://github.com/user-attachments/assets/c28d0114-0805-4b2e-b71d-2eadc43e31a5" />

With that the test prompt is now on the same level as overwatch score monitor and situational modifier, both with placement and with that placement coming with a keybinding.