### PR TITLE
[Bug] Fix sprite sheet misc fields throwing formInput errors on first render

### DIFF
--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -740,7 +740,7 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
      * Determine if an actor can choose a full defense attribute
      */
     get hasFullDefense(): boolean {
-        return ['character', 'vehicle', 'sprite', 'spirit'].includes(this.type);
+        return ['character', 'vehicle', 'spirit'].includes(this.type);
     }
 
     /**

--- a/src/templates/v2/actor/tabs/misc.hbs
+++ b/src/templates/v2/actor/tabs/misc.hbs
@@ -30,7 +30,7 @@
                             </div>
                         </div>
                     {{/if}}
-                    {{#if emerged}}
+                    {{#if (and emerged systemFields.technomancer)}}
                         <div class="list-item">
                             <div class="list-item-start">
                                 <label data-tooltip="{{systemFields.technomancer.fields.attribute.hint}}">
@@ -234,34 +234,37 @@
             <section class="scrollable standard-form">
                 {{#if @root.isPlayMode}}
                     {{#each system.modifiers as |value id|}} {{#ifne id 'wound'}} {{#if value}}
+                        {{#with (objValue @root.systemFields.modifiers.fields id) as |modifierField|}}
                         <div class="list-item">
                             <div class="list-item-start">
-                                <label data-tooltip="{{objValue (objValue @root.systemFields.modifiers.fields id) 'hint'}}">
-                                    {{objValue (objValue @root.systemFields.modifiers.fields id) 'label'}}
+                                <label data-tooltip="{{modifierField.hint}}">
+                                    {{modifierField.label}}
                                 </label>
                             </div>
                             <div class="list-item-col">
                                 <label>{{value}}</labeL>
                             </div>
                         </div>
+                        {{/with}}
                     {{/if}} {{/ifne}} {{/each}}
                 {{else}}
                     {{#each source.system.modifiers as |value id|}} {{#ifne id 'wound'}}
+                        {{#with (objValue @root.systemFields.modifiers.fields id) as |modifierField|}}
                         <div class="list-item">
                             <div class="list-item-start">
-                                <label data-tooltip="{{objValue (objValue @root.systemFields.modifiers.fields id) 'hint'}}">
-                                    {{objValue (objValue @root.systemFields.modifiers.fields id) 'label'}}
+                                <label data-tooltip="{{modifierField.hint}}">
+                                    {{modifierField.label}}
                                 </label>
                             </div>
                             <div class="list-item-col">
-                                {{formInput (objValue @root.systemFields.modifiers.fields id) value=value
+                                {{formInput modifierField value=value
                                             classes="short skinny" rootId=@root.rootId disabled=@root.isPlayMode }}
                             </div>
                         </div>
+                        {{/with}}
                     {{/ifne}} {{/each}}
                 {{/if}}
             </section>
         </div>
     </div>
 </section>
-


### PR DESCRIPTION
## Summary

Fix sprite actor sheet console errors on first render by preventing the misc tab from rendering form inputs for schema fields sprites do not have.

## Changes

- stop treating sprites as actors with a configurable `full_defense_attribute`
- guard the technomancer misc control so it only renders when the actor schema includes that field
- guard modifier field rendering so `formInput` is only called with existing schema fields

## Result

Creating a sprite actor no longer throws `Non-existent data field provided to {{formInput}} handlebars helper.` during the automatic first sheet render.

## Fixes
Fixes #1881 