### PR TITLE
[Bug] Add Dice So Nice d6 preset support for SR5 ds dice

### DIFF
--- a/public/locale/de/config.json
+++ b/public/locale/de/config.json
@@ -21,8 +21,6 @@
         "DefaultOpposedTestActorSelectionDescription": "Überschreibe Tokenauswahl mit den Zielen der Probe.",
         "DiagonalMovementDescription": "Wie soll diagonale Bewegung auf dem Gitter gehandhabt werden?",
         "DiagonalMovementName": "Diagonale Bewegung",
-        "DieFaceLabels": "Würfelseitenbeschriftungen",
-        "DieFaceLabelsDescription": "[Dice So Nice] Beschriftungen der Würfelseiten auf der Würfelkarte, beginnend mit 1.",
         "DisplayDefaultRollCardDescription": "Soll die Standard-Würfelkarte zusammen mit der Shadowrun Würfelkarte angezeigt werden?",
         "DisplayDefaultRollCardName": "Zeige Standard-Würfelkarte",
         "EstimateDiagonal": "Schätze diagonale Bewegung (1-2-1)",

--- a/public/locale/en/config.json
+++ b/public/locale/en/config.json
@@ -21,8 +21,6 @@
         "DefaultOpposedTestActorSelectionDescription": "Always overwrite selected tokens with targets used for testing",
         "DiagonalMovementDescription": "How should diagonal movement be handled when using a grid",
         "DiagonalMovementName": "Diagonal Movement",
-        "DieFaceLabels": "Test Die Face Labels",
-        "DieFaceLabelsDescription": "[Dice So Nice] Comma-separated list of 6 labels for the test die faces, starting with 1.",
         "DisplayDefaultRollCardDescription": "Should the default roll-card be displayed along with the Shadowrun roll-card",
         "DisplayDefaultRollCardName": "Display Default Roll Card",
         "EstimateDiagonal": "Estimate Diagonal Movement (1-2-1)",

--- a/public/locale/ko/config.json
+++ b/public/locale/ko/config.json
@@ -21,8 +21,6 @@
         "DefaultOpposedTestActorSelectionDescription": "항상 선택한 토큰을 판정에 사용된 대상으로 덮어씀",
         "DiagonalMovementDescription": "격자판 사용 시 대각선 이동 처리 방식",
         "DiagonalMovementName": "대각선 이동",
-        "DieFaceLabels": "판정 주사위 면 라벨",
-        "DieFaceLabelsDescription": "[Dice So Nice] 판정 주사위 면에 대한 6개의 라벨을 쉼표로 구분한 목록으로, 1번부터 시작한다.",
         "DisplayDefaultRollCardDescription": "기본 굴림 카드와 함께 섀도우런 굴림 카드 표시 여부",
         "DisplayDefaultRollCardName": "기본 굴림 카드 표시",
         "EstimateDiagonal": "대각선 이동 계산 (1-2-1)",

--- a/public/locale/pt-BR/config.json
+++ b/public/locale/pt-BR/config.json
@@ -19,8 +19,6 @@
         "ModifyRollExpandedDescription": "Salva se a seção Modificar Rolagem estava expandida na última vez e restaura esse estado na próxima janela de teste.",
         "DefaultOpposedTestActorSelection": "Sobrescrever seleções de token de testes de oposição",
         "DefaultOpposedTestActorSelectionDescription": "Sempre sobrescrever tokens selecionados com alvos usados para testes",
-        "DieFaceLabels": "Rótulos das Faces dos Dados",
-        "DieFaceLabelsDescription": "[Dice so Nice] Lista separada por vírgulas de 6 rótulos para as faces dos dados de teste, começando com 1.",
         "FreshColor": "Destacar Apenas com Cor do Texto",
         "FreshColorAndIcon": "Destacar com Cor do Texto e Ícone",
         "FreshIcon": "Destacar Apenas com Ícone",

--- a/src/module/constants.ts
+++ b/src/module/constants.ts
@@ -71,8 +71,7 @@ export const FLAGS = {
     CompendiaSettingsMenu: 'CompendiaSettingsMenu',
     TokenAutoRunning: 'TokenAutoRunning',
     CompendiumBrowserBlacklist: 'CompendiumBrowserBlacklist',
-    ImporterCompendiumOrder: 'ImporterCompendiumOrder',
-    DieFaceLabels: "DieFaceLabels"
+    ImporterCompendiumOrder: 'ImporterCompendiumOrder'
 } as const;
 export const CORE_NAME = 'core';
 export const METATYPEMODIFIER = 'SR5.Character.Modifiers.NPCMetatypeAttribute';

