### PR TITLE
[Bug] Restore default status conditions in Foundry V14 active effects and token HUD.

### DIFF
--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -415,7 +415,11 @@ ___________________
         // @ts-expect-error // TODO: Add declaration merging
         CONFIG.SR5 = SR5;
 
-        CONFIG.statusEffects.splice(5, 0, ...SRStatus);
+        CONFIG.statusEffects = [
+            ...CONFIG.statusEffects.slice(0, 5),
+            ...SRStatus,
+            ...CONFIG.statusEffects.slice(5),
+        ];
 
         CONFIG.Actor.compendiumIndexFields.push("system.description", "system.importFlags.isFreshImport");
         CONFIG.Item.compendiumIndexFields.push("system.description", "system.importFlags.isFreshImport");


### PR DESCRIPTION
## Problem
Foundry V14 stores `CONFIG.statusEffects` as a proxy-backed registry. Our old `splice(5, 0, ...SRStatus)` insertion shifted the numeric entries in place, but it did not preserve the full ID-keyed registry correctly. As a result, many default status conditions disappeared from places that read the registry with `Object.values(CONFIG.statusEffects)`, including the Active Effect form and the Token HUD.

When: 0.35.0

## Before fix:
<img width="546" height="360" alt="image" src="https://github.com/user-attachments/assets/094f52c4-fd01-4bba-a26d-e7bd5b5eabe1" />


