### PR TITLE
[BUG] Deleting a mark for a selected matrix target doesn't remove selection

### DIFF
--- a/src/module/actor/sheets/SR5MatrixActorSheet.ts
+++ b/src/module/actor/sheets/SR5MatrixActorSheet.ts
@@ -507,12 +507,7 @@ export class SR5MatrixActorSheet<T extends MatrixActorSheetData = MatrixActorShe
         const uuid = SheetFlow.closestUuid(event.target);
         if (!uuid) return;
 
-        if (this.selectedMatrixTarget === uuid) {
-            this.selectedMatrixTarget = undefined;
-        } else {
-            this.selectedMatrixTarget = uuid;
-        }
-
+        this.toggleMatrixTargetSelection(uuid);
         this.informAboutOfflineSelection();
 
         void this.render();
@@ -604,6 +599,25 @@ export class SR5MatrixActorSheet<T extends MatrixActorSheetData = MatrixActorShe
     }
 
     /**
+     * Set given uuid as the selected matrix target for this actor sheet.
+     * @param uuid The uuid of the matrix target to select. If undefined, no target is selected.
+     */
+    toggleMatrixTargetSelection(uuid: string | undefined) {
+        // Allow caller to unset selection completly.
+        if (!uuid) {
+            this.selectedMatrixTarget = undefined;
+            return;
+        };
+
+        // Toggle target selection on of, either to unselect or select another target.
+        if (this.selectedMatrixTarget === uuid) {
+            this.selectedMatrixTarget = undefined;
+        } else {
+            this.selectedMatrixTarget = uuid;
+        }
+    }
+
+    /**
      * Offline targets can be selected however later matrix actions may not be possible.
      *
      * Let users know about the limitations of selecting offline targets.
@@ -668,6 +682,8 @@ export class SR5MatrixActorSheet<T extends MatrixActorSheetData = MatrixActorShe
         const userConsented = await Helpers.confirmDeletion();
         if (!userConsented) return;
 
+        // Change selection state before triggering an update caused re-render.
+        this.toggleMatrixTargetSelection(undefined);
         await this.actor.clearMark(uuid);
     }
 
@@ -683,6 +699,8 @@ export class SR5MatrixActorSheet<T extends MatrixActorSheetData = MatrixActorShe
         const userConsented = await Helpers.confirmDeletion();
         if (!userConsented) return;
 
+        // Change selection state before triggering an update caused re-render.
+        this.toggleMatrixTargetSelection(undefined);
         await this.actor.clearMarks();
     }
 


### PR DESCRIPTION
Fixes #1981

Issue was related to selection state not getting reset whenever marks are deleted. This could cause the marked document to not exist on other visible icon lists, as it might be a host device, which now, without marks, might not be visible anymore.