--- a/src/module/rolls/DiceSoNice.ts
+++ b/src/module/rolls/DiceSoNice.ts
@@ -1,5 +1,34 @@
 import { SR5Die } from "./SR5Die";
-import { FLAGS, SYSTEM_NAME } from "../constants";
+
+type DiceSoNiceDieType = `d${string}`;
+
+export type DiceSoNicePreset = {
+    type: DiceSoNiceDieType,
+    labels: string[],
+    system: string,
+    colorset?: string,
+    font?: string,
+    fontScale?: number | Record<string, number>,
+    bumpMaps?: string[],
+    values?: { min: number, max: number, step?: number },
+    emissiveMaps?: string[],
+    emissive?: string | number,
+    emissiveIntensity?: number,
+    atlas?: string,
+    backgrounds?: {
+        labels?: string[],
+        bumpMaps?: string[],
+        emissiveMaps?: string[],
+    },
+    labelScale?: number,
+    modelFile?: string,
+    scaleModifier?: number,
+    valueMap?: Record<string | number, number>,
+};
+
+export type DiceSoNiceSystem = {
+    dice: Map<DiceSoNiceDieType, DiceSoNicePreset>
+};
 
 /*
  * Interface to interact with Dice So Nice module.
@@ -47,36 +76,60 @@ export interface DiceSoNice {
      * - atlas (optional): a TexturePacker JSON spritesheet that contains labels/bumps/emissiveMaps for this dice preset. Can be used for multiple types to create a single spritesheet for a full dice set.
      */
     addDicePreset: (
-        dice: {
-            type: `d${string}`,
-            labels: string[],
-            system: string,
-            colorset?: string,
-            font?: string,
-            fontScale?: number | Record<string, number>,
-            bumpMaps?: string[],
-            values?: { min: number, max: number },
-            emissiveMaps?: string[],
-            emissive?: string,
-            atlas?: object
-        },
-        shape?: `d${string}`,
+        dice: DiceSoNicePreset,
+        shape?: DiceSoNiceDieType,
     ) => void;
+
+    /**
+     * Get loaded Dice So Nice systems and their registered dice presets.
+     */
+    getLoadedDiceSystems: () => Map<string, DiceSoNiceSystem>;
 };
+
+const D6_DIE_TYPE = 'd6';
+const SR5_DIE_TYPE = `d${SR5Die.DENOMINATION}` as const;
+
+/**
+ * Clone a loaded `d6` Dice So Nice preset into an SR5 `ds` preset.
+ *
+ * The cloned preset keeps the original asset references and presentation
+ * settings, but changes the die type to `ds` so SR5 rolls continue to use
+ * their own denomination and any `ds`-specific effects keep working.
+ */
+export function mirrorD6Preset(source: DiceSoNicePreset, system: string): DiceSoNicePreset {
+    const preset = foundry.utils.deepClone(source);
+    preset.type = SR5_DIE_TYPE;
+    preset.system = system;
+    return preset;
+}
+
+/**
+ * Build SR5 `ds` presets for every loaded Dice So Nice system that exposes a
+ * `d6` preset.
+ *
+ * Systems without a `d6` entry are ignored. The returned presets are meant to
+ * be re-registered with Dice So Nice during `diceSoNiceReady` so the SR5 `ds`
+ * die can use the same visual systems as `d6`.
+ */
+export function mirrorD6Presets(systems: Map<string, DiceSoNiceSystem>): DiceSoNicePreset[] {
+    const presets: DiceSoNicePreset[] = [];
+
+    for (const [system, diceSystem] of systems) {
+        const d6Preset = diceSystem.dice.get(D6_DIE_TYPE);
+        if (!d6Preset) continue;
+
+        presets.push(mirrorD6Preset(d6Preset, system));
+    }
+
+    return presets;
+}
 
 export function initDiceSoNice() {
     Hooks.once('diceSoNiceReady', (dice3d) => {
         if (!dice3d) return;
-        const rawFaces = game.settings.get(SYSTEM_NAME, FLAGS.DieFaceLabels);
-        const parts = rawFaces.split(',').map(s => s.trim());
-        const faces = Array.from({ length: 6 }, (_, i) =>
-            parts[i] !== undefined ? parts[i] : String(i + 1)
-        );
 
-        dice3d.addDicePreset({
-            type: `d${SR5Die.DENOMINATION}`,
-            labels: faces,
-            system: 'standard'
-        }, 'd6');
+        for (const preset of mirrorD6Presets(dice3d.getLoadedDiceSystems())) {
+            dice3d.addDicePreset(preset, D6_DIE_TYPE);
+        }
     });
 }

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -309,18 +309,6 @@ export const registerSystemSettings = () => {
         default: []
     });
 
