### PR TITLE
[Bug] Fix ritual seal dice pool accumulation and ritual failure typo

### DIFF
--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -2800,7 +2800,7 @@
             "ResistedAllDamage": "No Damage taken!",
             "ResistedSomeDamage": "Damage taken!",
             "Results": "Results",
-            "RitualFailure": "The ritual was to strong for you",
+            "RitualFailure": "The ritual was too strong for you",
             "RitualSuccess": "The ritual is sealed",
             "SoakBlockedByHardenedArmor": "Blocked By Hardened Armor",
             "SpiritSummonFailure": "Spirit fled!",

--- a/src/module/tests/OpposedRitualTest.ts
+++ b/src/module/tests/OpposedRitualTest.ts
@@ -46,7 +46,8 @@ export class OpposedRitualTest extends OpposedTest<OpposedRitualTestData> {
     override applyPoolModifiers() {
         // NOTE: We don't have an actor, therefore don't need to call document modifiers.
         const pool = new ModifiableValue(this.data.pool);
-        pool.addUniqueBase('SR5.Force', this.against.data.force);
+        pool.remove('SR5.Force');
+        pool.addBase('SR5.Force', this.against.data.force);
         pool.addBase('SR5.Force', this.against.data.force);
     }
 


### PR DESCRIPTION
## Summary
Fix ritual sealing so repeated test preparation does not keep adding extra Force dice to the opposed pool.

This PR:
- rebuilds the ritual seal pool as exactly `Force + Force` on each preparation pass
- fixes the English ritual failure message typo from `to strong` to `too strong`


Fixes #1870 