### PR TITLE
[Bug] Fix actor sheet import review actions, move item handling, and reputation manager submit

### DIFF
--- a/packs/_source/sr5e-matrix-actions/trace-icon.json
+++ b/packs/_source/sr5e-matrix-actions/trace-icon.json
@@ -7,7 +7,7 @@
     "description": {
       "value": "",
       "chat": "",
-      "source": ""
+      "source": "SR5 243"
     },
     "action": {
       "type": "complex",

--- a/src/css/bundle-v2.scss
+++ b/src/css/bundle-v2.scss
@@ -412,6 +412,19 @@ body.theme-light,
                 display: flex;
                 flex-flow: row nowrap;
                 align-items: center;
+                gap: .25rem;
+                min-width: 0;
+            }
+
+            .sheet-header-name-input {
+                flex: 1 1 auto;
+                min-width: 0;
+
+                .sheet-name {
+                    width: 100%;
+                    min-width: 0;
+                    flex-shrink: 1;
+                }
             }
         }
 
@@ -482,9 +495,15 @@ body.theme-light,
         padding: 0;
     }
 
-    button.toggle-fresh-import {
+    .toggle-fresh-import {
         width: 1.5rem;
         flex-shrink: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    button.toggle-fresh-import {
         padding: 0;
     }
 

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -351,6 +351,7 @@ export class SR5BaseActorSheet<T extends SR5ActorSheetData = SR5ActorSheetData> 
             clearConditionMonitor: SR5BaseActorSheet.#clearConditionMonitor,
             rollConditionMonitor: SR5BaseActorSheet.#rollConditionMonitor,
 
+            clearFreshImports: SR5BaseActorSheet.#clearFreshImports,
             openSituationalModifiers: SR5BaseActorSheet.#openSituationalModifiers
         },
         filters: [{ inputSelector: '#filter-active-skills', contentSelector: '', callback: SR5BaseActorSheet.#handleFilterActiveSkills }],
@@ -2076,18 +2077,24 @@ export class SR5BaseActorSheet<T extends SR5ActorSheetData = SR5ActorSheetData> 
     }
 
     /**
-     * Toggle to isFreshImport property of importFlags for all items on the character sheet
-     *
-     * @param event
+     * Clear the fresh import flag for all owned items on the actor sheet.
      */
-    async _toggleAllFreshImportFlags(event: PointerEvent, onOff: boolean) {
+    static async #clearFreshImports(this: SR5BaseActorSheet, event: PointerEvent) {
+        event.preventDefault();
+        event.stopPropagation();
         if (!(event.target instanceof HTMLElement)) return;
+
         const allItems = this.actor.items;
-        console.debug('Toggling all importFlags on owned items to ->', onOff, event);
-        for (const item of allItems) {
-            if (item.system.importFlags) {
-                await item.update({ system: { importFlags: { isFreshImport: onOff } } });
-            }
+        console.debug(`Shadowrun 5e | Clearing fresh import flags for ${allItems.size} owned items`, event);
+        const updates = allItems
+            .filter(item => item.system.importFlags?.isFreshImport === true)
+            .map(item => ({
+                _id: item.id,
+                system: { importFlags: { isFreshImport: false } }
+            }));
+
+        if (updates.length > 0) {
+            await this.actor.updateEmbeddedDocuments('Item', updates);
         }
     }
 

--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -326,6 +326,7 @@ export class SR5BaseActorSheet<T extends SR5ActorSheetData = SR5ActorSheetData> 
 
             addItem: SR5BaseActorSheet.#createItem,
             editItem: SR5BaseActorSheet.#editItem,
+            moveItem: SR5BaseActorSheet.#moveItem,
             deleteItem: SR5BaseActorSheet.#deleteItem,
             favoriteItem: SR5BaseActorSheet.#favoriteItem,
 
@@ -1095,6 +1096,12 @@ export class SR5BaseActorSheet<T extends SR5ActorSheetData = SR5ActorSheetData> 
             item = await fromUuid(uuid);
         }
         if (item) await item.sheet?.render(true, { mode: 'edit' } as any);
+    }
+
+    static async #moveItem(this: SR5BaseActorSheet, event: PointerEvent) {
+        event.preventDefault();
+        if (!(event.target instanceof HTMLElement)) return;
+        await this._moveItemToInventory(event.target);
     }
 
     async _handleDeleteItem(item: SR5Item) {

--- a/src/module/apps/actor/ReputationManager.ts
+++ b/src/module/apps/actor/ReputationManager.ts
@@ -102,7 +102,11 @@ export class ReputationManager extends HandlebarsApplicationMixin(ApplicationV2)
         await this.render();
     }
 