-    if (game.modules.get('dice-so-nice')?.active) {
-        game.settings.register(SYSTEM_NAME, FLAGS.DieFaceLabels, {
-            name: 'SETTINGS.DieFaceLabels',
-            hint: 'SETTINGS.DieFaceLabelsDescription',
-            scope: 'world',
-            config: true,
-            type: String,
-            default: '1,2,3,4,5,6',
-            requiresReload: true,
-        });
-    }
-
     /**
      * Select compendia to use for system porpuses like different action packs
      */

--- a/src/module/types/global.ts
+++ b/src/module/types/global.ts
@@ -319,7 +319,6 @@ declare module "fvtt-types/configuration" {
         "shadowrun5e.SkillSetsPack": string;
         "shadowrun5e.CompendiumBrowserBlacklist": string[];
         "shadowrun5e.ImporterCompendiumOrder": string[];
-        "shadowrun5e.DieFaceLabels": string;
         "shadowrun5e.TokenAutoRunning": boolean;
     }
 }

--- a/src/unittests/quench.ts
+++ b/src/unittests/quench.ts
@@ -30,6 +30,7 @@ import { itemSkillTesting } from './ItemSkill.spec';
 import { shadowrunOpposedCompileSpriteTesting } from './sr5.OpposedCompileSprite.spec';
 import { shadowrunOpposedCallInMessageActionTesting } from './sr5.OpposedCallInMessageAction.spec';
 import { actorArmorFlowTesting } from './sr5.ActorArmorFlow.spec';
+import { shadowrunDiceSoNiceTesting } from './sr5.DiceSoNice.spec';
 
 import { Quench, QuenchRegisterBatchFunction, QuenchRegisterBatchOptions } from '@ethaks/fvtt-quench';
 import { shadowrunRiggerTesting } from '@/unittests/sr5.RiggerTesting.spec';
@@ -132,6 +133,9 @@ export const quenchRegister = (quench: Quench) => {
         displayName: 'SHADOWRUN5e: Resist Matrix Test'
     });
     registerBatch(quench, 'shadowrun5e.flow.sr5roll', shadowrunRolling, { displayName: 'SHADOWRUN5e: SR5Roll' });
+    registerBatch(quench, 'shadowrun5e.integration.dice_so_nice', shadowrunDiceSoNiceTesting, {
+        displayName: 'SHADOWRUN5e: Dice So Nice Integration',
+    });
     registerBatch(quench, 'shadowrun5e.parser.weapon', weaponParserBaseTesting, {
         displayName: 'SHADOWRUN5e: Data Importer Weapon Parsing',
     });

