### PR TITLE
[Bug] Fix Chummer data parsing by updating the importer data source

### DIFF
--- a/src/module/apps/itemImport/apps/BulkImporter.ts
+++ b/src/module/apps/itemImport/apps/BulkImporter.ts
@@ -98,8 +98,8 @@ export class BulkImporter extends BaseClass {
     private static readonly githubConfig = {
         owner: "chummer5a",
         repo: "chummer5a",
-        version: "v5.226.0",
-        branch: "0c354ec2b81da5ccd2c93648f93ec8f6831c030e",
+        version: "v5.226.91",
+        branch: "8544ecee1ad3edccc0853b7821067542130a5c68",
     } as const;
 
     /**

--- a/src/module/apps/itemImport/schema/QualitiesSchema.ts
+++ b/src/module/apps/itemImport/schema/QualitiesSchema.ts
@@ -36,7 +36,7 @@ export interface Quality {
     metagenic?: { _TEXT: "True"; };
     mutant?: { _TEXT: "True"; };
     name: { _TEXT: string; };
-    nameonpage?: { _TEXT: "Adepts" | "Aspected Magicians" | "Magicians" | "Mystic Adepts" | "Special Modifications"; };
+    nameonpage?: { _TEXT: string; };
     naturalweapons?: {
         naturalweapon: OneOrMany<{
             accuracy: { _TEXT: "Physical"; };

--- a/utils/generate_schemas.py
+++ b/utils/generate_schemas.py
@@ -19,7 +19,7 @@ from io import BytesIO
 # Repository details for fetching XML files if no local path is provided
 OWNER = "chummer5a"
 REPO = "chummer5a"
-BRANCH = "0c354ec2b81da5ccd2c93648f93ec8f6831c030e"  # v5.256.0
+BRANCH = "8544ecee1ad3edccc0853b7821067542130a5c68"  # v5.226.91
 
 # String length threshold for inline union literals
 STRING_LIMIT = 100


### PR DESCRIPTION
## Summary

- Update the importer to Chummer v5.226.91.
- Align schema generation with the same Chummer revision.
- Fix parsing failures caused by outdated Chummer data.