### PR TITLE
[Bug] Fix natural recovery extended tests using a shrinking threshold

### DIFF
--- a/src/module/tests/NaturalRecoveryPhysicalTest.ts
+++ b/src/module/tests/NaturalRecoveryPhysicalTest.ts
@@ -27,10 +27,13 @@ export class NaturalRecoveryPhysicalTest extends SuccessTest {
     prepareThreshold() {
         if (!this.actor) return;
 
+        const threshold = new ModifiableValue(this.threshold);
+        if (this.extendedRoll && threshold.get('SR5.PhysicalTrack') !== undefined) return;
+
         const track = this.actor.getPhysicalTrack();
         const boxes = track?.value || 0;
 
-        ModifiableValue.addUniqueBase(this.threshold, 'SR5.PhysicalTrack', boxes)
+        threshold.addUniqueBase('SR5.PhysicalTrack', boxes)
     }
 
     /**

--- a/src/module/tests/NaturalRecoveryStunTest.ts
+++ b/src/module/tests/NaturalRecoveryStunTest.ts
@@ -17,10 +17,13 @@ export class NaturalRecoveryStunTest extends SuccessTest {
     prepareThreshold() {
         if (!this.actor) return;
 
+        const threshold = new ModifiableValue(this.threshold);
+        if (this.extendedRoll && threshold.get('SR5.StunTrack') !== undefined) return;
+
         const track = this.actor.getStunTrack();
         const boxes = track?.value || 0;
 
-        ModifiableValue.addUniqueBase(this.threshold, 'SR5.StunTrack', boxes)
+        threshold.addUniqueBase('SR5.StunTrack', boxes)
     }
 
     /**

--- a/src/unittests/sr5.Testing.spec.ts
+++ b/src/unittests/sr5.Testing.spec.ts
@@ -3,6 +3,8 @@ import { QuenchBatchContext } from "@ethaks/fvtt-quench";
 import { TestCreator } from "../module/tests/TestCreator";
 import { DataDefaults } from "@/module/data/DataDefaults";
 import { ModifiableValue } from "@/module/mods/ModifiableValue";
+import { NaturalRecoveryStunTest } from "@/module/tests/NaturalRecoveryStunTest";
+import { NaturalRecoveryPhysicalTest } from "@/module/tests/NaturalRecoveryPhysicalTest";
 
 export const shadowrunTesting = (context: QuenchBatchContext) => {
     const factory = new SR5TestFactory();
@@ -194,6 +196,60 @@ export const shadowrunTesting = (context: QuenchBatchContext) => {
             }));
 
             assert.isTrue(test.codeTerms.threshold.every(term => !term.tooltipSource));
+        });
+
+        it('keeps the stun recovery threshold fixed on extended rolls', async () => {
+            const actor = await factory.createActor({
+                type: 'character',
+                system: {
+                    track: {
+                        stun: { value: 5 }
+                    }
+                }
+            });
+
+            const test = new NaturalRecoveryStunTest(TestCreator._minimalTestData(), { actor }, { showMessage: false, showDialog: false });
+            test.prepareBaseValues();
+            test.calculateBaseValues();
+
+            assert.strictEqual(test.threshold.value, 5);
+
+            await actor.update({ system: { track: { stun: { value: 2 } } } });
+
+            const extendedData = foundry.utils.duplicate(test.data);
+            extendedData.extendedRoll = true;
+            const extendedTest = new NaturalRecoveryStunTest(extendedData, { actor }, { showMessage: false, showDialog: false });
+            extendedTest.prepareBaseValues();
+            extendedTest.calculateBaseValues();
+
+            assert.strictEqual(extendedTest.threshold.value, 5);
+        });
+
+        it('keeps the physical recovery threshold fixed on extended rolls', async () => {
+            const actor = await factory.createActor({
+                type: 'character',
+                system: {
+                    track: {
+                        physical: { value: 6 }
+                    }
+                }
+            });
+
+            const test = new NaturalRecoveryPhysicalTest(TestCreator._minimalTestData(), { actor }, { showMessage: false, showDialog: false });
+            test.prepareBaseValues();
+            test.calculateBaseValues();
+
+            assert.strictEqual(test.threshold.value, 6);
+
+            await actor.update({ system: { track: { physical: { value: 3 } } } });
+
+            const extendedData = foundry.utils.duplicate(test.data);
+            extendedData.extendedRoll = true;
+            const extendedTest = new NaturalRecoveryPhysicalTest(extendedData, { actor }, { showMessage: false, showDialog: false });
+            extendedTest.prepareBaseValues();
+            extendedTest.calculateBaseValues();
+
+            assert.strictEqual(extendedTest.threshold.value, 6);
         });
 
         it('evaluate an opposed roll from a opposed action', async () => {


### PR DESCRIPTION
## Summary

Natural recovery extended tests were recalculating their threshold on each follow-up roll from the actor's current remaining damage. Because extended hits are accumulated across the whole sequence, this caused later rolls to compare against a smaller threshold and stop the test prematurely.

This change keeps the original stun or physical damage threshold for the full extended recovery sequence while preserving the existing behavior for the first roll of a new recovery test.

## Changes

- Preserve the existing `SR5.StunTrack` threshold on `NaturalRecoveryStunTest` extended rerolls
- Preserve the existing `SR5.PhysicalTrack` threshold on `NaturalRecoveryPhysicalTest` extended rerolls
- Add deterministic regression tests covering stun and physical natural recovery extended rolls

Fixes #1741