### PR TITLE
[Bug] Prevent repeated migration prompts and ActorDelta update failures

### DIFF
--- a/src/module/migrator/Migrator.ts
+++ b/src/module/migrator/Migrator.ts
@@ -242,6 +242,8 @@ export class Migrator {
 
     public static BeginMigration() {
         if (this.pendingMigrationCount === 0) return;
+        const migratedVersion = game.settings.get(game.system.id, FLAGS.KEY_DATA_VERSION);
+        if (this.compareVersion(migratedVersion, game.system.version) >= 0) return;
 
         const localizedWarningTitle = game.i18n.localize('SR5.MIGRATION.WarningTitle');
         const localizedWarningHeader = game.i18n.localize('SR5.MIGRATION.WarningHeader');
@@ -295,7 +297,7 @@ export class Migrator {
         try {
             return await cls.implementation.updateDocuments(
                 docs.filter(d => d._stats?.systemVersion === this._migrationMark) as any,
-                { diff: false, recursive: false, parent: parent as any }
+                { parent: parent as any, diff: false, recursive: false, noHook: true, render: false }
             );
         } catch (error) {
             console.error(`Failed migration update for ${cls.documentName} documents (parent: ${parent?.uuid ?? 'none'}).`, error);
@@ -344,8 +346,17 @@ export class Migrator {
             this.updateProgressbar();
             try {
                 await TokenDocument.implementation.updateDocuments(
-                    scene.tokens.map(t => t.toObject()),
-                    { diff: false, recursive: false, parent: scene }
+                    scene.tokens.map(token => {
+                        const data = token.toObject();
+
+                        // Foundry uses the parent token ID as the ActorDelta ID.
+                        // Provide it upfront to avoid ActorDeltaField._updateDiff assigning _id to the cleaned update value.
+                        if (!token.actorLink && data.delta && !data.delta._id)
+                            data.delta._id = token.id;
+
+                        return data;
+                    }),
+                    { parent: scene, diff: false, recursive: false, noHook: true, render: false }
                 );
             } catch (error) {
                 console.error(`Failed migration update for Token documents in ${scene.uuid}.`, error);

--- a/src/module/migrator/Migrator.ts
+++ b/src/module/migrator/Migrator.ts
@@ -236,8 +236,8 @@ export class Migrator {
         if (doc.parent instanceof Actor || doc.parent instanceof Item || doc.parent instanceof Combat)
             await this.updateMigratedDocument(doc.parent);
 
-        // Persist the change without triggering diff logic
-        return doc.update(doc.toObject() as any, { diff: false, recursive: false });
+        // Save migrated data silently (no hooks/renders) to avoid intermediate state issues.
+        return doc.update(doc.toObject() as any, { diff: false, recursive: false, noHook: true, render: false });
     }
 
     public static BeginMigration() {
@@ -297,6 +297,7 @@ export class Migrator {
         try {
             return await cls.implementation.updateDocuments(
                 docs.filter(d => d._stats?.systemVersion === this._migrationMark) as any,
+                // Save migrated data silently (no hooks/renders) to avoid intermediate state issues.
                 { parent: parent as any, diff: false, recursive: false, noHook: true, render: false }
             );
         } catch (error) {
@@ -356,6 +357,7 @@ export class Migrator {
 
                         return data;
                     }),
+                    // Save migrated data silently (no hooks/renders) to avoid intermediate state issues.
                     { parent: scene, diff: false, recursive: false, noHook: true, render: false }
                 );
             } catch (error) {


### PR DESCRIPTION
## Summary

- Skip the migration prompt when the world was already migrated on the current or a newer system version.
- Supply missing ActorDelta IDs when updating unlinked scene tokens.
- Disable hooks and rendering during bulk migration updates.
