### PR TITLE
[Bug] Fix stale Matrix mark storage on mark cleanup.

### DIFF
--- a/src/module/actor/flows/ActorMarksFlow.ts
+++ b/src/module/actor/flows/ActorMarksFlow.ts
@@ -97,6 +97,7 @@ export const ActorMarksFlow = {
 
         // Delete all markId properties from ActorData
         await persona.update({ system: { matrix: { marks: [] } } });
+        if (persona.uuid) await MarksStorage.storeRelations(persona.uuid, []);
     },
 
     /**
@@ -107,6 +108,7 @@ export const ActorMarksFlow = {
 
         const marksData = persona.matrixData()?.marks.filter(mark => mark.uuid !== uuid) ?? [];
         await persona.update({ system: { matrix: { marks: marksData } } });
+        if (persona.uuid) await MarksStorage.storeRelations(persona.uuid, marksData);
     },
 
     /**

--- a/src/module/flows/StorageFlow.ts
+++ b/src/module/flows/StorageFlow.ts
@@ -2,6 +2,7 @@ import { MatrixNetworkFlow } from '@/module/item/flows/MatrixNetworkFlow';
 import { SR5Actor } from '@/module/actor/SR5Actor';
 import { SR5Item } from '@/module/item/SR5Item';
 import { ItemMarksFlow } from '@/module/item/flows/ItemMarksFlow';
+import { MarksStorage } from '@/module/storage/MarksStorage';
 
 /**
  * Storage Flow Handles global storage changes when an actor or item is deleted
@@ -54,6 +55,7 @@ export const StorageFlow = {
             message: `${actor.name} - ${game.i18n.localize(`SR5.Notifications.DeletingStorageReferences.Finished`)}`,
         });
         // handle our own actual deletion
+        if (actor.uuid) await MarksStorage.clearRelations(actor.uuid);
         await MatrixNetworkFlow.handleOnDeleteDocument(actor);
         // remove the progress bar now, we don't need to keep it around
         progressBar.remove();

--- a/src/module/storage/MarksStorage.ts
+++ b/src/module/storage/MarksStorage.ts
@@ -92,7 +92,7 @@ export const MarksStorage = {
     getMarksRelations(uuid: string): string[] {
         const uuidForStorage = Helpers.uuidForStorage(uuid);
         const marksStorage = MarksStorage.getStorage();
-        return marksStorage[`${MarksStorage.key}.${uuidForStorage}`] ?? [];
+        return marksStorage[uuidForStorage] ?? [];
     },
 
     /**
@@ -103,9 +103,17 @@ export const MarksStorage = {
      */
     async storeRelations(uuid: string, marksData: MatrixMarksType) {
         const uuidForStorage = Helpers.uuidForStorage(uuid);
-        const key = `${MarksStorage.key}.${uuidForStorage}`;
         const marks = marksData.map(({uuid}) => uuid);
-        await DataStorage.set(key, marks);
+
+        if (marks.length === 0) {
+            const storage = MarksStorage.getStorage();
+            delete storage[uuidForStorage];
+            await DataStorage.set(MarksStorage.key, storage);
+        } else {
+            const key = `${MarksStorage.key}.${uuidForStorage}`;
+            await DataStorage.set(key, marks);
+        }
+
         await MarksStorage.cleanupOrphanedRelations();
     },
 