--- a/src/unittests/sr5.DiceSoNice.spec.ts
+++ b/src/unittests/sr5.DiceSoNice.spec.ts
@@ -1,0 +1,95 @@
+import { QuenchBatchContext } from '@ethaks/fvtt-quench';
+import {
+    mirrorD6Preset,
+    mirrorD6Presets,
+    DiceSoNicePreset,
+    DiceSoNiceSystem,
+} from '@/module/rolls/DiceSoNice';
+
+export const shadowrunDiceSoNiceTesting = (context: QuenchBatchContext) => {
+    const { describe, it } = context;
+    const assert: Chai.AssertStatic = context.assert;
+
+    describe('Dice So Nice integration', () => {
+        it('mirrors d6 preset fields to ds while keeping the target system', () => {
+            const d6Preset: DiceSoNicePreset = {
+                type: 'd6',
+                labels: ['d6-1.webp', 'd6-2.webp', 'd6-3.webp', 'd6-4.webp', 'd6-5.webp', 'd6-6.webp'],
+                system: 'dot',
+                atlas: 'modules/dice-so-nice/textures/dot.json',
+                bumpMaps: ['d6-1-b.webp', 'd6-2-b.webp', 'd6-3-b.webp', 'd6-4-b.webp', 'd6-5-b.webp', 'd6-6-b.webp'],
+                emissiveMaps: ['d6-1-e.webp', 'd6-2-e.webp'],
+                emissive: 0xffffff,
+                emissiveIntensity: 0.8,
+                font: 'FoundryVTT',
+                fontScale: 0.9,
+                colorset: 'spectrum_default',
+                backgrounds: { labels: ['background.webp'], bumpMaps: ['background-bump.webp'] },
+                labelScale: 0.75,
+            };
+
+            const preset = mirrorD6Preset(d6Preset, 'dot');
+
+            assert.deepEqual(preset, {
+                ...d6Preset,
+                type: 'ds',
+                system: 'dot',
+            });
+        });
+
+        it('mirrors every non-standard system with a d6 preset', () => {
+            const dot: DiceSoNicePreset = {
+                type: 'd6',
+                labels: ['d6-1.webp', 'd6-2.webp', 'd6-3.webp', 'd6-4.webp', 'd6-5.webp', 'd6-6.webp'],
+                bumpMaps: ['d6-1-b.webp', 'd6-2-b.webp'],
+                atlas: 'modules/dice-so-nice/textures/dot.json',
+                system: 'dot',
+            };
+            const dotBlack: DiceSoNicePreset = {
+                type: 'd6',
+                labels: ['d6-1-black.webp', 'd6-2-black.webp', 'd6-3-black.webp', 'd6-4-black.webp', 'd6-5-black.webp', 'd6-6-black.webp'],
+                bumpMaps: ['d6-1-b.webp', 'd6-2-b.webp'],
+                atlas: 'modules/dice-so-nice/textures/dot.json',
+                system: 'dot_b',
+            };
+            const foundry: DiceSoNicePreset = {
+                type: 'd6',
+                labels: ['1', '2', '3', '4', '5', 'E'],
+                font: 'FoundryVTT',
+                system: 'foundry_vtt',
+            };
+            const spectrum: DiceSoNicePreset = {
+                type: 'd6',
+                labels: ['d6-1.webp', 'd6-2.webp', 'd6-3.webp', 'd6-4.webp', 'd6-5.webp', 'd6-6.webp'],
+                emissiveMaps: ['d6-1.webp', 'd6-2.webp', 'd6-3.webp', 'd6-4.webp', 'd6-5.webp', 'd6-6.webp'],
+                emissive: 0xffffff,
+                colorset: 'spectrum_default',
+                system: 'spectrum',
+            };
+            const standard: DiceSoNicePreset = {
+                type: 'd6',
+                labels: ['1', '2', '3', '4', '5', '6'],
+                system: 'standard',
+            };
+
+            const systems = new Map<string, DiceSoNiceSystem>([
+                ['standard', { dice: new Map([['d6', standard]]) }],
+                ['dot', { dice: new Map([['d6', dot]]) }],
+                ['dot_b', { dice: new Map([['d6', dotBlack]]) }],
+                ['foundry_vtt', { dice: new Map([['d6', foundry]]) }],
+                ['spectrum', { dice: new Map([['d6', spectrum]]) }],
+                ['without_d6', { dice: new Map([['d8', { type: 'd8', labels: ['1'], system: 'without_d6' }]]) }],
+            ]);
+
+            const presets = mirrorD6Presets(systems);
+
+            assert.sameMembers(presets.map(preset => preset.system), ['standard', 'dot', 'dot_b', 'foundry_vtt', 'spectrum']);
+            assert.isTrue(presets.every(preset => preset.type === 'ds'));
+            assert.deepInclude(presets, { ...standard, type: 'ds' });
+            assert.deepInclude(presets, { ...dot, type: 'ds' });
+            assert.deepInclude(presets, { ...dotBlack, type: 'ds' });
+            assert.deepInclude(presets, { ...foundry, type: 'ds' });
+            assert.deepInclude(presets, { ...spectrum, type: 'ds' });
+        });
+    });
+};


### PR DESCRIPTION
## Summary
- mirror every loaded Dice So Nice `d6` preset to the SR5 `ds` die during `diceSoNiceReady`
- preserve the `ds` denomination so SR5-specific `ds` behavior and effects still apply
- remove the SR5 custom `DieFaceLabels` setting and its locale/type/constant references
- add focused unit tests for preset mirroring and system filtering

## Why
Dice So Nice exposes multiple `d6` visual systems, but SR5 `ds` rolls only had a single custom registration path. This change lets `ds` use the same preset systems as `d6` without changing the die denomination used by SR5.


Fixes: #1976 