### PR TITLE
[Bug] Wait for asset copy streams before completing Gulp builds

### DIFF
--- a/gulp.tasks.js
+++ b/gulp.tasks.js
@@ -1,6 +1,7 @@
 'use strict';
 const fs = require('fs-extra');
 const path = require('path');
+const { finished } = require('stream/promises');
 
 // Sass
 const gulpsass = require('gulp-sass')(require('sass'));
@@ -84,9 +85,11 @@ const buildJSDev = () => buildJS('dev');
  * COPY ASSETS
  */
 async function copyAssets() {
-    gulp.src('public/**/*', {encoding: false}).pipe(gulp.dest(destFolder));
-    gulp.src('src/templates/**/*').pipe(gulp.dest(path.resolve(destFolder, 'templates')));
-    gulp.src('src/module/tours/jsons/**/*').pipe(gulp.dest(path.resolve(destFolder, 'tours')));
+    await Promise.all([
+        finished(gulp.src('public/**/*', {encoding: false}).pipe(gulp.dest(destFolder))),
+        finished(gulp.src('src/templates/**/*').pipe(gulp.dest(path.resolve(destFolder, 'templates')))),
+        finished(gulp.src('src/module/tours/jsons/**/*').pipe(gulp.dest(path.resolve(destFolder, 'tours')))),
+    ]);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes Gulp builds completing before public assets, templates, and tours finish copying into `dist`.

## Changes

- Await all asset copy streams with `stream/promises.finished`.
- Run the independent copy operations concurrently with `Promise.all`.
- Ensure subsequent build steps only start after copied assets are available.