@@ -144,7 +152,12 @@ export const MarksStorage = {
             // if we don't include the id, skip this object
             if (!markRelations.includes(uuid)) continue;
             changed = true;
-            storage[uuidForStorage] = markRelations.filter(markedUuid => markedUuid !== uuid);
+            const updatedRelations = markRelations.filter(markedUuid => markedUuid !== uuid);
+            if (updatedRelations.length === 0) {
+                delete storage[uuidForStorage];
+            } else {
+                storage[uuidForStorage] = updatedRelations;
+            }
 
             // Update lokal marks placed on the main uuid.
             const document = fromUuidSync(Helpers.uuidFromStorage(uuidForStorage)) as SR5Actor | SR5Item;

--- a/src/unittests/sr5.Marks.spec.ts
+++ b/src/unittests/sr5.Marks.spec.ts
@@ -1,5 +1,7 @@
 import { SR5TestFactory } from "./utils";
 import { QuenchBatchContext } from "@ethaks/fvtt-quench";
+import { Helpers } from "@/module/helpers";
+import { MarksStorage } from "@/module/storage/MarksStorage";
 
 export const shadowrunMarks = (context: QuenchBatchContext) => {
     const factory = new SR5TestFactory();
@@ -85,6 +87,55 @@ export const shadowrunMarks = (context: QuenchBatchContext) => {
 
             correctMarks = decker.getMarksPlaced(grid.uuid);
             assert.equal(correctMarks, 0);
+        });
+
+        it('Should remove one cleared mark from actor data and global marks storage', async () => {
+            const decker = await factory.createActor({ type: 'character' });
+            const firstTarget = await factory.createItem({ type: 'device' });
+            const secondTarget = await factory.createItem({ type: 'device' });
+
+            await decker.setMarks(firstTarget, 1);
+            await decker.setMarks(secondTarget, 1);
+            await decker.clearMark(firstTarget.uuid);
+
+            assert.equal(decker.getMarksPlaced(firstTarget.uuid), 0);
+            assert.equal(decker.getMarksPlaced(secondTarget.uuid), 1);
+            assert.sameMembers(MarksStorage.retrieveMarks(decker), [secondTarget.uuid]);
+            assert.sameMembers(MarksStorage.getMarksRelations(decker.uuid), [secondTarget.uuid]);
+        });
+
+        it('Should remove all cleared marks from actor data and global marks storage', async () => {
+            const decker = await factory.createActor({ type: 'character' });
+            const target = await factory.createItem({ type: 'device' });
+
+            await decker.setMarks(target, 1);
+            await decker.clearMarks();
+
+            assert.lengthOf(decker.marksData ?? [], 0);
+            assert.notProperty(MarksStorage.getStorage(), Helpers.uuidForStorage(decker.uuid));
+        });
+
+        it('Should remove global marks storage relations when the marking actor is deleted', async () => {
+            const decker = await factory.createActor({ type: 'character' });
+            const target = await factory.createItem({ type: 'device' });
+
+            await decker.setMarks(target, 1);
+            await decker.delete();
+            factory.actors.splice(factory.actors.indexOf(decker), 1);
+
+            assert.notProperty(MarksStorage.getStorage(), Helpers.uuidForStorage(decker.uuid));
+        });
+
+        it('Should clear actor marks and empty storage relations when the marked item is deleted', async () => {
+            const decker = await factory.createActor({ type: 'character' });
+            const target = await factory.createItem({ type: 'device' });
+
+            await decker.setMarks(target, 1);
+            await target.delete();
+            factory.items.splice(factory.items.indexOf(target), 1);
+
+            assert.equal(decker.getMarksPlaced(target.uuid), 0);
+            assert.notProperty(MarksStorage.getStorage(), Helpers.uuidForStorage(decker.uuid));
         });
     });
 };


### PR DESCRIPTION
## Summary
Fix stale entries in global Matrix mark storage when marks are removed or when marked documents are deleted.

Before this change, Matrix mark cleanup only updated the actor's local `marksData` in some delete paths. The global `matrix.marks` storage could still keep old mark relationships, which left deleted marks visible in storage and caused empty relation entries to remain after the last marked document was removed.

This updates mark cleanup to:
- rewrite global mark relations when a single mark is removed
- remove global mark relations when all marks are cleared
- clear actor mark relations when a marking actor is deleted
- drop empty relation arrays from global storage
- fix `getMarksRelations` to read the normalized storage key correctly

Fixes #1933 