-    static async #submitChanges(this: ReputationManager) {
+    static async #submitChanges(this: ReputationManager, event: Event) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!(event.target instanceof HTMLElement)) return;
+
         const updateData = {};
         if (this.streetCredModifier !== 0) {
             updateData['system.street_cred'] = this.getStreetCred() + this.streetCredModifier;
@@ -113,7 +117,7 @@ export class ReputationManager extends HandlebarsApplicationMixin(ApplicationV2)
         if (this.notorietyModifier !== 0) {
             updateData['system.notoriety'] = this.getNotoriety() + this.notorietyModifier;
         }
-        if (!isEmpty(updateData)) {
+        if (!foundry.utils.isEmpty(updateData)) {
             await this.actor.update(updateData);
         }
         void this.close();

--- a/src/templates/v2/actor/header.hbs
+++ b/src/templates/v2/actor/header.hbs
@@ -10,7 +10,7 @@
             {{#unless isLimited}}
                 {{#if (hasAnyFreshImports actor)}}
                     {{#if @root.isEditMode}}
-                        <button type="button" class="toggle-fresh-import" data-tooltip="SR5.MarkImportsTooltip" data-action="toggleFreshImports">
+                        <button type="button" class="toggle-fresh-import" data-tooltip="SR5.MarkImportsTooltip" data-action="clearFreshImports">
                             <img src="systems/shadowrun5e/dist/icons/checklist-white.svg" width="32px" height="32px" />
                         </button>
                     {{else}}

--- a/src/templates/v2/actor/header.hbs
+++ b/src/templates/v2/actor/header.hbs
@@ -14,15 +14,17 @@
                             <img src="systems/shadowrun5e/dist/icons/checklist-white.svg" width="32px" height="32px" />
                         </button>
                     {{else}}
-                        <label class="toggle-fresh-import" data-tooltip="SR5.MarkImportsTooltip" style="width: 1.5rem; flex-shrink: 0;">
+                        <label class="toggle-fresh-import" data-tooltip="SR5.MarkImportsTooltip">
                             <img src="systems/shadowrun5e/dist/icons/checklist-white.svg" width="32px" height="32px" />
                         </label>
                     {{/if}}
                 {{/if}}
                 {{> 'systems/shadowrun5e/dist/templates/v2/common/document-source-icon.hbs' system.description.source }}
             {{/unless}}
-            {{formInput fields.name value=actor.name classes="sheet-name"
-                        placeholder=(localize "SR5.Name") disabled=@root.isPlayMode rootId=rootId}}
+            <span class="sheet-header-name-input">
+                {{formInput fields.name value=actor.name classes="sheet-name"
+                            placeholder=(localize "SR5.Name") disabled=@root.isPlayMode rootId=rootId}}
+            </span>
         </div>
         {{#if @root.isEditMode}}
             <div class="sheet-header-source">

--- a/src/templates/v2/item/header.hbs
+++ b/src/templates/v2/item/header.hbs
@@ -16,13 +16,13 @@
                                 <img src="systems/shadowrun5e/dist/icons/checklist-white.svg" width="32px" height="32px" />
                             </button>
                         {{else}}
-                            <label class="toggle-fresh-import" style="width: 1.5rem; flex-shrink: 0;" data-tooltip="SR5.MarkImportedItemTooltip">
+                            <label class="toggle-fresh-import" data-tooltip="SR5.MarkImportedItemTooltip">
                                 <img src="systems/shadowrun5e/dist/icons/checklist-white.svg" width="32px" height="32px" />
                             </label>
                         {{/if}}
                     {{/if}}
                 {{/unless}}
-                <span style="width: 100%">
+                <span class="sheet-header-name-input">
                     {{formInput fields.name value=item.name classes="sheet-name"
                                 placeholder=(localize "SR5.Name") disabled=@root.isPlayMode rootId=rootId}}
                 </span>

--- a/src/templates/v2/item/header/skill.hbs
+++ b/src/templates/v2/item/header/skill.hbs
@@ -17,13 +17,13 @@
                                         <img src="systems/shadowrun5e/dist/icons/checklist-white.svg" width="32px" height="32px" />
                                     </button>
                                 {{else}}
-                                    <label style="width: 1.5rem; flex-shrink: 0;" data-tooltip="SR5.MarkImportedItemTooltip">
+                                    <label class="toggle-fresh-import" data-tooltip="SR5.MarkImportedItemTooltip">
                                         <img src="systems/shadowrun5e/dist/icons/checklist.svg" width="32px" height="32px" />
                                     </label>
                                 {{/if}}
                             {{/if}}
                         {{/unless}}
-                        <span style="width: 100%">
+                        <span class="sheet-header-name-input">
                             {{#if @root.isEditMode}}
                                 {{formInput fields.name value=item.name classes="sheet-name"
                                             placeholder=(localize "SR5.Name") rootId=rootId}}


### PR DESCRIPTION
## Summary

This PR fixes five regressions for `release/0.36.0`:

- #1953
- #1952
- #1951
- #1950
- #1949

## What changed

- Fixed the actor sheet action for reviewing imported items so it clears fresh import flags correctly.
- Fixed the actor sheet move-item action so items can be moved between inventories again.
- Fixed the Street Cred dialog submit flow so changes are applied and the dialog closes.
- Fixed imported actor header layout in edit mode so the name field no longer overlaps the Edge area.
- Added the missing source reference for the `Trace Icon` matrix action.

## Closes

Closes #1953  
Closes #1952  
Closes #1951  
Closes #1950  
Closes #1949