### PR TITLE
[Bug] Fix incorrect damage and AP parsing for Chummer items

### DIFF
--- a/src/module/apps/actorImport/itemImporter/weaponImport/WeaponParser.ts
+++ b/src/module/apps/actorImport/itemImporter/weaponImport/WeaponParser.ts
@@ -59,7 +59,7 @@ export class WeaponParser extends Parser<'weapon'> {
         let base_formula_operator: AttributeFormulaOperator = 'add';
         let parsed = false;
 
-        const attributeDamage = /^(?:\((.+)\)|(.+))([PSM])?(?:\(([a-zA-Z]+)\))?$/i.exec(damageCode);
+        const attributeDamage = /^(?:\((.+)\)|(.+?))([PSM])?(?:\(([a-zA-Z]+)\))?$/i.exec(damageCode);
         if (attributeDamage) {
             const formulaText = attributeDamage[1] ?? attributeDamage[2];
             if (formulaText.includes('{')) {

--- a/src/module/apps/actorImport/itemImporter/weaponImport/WeaponParser.ts
+++ b/src/module/apps/actorImport/itemImporter/weaponImport/WeaponParser.ts
@@ -1,4 +1,4 @@
-import { DamageTypeType } from "src/module/types/item/Action";
+import { DamageType, DamageTypeType } from "src/module/types/item/Action";
 import { DataDefaults } from "src/module/data/DataDefaults";
 import { ActorSchema } from "../../ActorSchema";
 import { Unwrap } from "../ItemsParser";
@@ -7,6 +7,10 @@ import { ImportHelper as IH } from "@/module/apps/itemImport/helper/ImportHelper
 import { AccessoryParser } from "./AccessoryParser";
 import { ClipParser } from "./ClipParser";
 import { RangeType } from "@/module/types/item/Weapon";
+import { Constants } from "@/module/apps/itemImport/importer/Constants";
+
+type DamageElement = DamageType['element']['base'];
+type AttributeFormulaOperator = DamageType['base_formula_operator'];
 
 export class WeaponParser extends Parser<'weapon'> {
     protected readonly parseType = 'weapon';
@@ -14,46 +18,163 @@ export class WeaponParser extends Parser<'weapon'> {
     private getValues(val: string) {
         const regex = /(-?[0-9]+)(?:([0-9]+))*/g;
         const l = val.match(regex);
-        return l || ['0'];
+        return l ?? ['0'];
     }
 
-    private parseDamage(val: string) {
-        const damage = {
-            damage: 0,
-            type: '' as DamageTypeType,
-            radius: 0,
-            dropoff: 0,
-        };
+    public parseChummerDamage(rawDamage?: string | null, fallbackDamage?: string | null) {
+        return this.parseDamage(rawDamage) ?? this.parseDamage(fallbackDamage);
+    }
 
-        const split = val.split(' ');
+    public parseChummerAP(rawAP?: string | null, fallbackAP?: string | null) {
+        for (const ap of [rawAP, fallbackAP]) {
+            const apText = ap?.trim();
+            if (!apText || apText === '-') continue;
 
-        if (split.length > 0) {
-            const l = /(\d+)(\w+)/.exec(split[0]);
-            
-            if (l?.[1]) {
-                damage.damage = parseInt(l[1]);
-            }
+            const formula = this.parseAttributeFormula(apText);
+            if (formula) return formula;
 
-            if (l?.[2]) {
-                damage.type = l[2] === 'P' ? 'physical' : 'stun';
-            }
-        }
-
-        for (let i = 1; i < split.length; i++) {
-            const l = /(-?\d+)(.*)/.exec(split[i]);
-            if (l?.[2]) {
-                if (l[2].toLowerCase().includes('/m')) { 
-                    damage.dropoff = parseInt(l[1]);
-                    damage.radius = damage.damage / Math.abs(damage.dropoff)
-                }
-                else {
-                    damage.radius = parseInt(l[1]);
-                }
+            const simpleAP = /^[+-]?\d+(?:\.\d+)?$/.exec(apText);
+            if (simpleAP) {
+                return {
+                    base: Number(simpleAP[0]) || 0,
+                    attribute: '',
+                    base_formula_operator: 'add',
+                } as const;
             }
         }
 
-        return damage;
-    };
+        return null;
+    }
+
+    private parseDamage(val?: string | null) {
+        const damageText = val?.trim();
+        if (!damageText) return null;
+
+        const blast = this.parseBlast(damageText);
+        const damageCode = blast.damageCode;
+        let damage = 0;
+        let type: DamageTypeType = 'physical';
+        let element: DamageElement = '';
+        let attribute: DamageType['attribute'] = '';
+        let base_formula_operator: AttributeFormulaOperator = 'add';
+        let parsed = false;
+
+        const attributeDamage = /^(?:\((.+)\)|(.+))([PSM])?(?:\(([a-zA-Z]+)\))?$/i.exec(damageCode);
+        if (attributeDamage) {
+            const formulaText = attributeDamage[1] ?? attributeDamage[2];
+            if (formulaText.includes('{')) {
+                const formula = this.parseAttributeFormula(formulaText);
+                if (!formula) return null;
+
+                damage = formula.base;
+                type = this.parseDamageType(attributeDamage[3]);
+                element = this.parseDamageElement(attributeDamage[4]);
+                attribute = formula.attribute;
+                base_formula_operator = formula.base_formula_operator;
+                parsed = true;
+            }
+        }
+
+        if (!parsed) {
+            const simpleDamage = /^(\d+)([PSM])?(?:\(([a-zA-Z]+)\))?$/i.exec(damageCode);
+            if (!simpleDamage) return null;
+
+            damage = Number(simpleDamage[1]) || 0;
+            type = this.parseDamageType(simpleDamage[2]);
+            element = this.parseDamageElement(simpleDamage[3]);
+        }
+
+        return {
+            damage,
+            type,
+            element,
+            attribute,
+            base_formula_operator,
+            dropoff: blast.dropoff,
+            radius: blast.dropoff && !blast.radius ? damage / Math.abs(blast.dropoff) : blast.radius,
+        } as const;
+    }
+
+    public parseAttributeFormula(val: string) {
+        const expression = val.replace(/\s/g, '');
+        const attributeFormula = /^(-)?\{([A-Z]+)\}(?:(\+|-|\*|\/)([+-]?\d+(?:\.\d+)?))?$/i.exec(expression);
+        if (!attributeFormula) return null;
+
+        const attribute = Constants.attributeTable[attributeFormula[2].toUpperCase()] as DamageType['attribute'] | undefined;
+        if (!attribute) return null;
+
+        const sign = attributeFormula[1] === '-' ? -1 : 1;
+        const operator = attributeFormula[3];
+        const operand = Number(attributeFormula[4]) || 0;
+
+        switch (operator) {
+            case '+':
+                return { base: operand, attribute, base_formula_operator: 'add' } as const;
+            case '-':
+                return { base: -operand, attribute, base_formula_operator: 'add' } as const;
+            case '*':
+                return { base: sign * operand, attribute, base_formula_operator: 'multiply' } as const;
+            case '/':
+                return null;
+            default:
+                return { base: 0, attribute, base_formula_operator: sign === -1 ? 'subtract' : 'add' } as const;
+        }
+    }
+
+    private parseBlast(damageText: string) {
+        let damageCode = damageText;
+        let radius = 0;
+        let dropoff = 0;
+
+        const dropoffMatch = /\((-?\d+)\/m\)/i.exec(damageCode);
+        if (dropoffMatch) {
+            dropoff = Number(dropoffMatch[1]) || 0;
+            damageCode = damageCode.replace(dropoffMatch[0], '').trim();
+        }
+
+        const radiusMatch = /\((\d+)m(?:\s+radius)?\)/i.exec(damageCode);
+        if (radiusMatch) {
+            radius = Number(radiusMatch[1]) || 0;
+            damageCode = damageCode.replace(radiusMatch[0], '').trim();
+        }
+
+        return { damageCode, radius, dropoff } as const;
+    }
+
+    private parseDamageType(parsedType?: string): DamageTypeType {
+        switch (parsedType?.toUpperCase()) {
+            case 'S':
+                return 'stun';
+            case 'M':
+                return 'matrix';
+            case 'P':
+            default:
+                return 'physical';
+        }
+    }
+
+    private parseDamageElement(parsedElement?: string): DamageElement {
+        switch (parsedElement?.toLowerCase()) {
+            case 'e':
+            case 'electricity':
+                return 'electricity';
+            case 'f':
+            case 'fire':
+                return 'fire';
+            case 'cold':
+                return 'cold';
+            case 'acid':
+                return 'acid';
+            case 'pollutant':
+                return 'pollutant';
+            case 'radiation':
+                return 'radiation';
+            case 'water':
+                return 'water';
+            default:
+                return '';
+        }
+    }
 
     async parseWeapons(chummerChar: ActorSchema | Unwrap<NonNullable<ActorSchema['vehicles']>['vehicle']>) {
         return this.parseItems(IH.getArray(chummerChar.weapons?.weapon))
@@ -65,7 +186,13 @@ export class WeaponParser extends Parser<'weapon'> {
         const action = system.action;
         const damage = system.action.damage;
 
-        damage.ap.base = Number(this.getValues(itemData.rawap)[0]) || 0;
+        const chummerAP = this.parseChummerAP(itemData.rawap, itemData.ap_english);
+        if (chummerAP) {
+            damage.ap.base = chummerAP.base;
+            damage.ap.value = damage.ap.base;
+            damage.ap.attribute = chummerAP.attribute;
+            damage.ap.base_formula_operator = chummerAP.base_formula_operator;
+        }
 
         action.type = 'varies';
 
@@ -115,11 +242,17 @@ export class WeaponParser extends Parser<'weapon'> {
             }
         }
 
-        {
-            //TODO change this to 'rawdamage' when mods can have damage value
-            const chummerDamage = this.parseDamage(itemData.damage_noammo_english);
+        const chummerDamage = this.parseChummerDamage(itemData.rawdamage, itemData.damage_english);
+        if (chummerDamage) {
             damage.base = chummerDamage.damage;
+            damage.value = chummerDamage.damage;
+            damage.attribute = chummerDamage.attribute;
             damage.type.base = chummerDamage.type;
+            damage.type.value = chummerDamage.type;
+            damage.element.base = chummerDamage.element;
+            damage.element.value = chummerDamage.element;
+            damage.base_formula_operator = chummerDamage.base_formula_operator;
+
             if (chummerDamage.dropoff || chummerDamage.radius) {
                 system.thrown = {
                     ...system.thrown,

--- a/src/module/apps/itemImport/parser/gear/AmmoParser.ts
+++ b/src/module/apps/itemImport/parser/gear/AmmoParser.ts
@@ -44,6 +44,8 @@ export class AmmoParser extends Parser<'ammo'> {
             system.damage = damageData.value;
             system.damageType = damageData.type.value;
             system.element = damageData.element.value;
+            system.replaceAP = !!bonusData.apreplace?._TEXT;
+            system.replaceDamage = !!bonusData.damagereplace?._TEXT;
         }
 
         return system;

--- a/src/module/apps/itemImport/parser/gear/AmmoParser.ts
+++ b/src/module/apps/itemImport/parser/gear/AmmoParser.ts
@@ -2,6 +2,9 @@ import { Parser, SystemType } from "../Parser";
 import { CompendiumKey } from "../../importer/Constants";
 import { Gear, GearSchema } from "../../schema/GearSchema";
 import { ImportHelper as IH } from "../../helper/ImportHelper";
+import { WeaponParserBase } from "../weapon/WeaponParserBase";
+
+const weaponParser = new WeaponParserBase();
 
 export class AmmoParser extends Parser<'ammo'> {
     protected readonly parseType = 'ammo';
@@ -16,16 +19,31 @@ export class AmmoParser extends Parser<'ammo'> {
 
         const bonusData = jsonData.weaponbonus;
         if (bonusData) {
-            system.ap = Number(bonusData.ap?._TEXT) || 0;
-            system.damage = Number(bonusData.damage?._TEXT) || 0;
+            let damageText = bonusData.damagereplace?._TEXT?.trim() ?? bonusData.damage?._TEXT?.trim() ?? '';
+            const apText = bonusData.apreplace?._TEXT?.trim() ?? bonusData.ap?._TEXT ?? 0;
+            const damageTypeText = bonusData.damagetype?._TEXT?.trim() ?? '';
+            let normalizedDamageType = '';
 
-            const damageType = bonusData.damagetype?._TEXT ?? '';
-            if (damageType.includes('S'))
-                system.damageType = 'stun';
-            else if (damageType.includes('M'))
-                system.damageType = 'matrix';
-            else
-                system.damageType = 'physical';
+            if (/^\([PSM]\)$/i.test(damageTypeText))
+                normalizedDamageType = damageTypeText.slice(1, -1);
+            else if (/^[PSM](?:\([a-zA-Z]+\))?$/i.test(damageTypeText))
+                normalizedDamageType = damageTypeText;
+            else if (/^Acid$/i.test(damageTypeText))
+                normalizedDamageType = 'P(acid)';
+
+            const parsedDamageText = /^([+-]?\d+(?:\.\d+)?)([PSM])?(?:\(([a-zA-Z]+)\))?$/i.exec(damageText);
+            if (parsedDamageText && normalizedDamageType) {
+                const [, amount] = parsedDamageText;
+                damageText = `${amount}${normalizedDamageType}`;
+            } else if (!damageText && normalizedDamageType) {
+                damageText = `0${normalizedDamageType}`;
+            }
+
+            const damageData = weaponParser.parseDamageData(damageText, apText);
+            system.ap = damageData.ap.value;
+            system.damage = damageData.value;
+            system.damageType = damageData.type.value;
+            system.element = damageData.element.value;
         }
 
         return system;

--- a/src/module/apps/itemImport/parser/metatype/MetatypeParserBase.ts
+++ b/src/module/apps/itemImport/parser/metatype/MetatypeParserBase.ts
@@ -4,11 +4,14 @@ import { BonusSchema } from '../../schema/BonusSchema';
 import { DataDefaults } from 'src/module/data/DataDefaults';
 import { InitiativeType } from 'src/module/types/template/Initiative';
 import { ImportHelper as IH, OneOrMany, RetrievedItem } from '../../helper/ImportHelper';
+import { WeaponParserBase } from '../weapon/WeaponParserBase';
 
 type MetatypeItemData = {
     _TEXT: string;
     $?: { select?: string; rating?: string; spec?: string };
 };
+
+const weaponParser = new WeaponParserBase();
 
 export abstract class MetatypeParserBase<TResult extends ('character' | 'spirit' | 'sprite')> extends Parser<TResult> {
     /**
@@ -205,50 +208,16 @@ export abstract class MetatypeParserBase<TResult extends ('character' | 'spirit'
             const names = rawName.split('/').map(n => n.trim()).filter(Boolean);
             if (names.length === 0) names.push('Natural Weapon');
 
-            // 2. Extract DV segment anywhere in the string
-            const dvMatch = /\bDV\s+(\(?[A-Z0-9+-]+\)?)\s*([PSM])?\b/i.exec(select);
-            if (!dvMatch) {
+            const damageText = /\bDV\s+([^,]+)/i.exec(select)?.[1]?.trim();
+            if (!damageText) {
                 console.warn(`[Natural Weapon Parse]\nCritter: ${options.actorName}\nSelect: ${select}`);
                 continue;
             }
-
-            const dvFormula = dvMatch[1].toUpperCase().replace(/[()\s]/g, '');
-            let damageBase = 0;
-            let damageAttribute: 'strength' | 'force' | undefined;
-
-            if (dvFormula.includes('STR')) {
-                damageAttribute = 'strength';
-                damageBase = Number(/[+-]\d+/.exec(dvFormula)?.[0]) || 0;
-            } else if (dvFormula.includes('F')) {
-                damageAttribute = 'force';
-                damageBase = Number(/[+-]\d+/.exec(dvFormula)?.[0]) || 0;
-            } else {
-                damageBase = Number(dvFormula) || 0;
-            }
-
-            const typeStr = dvMatch[2]?.toUpperCase();
-            const damageType = typeStr === 'S' ? 'stun' : 'physical';
-
-            // 3. Extract AP segment anywhere in the string (Optional)
-            const apMatch = /\bAP\s+([-A-Z0-9+]+)\b/i.exec(select);
-            let apBase = 0;
-            let apAttribute: 'force' | undefined;
-            let apOperator: 'add' | 'subtract' | undefined;
-
-            if (apMatch) {
-                const apRaw = apMatch[1].toUpperCase().replace(/\s+/g, '');
-                if (apRaw.includes('F')) {
-                    apAttribute = 'force';
-                    apOperator = apRaw.includes('-') ? 'subtract' : 'add';
-                    apBase = Number(/[+-]\d+/.exec(apRaw)?.[0]) || 0;
-                } else {
-                    apBase = Number(apRaw) || 0;
-                }
-            }
+            const apText = /\bAP\s+([^,]+)/i.exec(select)?.[1]?.trim() ?? '-';
 
             // 4. Extract Reach (Optional)
-            const reachMatch = /\bREACH\s+([-+]?\d+)\b/i.exec(select);
-            const reach = reachMatch ? Number(reachMatch[1]) || 0 : undefined;
+            const reachMatch = /(?:\bREACH\s+([-+]?\d+)\b|\b([-+]?\d+)\s+REACH\b)/i.exec(select);
+            const reach = reachMatch ? Number(reachMatch[1] ?? reachMatch[2]) || 0 : undefined;
 
             // 5. Detect if the weapon is Ranged
             const isRanged = /\bRANGED?\b/i.test(select);
@@ -263,19 +232,7 @@ export abstract class MetatypeParserBase<TResult extends ('character' | 'spirit'
 
             system.action.attribute = 'agility';
             system.action.skill = isRanged ? 'exotic_ranged_weapon' : 'unarmed_combat';
-            
-            system.action.damage = DataDefaults.createData('damage', {
-                base: damageBase,
-                type: { base: damageType },
-                ap: { 
-                    base: apBase,
-                    ...(apAttribute && { 
-                        attribute: apAttribute,
-                        base_formula_operator: apOperator 
-                    })
-                },
-                ...(damageAttribute && { attribute: damageAttribute }),
-            });
+            system.action.damage = weaponParser.parseDamageData(damageText, apText);
 
             // --- Push Items ---
             // Loop through all parsed names and create a unique item for each one

--- a/src/module/apps/itemImport/parser/powers/CritterPowerParser.ts
+++ b/src/module/apps/itemImport/parser/powers/CritterPowerParser.ts
@@ -3,6 +3,9 @@ import { CompendiumKey } from '../../importer/Constants';
 import { Power } from '../../schema/CritterpowersSchema';
 import { ImportHelper as IH } from '../../helper/ImportHelper';
 import { CritterPowerCategories } from 'src/module/types/item/CritterPower';
+import { WeaponParserBase } from '../weapon/WeaponParserBase';
+
+const weaponParser = new WeaponParserBase();
 
 export class CritterPowerParser extends Parser<'critter_power'> {
     protected readonly parseType = 'critter_power';
@@ -25,6 +28,17 @@ export class CritterPowerParser extends Parser<'critter_power'> {
         system.powerType = CritterPowerParser.typeMap[type] as any ?? "";
 
         system.rating = 1;
+
+        const naturalWeapon = jsonData.bonus?.naturalweapon;
+        if (naturalWeapon) {
+            system.action.type = 'varies';
+            system.action.attribute = 'agility';
+            system.action.skill = naturalWeapon.useskill._TEXT.replace(/[\s-]/g, '_').toLowerCase();
+            system.action.damage = weaponParser.parseDamageData(naturalWeapon.damage._TEXT, naturalWeapon.ap._TEXT);
+
+            if (naturalWeapon.accuracy._TEXT.includes('Physical'))
+                system.action.limit.attribute = 'physical';
+        }
 
         return system;
     }

--- a/src/module/apps/itemImport/parser/weapon/WeaponParserBase.ts
+++ b/src/module/apps/itemImport/parser/weapon/WeaponParserBase.ts
@@ -94,7 +94,7 @@ export class WeaponParserBase extends Parser<'weapon'> {
         system.subcategory = category.toLowerCase();
 
         system.action.skill = this.getSkill(jsonData);
-        system.action.damage = this.getDamage(jsonData as any);
+        system.action.damage = this.parseDamageData(jsonData.damage._TEXT, jsonData.ap._TEXT);
 
         if (jsonData.accuracy?._TEXT) {
             let accuracy: string = jsonData.accuracy._TEXT;
@@ -110,12 +110,12 @@ export class WeaponParserBase extends Parser<'weapon'> {
 
         return system;
     }
-    
-    protected getDamage(jsonData: Weapon): DamageType {
-        const partialDamageData: Partial<DamageType> = {};
-        const damageText = String(jsonData.damage._TEXT).trim();
 
-        const attributeDamage = /^(?:\((.+)\)|(.+))([PSM])?(?:\(([a-zA-Z]+)\))?(?:\s+\(-?\d+\/m\))?$/i.exec(damageText);
+    public parseDamageData(damageText: string | number, apText: string | number): DamageType {
+        const partialDamageData: Partial<DamageType> = {};
+        const parsedDamageText = String(damageText).trim();
+
+        const attributeDamage = /^(?:\((.+)\)|(.+?))([PSM])?(?:\(([a-zA-Z]+)\))?(?:\s+\(-?\d+\/m\))?$/i.exec(parsedDamageText);
         if (attributeDamage) {
             const formulaText = attributeDamage[1] ?? attributeDamage[2];
             if (formulaText.includes('{')) {
@@ -135,7 +135,7 @@ export class WeaponParserBase extends Parser<'weapon'> {
         }
 
         if (partialDamageData.base === undefined) {
-            const simpleDamage = /^(\d+)([PSM])?(?:\(([a-zA-Z]+)\))?(?:\s+\(-?\d+\/m\))?$/i.exec(damageText);
+            const simpleDamage = /^([+-]?\d+(?:\.\d+)?)([PSM])?(?:\(([a-zA-Z]+)\))?(?:\s+\(-?\d+\/m\))?$/i.exec(parsedDamageText);
             if (simpleDamage) {
                 const damageType = this.parseDamageType(simpleDamage[2]);
                 const damageElement = this.parseDamageElement(simpleDamage[3]);
@@ -148,9 +148,9 @@ export class WeaponParserBase extends Parser<'weapon'> {
             }
         }
 
-        const apText = String(jsonData.ap._TEXT).trim();
-        const apFormula = this.parseAttributeFormula(apText);
-        const simpleAP = /^[+-]?\d+(?:\.\d+)?$/.exec(apText);
+        const parsedApText = String(apText).trim();
+        const apFormula = this.parseAttributeFormula(parsedApText);
+        const simpleAP = /^[+-]?\d+(?:\.\d+)?$/.exec(parsedApText);
         if (apFormula) {
             partialDamageData.ap = {
                 base: apFormula.base,
@@ -215,6 +215,9 @@ export class WeaponParserBase extends Parser<'weapon'> {
             case 'fire':
             case '(fire)':
                 return 'fire';
+            case 'acid':
+            case '(acid)':
+                return 'acid';
             default:
                 return '';
         }

--- a/src/module/apps/itemImport/parser/weapon/WeaponParserBase.ts
+++ b/src/module/apps/itemImport/parser/weapon/WeaponParserBase.ts
@@ -6,8 +6,13 @@ import { DataDefaults } from '../../../../data/DataDefaults';
 import { ImportHelper as IH } from '../../helper/ImportHelper';
 import { CompendiumKey, Constants } from '../../importer/Constants';
 import { DamageType, DamageTypeType } from 'src/module/types/item/Action';
-import PhysicalAttribute = Shadowrun.PhysicalAttribute;
 type DamageElement = DamageType['element']['base'];
+type AttributeFormulaOperator = DamageType['base_formula_operator'];
+type ParsedAttributeFormula = {
+    base: number;
+    attribute: DamageType['attribute'];
+    base_formula_operator: AttributeFormulaOperator;
+};
 
 export class WeaponParserBase extends Parser<'weapon'> {
     protected readonly parseType = 'weapon';
@@ -107,48 +112,85 @@ export class WeaponParserBase extends Parser<'weapon'> {
     }
     
     protected getDamage(jsonData: Weapon): DamageType {
-        const jsonDamage = jsonData.damage._TEXT;
-        // ex. 15S(e)
-        const simpleDamage = /^([0-9]+)([PSM])? ?(\([a-zA-Z]+\))?/g.exec(jsonDamage);
-        // ex. ({STR}+1)P(fire)
-        const strengthDamage = /^\({STR}([+-]?[0-9]*)\)([PSM])? ?(\([a-zA-Z]+\))?/g.exec(jsonDamage);
+        const partialDamageData: Partial<DamageType> = {};
+        const damageText = String(jsonData.damage._TEXT).trim();
 
-        let damageType: DamageTypeType = 'physical';
-        let damageAttribute: PhysicalAttribute | undefined;
-        let damageBase = 0;
-        let damageElement: DamageElement = '';
+        const attributeDamage = /^(?:\((.+)\)|(.+))([PSM])?(?:\(([a-zA-Z]+)\))?(?:\s+\(-?\d+\/m\))?$/i.exec(damageText);
+        if (attributeDamage) {
+            const formulaText = attributeDamage[1] ?? attributeDamage[2];
+            if (formulaText.includes('{')) {
+                const formula = this.parseAttributeFormula(formulaText);
+                if (formula) {
+                    const damageType = this.parseDamageType(attributeDamage[3]);
+                    const damageElement = this.parseDamageElement(attributeDamage[4]);
 
-        if(simpleDamage) {
-            damageBase = parseInt(simpleDamage[1], 10);
-            damageType = this.parseDamageType(simpleDamage[2]);
-            damageElement = this.parseDamageElement(simpleDamage[3])
-        } else if (strengthDamage) {
-            damageAttribute = 'strength';
-            damageBase = parseInt(strengthDamage[1], 10) || 0;
-            damageType = this.parseDamageType(strengthDamage[2]);
-            damageElement = this.parseDamageElement(strengthDamage[3]);
+                    partialDamageData.base = formula.base;
+                    partialDamageData.value = formula.base;
+                    partialDamageData.attribute = formula.attribute;
+                    partialDamageData.base_formula_operator = formula.base_formula_operator;
+                    partialDamageData.type = { base: damageType, value: damageType };
+                    partialDamageData.element = { base: damageElement, value: damageElement };
+                }
+            }
         }
 
-        const damageAp = Number(jsonData.ap._TEXT) || 0;
+        if (partialDamageData.base === undefined) {
+            const simpleDamage = /^(\d+)([PSM])?(?:\(([a-zA-Z]+)\))?(?:\s+\(-?\d+\/m\))?$/i.exec(damageText);
+            if (simpleDamage) {
+                const damageType = this.parseDamageType(simpleDamage[2]);
+                const damageElement = this.parseDamageElement(simpleDamage[3]);
+                const damageBase = Number(simpleDamage[1]) || 0;
 
-        const partialDamageData = {
-            type: {
-                base: damageType,
-                value: damageType,
-            },
-            base: damageBase,
-            value: damageBase,
-            ap: {
-                base: damageAp,
-                value: damageAp,
-            },
-            element: {
-                base: damageElement,
-                value: damageElement,
-            },
-            ...(damageAttribute && { attribute: damageAttribute })
-        } as const;
+                partialDamageData.base = damageBase;
+                partialDamageData.value = damageBase;
+                partialDamageData.type = { base: damageType, value: damageType };
+                partialDamageData.element = { base: damageElement, value: damageElement };
+            }
+        }
+
+        const apText = String(jsonData.ap._TEXT).trim();
+        const apFormula = this.parseAttributeFormula(apText);
+        const simpleAP = /^[+-]?\d+(?:\.\d+)?$/.exec(apText);
+        if (apFormula) {
+            partialDamageData.ap = {
+                base: apFormula.base,
+                value: apFormula.base,
+                attribute: apFormula.attribute,
+                base_formula_operator: apFormula.base_formula_operator,
+            } as DamageType['ap'];
+        } else if (simpleAP) {
+            const damageAp = Number(simpleAP[0]) || 0;
+            partialDamageData.ap = { base: damageAp, value: damageAp } as DamageType['ap'];
+        }
+
         return DataDefaults.createData('damage', partialDamageData);
+    }
+
+    public parseAttributeFormula(val: string): ParsedAttributeFormula | null {
+        const expression = val.replace(/\s/g, '');
+        const attributeFormula = /^(-)?\{([A-Z]+)\}(?:(\+|-|\*|\/)([+-]?\d+(?:\.\d+)?))?$/i.exec(expression);
+        if (!attributeFormula) return null;
+
+        const mappedAttribute = Constants.attributeTable[attributeFormula[2].toUpperCase() as keyof typeof Constants.attributeTable];
+        if (!mappedAttribute) return null;
+        const attribute = mappedAttribute as DamageType['attribute'];
+
+        const sign = attributeFormula[1] === '-' ? -1 : 1;
+        const operator = attributeFormula[3];
+        const operand = Number(attributeFormula[4]) || 0;
+
+        switch (operator) {
+            case '+':
+                return { base: operand, attribute, base_formula_operator: 'add' };
+            case '-':
+                return { base: -operand, attribute, base_formula_operator: 'add' };
+            case '*':
+                return { base: sign * operand, attribute, base_formula_operator: 'multiply' };
+            case '/':
+                return null;
+            default:
+                return { base: 0, attribute, base_formula_operator: sign === -1 ? 'subtract' : 'add' };
+        }
     }
 
     protected parseDamageType(parsedType: string | undefined): DamageTypeType {
@@ -165,8 +207,12 @@ export class WeaponParserBase extends Parser<'weapon'> {
 
     protected parseDamageElement(parsedElement: string | undefined): DamageElement {
         switch(parsedElement?.toLowerCase()) {
+            case 'e':
             case '(e)':
                 return 'electricity';
+            case 'f':
+            case '(f)':
+            case 'fire':
             case '(fire)':
                 return 'fire';
             default:

--- a/src/unittests/actorImport/sr5.CharacterImporter.spec.ts
+++ b/src/unittests/actorImport/sr5.CharacterImporter.spec.ts
@@ -216,6 +216,16 @@ export const characterImporterTesting = (context: QuenchBatchContext) => {
             assert.strictEqual(IH.getArray(weapon.flags.shadowrun5e?.embeddedItems).length, 1);
         });
 
+        it('Should import strength-based weapon damage from raw Chummer damage', async () => {
+            if (!actor) throw new Error('No actor created');
+            const weapon = actor.items.find(i => i.name === 'Unarmed Attack') as SR5Item<'weapon'>;
+            if (!weapon) throw new Error('Weapon not found');
+
+            assert.strictEqual(weapon.system.action.damage.base, 0);
+            assert.strictEqual(weapon.system.action.damage.attribute, 'strength');
+            assert.strictEqual(weapon.system.action.damage.type.base, 'stun');
+        });
+
         it('Should have the correct vehicles', async () => {
             const vehicle = vehicles[0];
             if (!vehicle) throw new Error('No vehicle created');

--- a/src/unittests/sr5.WeaponParser.spec.ts
+++ b/src/unittests/sr5.WeaponParser.spec.ts
@@ -1,16 +1,10 @@
 import { QuenchBatchContext } from '@ethaks/fvtt-quench';
-import { DamageType } from 'src/module/types/item/Action';
 import { DataDefaults } from '../module/data/DataDefaults';
-import { Weapon } from '../module/apps/itemImport/schema/WeaponsSchema';
 import { WeaponParserBase } from '../module/apps/itemImport/parser/weapon/WeaponParserBase';
 import { WeaponParser as ActorWeaponParser } from '../module/apps/actorImport/itemImporter/weaponImport/WeaponParser';
 import { Constants } from '../module/apps/itemImport/importer/Constants';
-
-class TestWeaponParser extends WeaponParserBase {
-    public override getDamage(jsonData: Weapon): DamageType {
-        return super.getDamage(jsonData);
-    }
-}
+import { CritterParser } from '../module/apps/itemImport/parser/metatype/CritterParser';
+import { AmmoParser as ItemAmmoParser } from '../module/apps/itemImport/parser/gear/AmmoParser';
 
 function mockXmlData(data: Record<string, unknown>): Record<string, unknown> {
     return Object.fromEntries(Object.entries(data)
@@ -18,20 +12,26 @@ function mockXmlData(data: Record<string, unknown>): Record<string, unknown> {
             [key, { '_TEXT': value }]));
 }
 
-function getData(damageString: string, apString: string | number = 0): Partial<Weapon> {
-    return mockXmlData({
-        damage: damageString, ap: apString
-    });
+class TestCritterParser extends CritterParser {
+    public override getNaturalWeapons(powers: { _TEXT: string; $?: { select?: string } }[], options: { actorName: string }) {
+        return super.getNaturalWeapons(powers, options);
+    }
+}
+
+class TestItemAmmoParser extends ItemAmmoParser {
+    public override getSystem(jsonData: any) {
+        return super.getSystem(jsonData);
+    }
 }
 
 export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
     const { describe, it, assert } = context;
 
-    const mut = new TestWeaponParser();
+    const mut = new WeaponParserBase();
 
     describe("Weapon Damage Values", () => {
         it("Parses simple damage", () => {
-            const output = mut.getDamage(getData("12P") as Weapon);
+            const output = mut.parseDamageData("12P", 0);
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 12,
                 value: 12,
@@ -43,7 +43,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
 
         it("Parses elemental damage", () => {
-            const output = mut.getDamage(getData("8S(e)") as Weapon);
+            const output = mut.parseDamageData("8S(e)", 0);
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 8,
                 value: 8,
@@ -59,7 +59,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
 
         it("Parses strength-based damage", () => {
-            const output = mut.getDamage(getData("({STR}+3)P") as Weapon);
+            const output = mut.parseDamageData("({STR}+3)P", 0);
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 3,
                 value: 3,
@@ -72,7 +72,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
 
         it("Parses damage without type as physical", () => {
-            const output = mut.getDamage(getData("11") as Weapon);
+            const output = mut.parseDamageData("11", 0);
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 11,
                 value: 11,
@@ -84,7 +84,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
 
         it("Parses 0 damage", () => {
-            const output = mut.getDamage(getData("0") as Weapon);
+            const output = mut.parseDamageData("0", 0);
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 0,
                 value: 0,
@@ -96,7 +96,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
 
         it("Parses basic matrix damage", () => {
-            const output = mut.getDamage(getData("7M") as Weapon);
+            const output = mut.parseDamageData("7M", 0);
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 7,
                 value: 7,
@@ -108,7 +108,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
 
         it("Parses strength-based damage without modifier", () => {
-            const output = mut.getDamage(getData("({STR})P") as Weapon);
+            const output = mut.parseDamageData("({STR})P", 0);
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 0,
                 value: 0,
@@ -121,7 +121,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
 
         it("Parses multiplied attribute damage", () => {
-            const output = mut.getDamage(getData("({MAG}*2)P") as Weapon);
+            const output = mut.parseDamageData("({MAG}*2)P", 0);
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 2,
                 value: 2,
@@ -135,7 +135,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
 
         it("Parses attribute AP formulas", () => {
-            const output = mut.getDamage(getData("9P", "-{MAG}*0.5") as Weapon);
+            const output = mut.parseDamageData("9P", "-{MAG}*0.5");
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 9,
                 value: 9,
@@ -164,7 +164,7 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
 
         it("Parses short fire elemental damage", () => {
-            const output = mut.getDamage(getData("8P(f)") as Weapon);
+            const output = mut.parseDamageData("8P(f)", 0);
             assert.deepEqual(output, DataDefaults.createData('damage', {
                 base: 8,
                 value: 8,
@@ -180,8 +180,24 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
         });
 
         it("Leaves unsupported complex damage at defaults", () => {
-            const output = mut.getDamage(getData("({STR}+2)P + 12(e)", "-") as Weapon);
+            const output = mut.parseDamageData("({STR}+2)P + 12(e)", "-");
             assert.deepEqual(output, DataDefaults.createData('damage'));
+        });
+
+        it("Parses signed elemental damage modifiers", () => {
+            const output = mut.parseDamageData("-2S(e)", 0);
+            assert.deepEqual(output, DataDefaults.createData('damage', {
+                base: -2,
+                value: -2,
+                type: {
+                    base: 'stun',
+                    value: 'stun',
+                },
+                element: {
+                    base: 'electricity',
+                    value: 'electricity',
+                },
+            }));
         });
     })
 
@@ -295,5 +311,55 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
 
             assert.strictEqual(output, null);
         });
-    })
+    });
+
+    describe("Item Import Natural Weapon Values", () => {
+        const critterParser = new TestCritterParser();
+
+        it("Parses metatype natural weapon formulas from power select text", () => {
+            const [item] = critterParser.getNaturalWeapons([{
+                _TEXT: 'Natural Weapon',
+                $: { select: 'Kick: DV ({STR} + 2)P, AP +1, +1 Reach' },
+            }], { actorName: 'Centaur' });
+
+            const system = (item as unknown as { system: Item.SystemOfType<'weapon'> }).system;
+            assert.strictEqual(system.action.damage.base, 2);
+            assert.strictEqual(system.action.damage.attribute, 'strength');
+            assert.strictEqual(system.action.damage.ap.base, 1);
+            assert.strictEqual(system.melee.reach, 1);
+        });
+    });
+
+    describe("Item Import Ammo Bonus Values", () => {
+        const ammoParser = new TestItemAmmoParser([] as any);
+
+        it("Parses signed elemental ammo damage bonuses", () => {
+            const output = ammoParser.getSystem({
+                weaponbonus: {
+                    damage: { _TEXT: '-2S(e)' },
+                    ap: { _TEXT: '-5' },
+                },
+            });
+
+            assert.strictEqual(output.damage, -2);
+            assert.strictEqual(output.damageType, 'stun');
+            assert.strictEqual(output.element, 'electricity');
+            assert.strictEqual(output.ap, -5);
+        });
+
+        it("Parses ammo damage replacements with acid damage types", () => {
+            const output = ammoParser.getSystem({
+                weaponbonus: {
+                    damagereplace: { _TEXT: '6P' },
+                    damagetype: { _TEXT: 'Acid' },
+                    apreplace: { _TEXT: '-5' },
+                },
+            });
+
+            assert.strictEqual(output.damage, 6);
+            assert.strictEqual(output.damageType, 'physical');
+            assert.strictEqual(output.element, 'acid');
+            assert.strictEqual(output.ap, -5);
+        });
+    });
 }

--- a/src/unittests/sr5.WeaponParser.spec.ts
+++ b/src/unittests/sr5.WeaponParser.spec.ts
@@ -3,6 +3,8 @@ import { DamageType } from 'src/module/types/item/Action';
 import { DataDefaults } from '../module/data/DataDefaults';
 import { Weapon } from '../module/apps/itemImport/schema/WeaponsSchema';
 import { WeaponParserBase } from '../module/apps/itemImport/parser/weapon/WeaponParserBase';
+import { WeaponParser as ActorWeaponParser } from '../module/apps/actorImport/itemImporter/weaponImport/WeaponParser';
+import { Constants } from '../module/apps/itemImport/importer/Constants';
 
 class TestWeaponParser extends WeaponParserBase {
     public override getDamage(jsonData: Weapon): DamageType {
@@ -16,9 +18,9 @@ function mockXmlData(data: Record<string, unknown>): Record<string, unknown> {
             [key, { '_TEXT': value }]));
 }
 
-function getData(damageString: string): Partial<Weapon> {
+function getData(damageString: string, apString: string | number = 0): Partial<Weapon> {
     return mockXmlData({
-        damage: damageString, ap: 0
+        damage: damageString, ap: apString
     });
 }
 
@@ -116,6 +118,182 @@ export const weaponParserBaseTesting = (context: QuenchBatchContext) => {
                 },
                 attribute: 'strength',
             }));
+        });
+
+        it("Parses multiplied attribute damage", () => {
+            const output = mut.getDamage(getData("({MAG}*2)P") as Weapon);
+            assert.deepEqual(output, DataDefaults.createData('damage', {
+                base: 2,
+                value: 2,
+                base_formula_operator: 'multiply',
+                type: {
+                    base: 'physical',
+                    value: 'physical',
+                },
+                attribute: 'magic',
+            }));
+        });
+
+        it("Parses attribute AP formulas", () => {
+            const output = mut.getDamage(getData("9P", "-{MAG}*0.5") as Weapon);
+            assert.deepEqual(output, DataDefaults.createData('damage', {
+                base: 9,
+                value: 9,
+                type: {
+                    base: 'physical',
+                    value: 'physical',
+                },
+                ap: {
+                    base: -0.5,
+                    value: -0.5,
+                    attribute: 'magic',
+                    base_formula_operator: 'multiply',
+                },
+            }));
+        });
+
+        it("Parses item imported Chummer attribute formulas using the Chummer attribute table", () => {
+            for (const [chummerAttribute, systemAttribute] of Object.entries(Constants.attributeTable)) {
+                const output = mut.parseAttributeFormula(`{${chummerAttribute}}+2`);
+                if (!output) throw new Error(`Could not parse ${chummerAttribute} formula`);
+
+                assert.strictEqual(output.base, 2, chummerAttribute);
+                assert.strictEqual(output.attribute, systemAttribute, chummerAttribute);
+                assert.strictEqual(output.base_formula_operator, 'add', chummerAttribute);
+            }
+        });
+
+        it("Parses short fire elemental damage", () => {
+            const output = mut.getDamage(getData("8P(f)") as Weapon);
+            assert.deepEqual(output, DataDefaults.createData('damage', {
+                base: 8,
+                value: 8,
+                type: {
+                    base: 'physical',
+                    value: 'physical',
+                },
+                element: {
+                    base: 'fire',
+                    value: 'fire',
+                },
+            }));
+        });
+
+        it("Leaves unsupported complex damage at defaults", () => {
+            const output = mut.getDamage(getData("({STR}+2)P + 12(e)", "-") as Weapon);
+            assert.deepEqual(output, DataDefaults.createData('damage'));
+        });
+    })
+
+    describe("Actor Import Weapon Damage Values", () => {
+        const actorWeaponParser = new ActorWeaponParser();
+
+        it("Parses actor imported strength-based damage from rawdamage", () => {
+            const output = actorWeaponParser.parseChummerDamage("({STR}+2)P", "7P")!;
+
+            assert.strictEqual(output.damage, 2);
+            assert.strictEqual(output.attribute, 'strength');
+            assert.strictEqual(output.base_formula_operator, 'add');
+            assert.strictEqual(output.type, 'physical');
+        });
+
+        it("Parses actor imported ranged damage from rawdamage", () => {
+            const output = actorWeaponParser.parseChummerDamage("9P", "9P")!;
+
+            assert.strictEqual(output.damage, 9);
+            assert.strictEqual(output.attribute, '');
+            assert.strictEqual(output.type, 'physical');
+        });
+
+        it("Parses actor imported strength-based stun damage without modifier", () => {
+            const output = actorWeaponParser.parseChummerDamage("({STR})S", "5S")!;
+
+            assert.strictEqual(output.damage, 0);
+            assert.strictEqual(output.attribute, 'strength');
+            assert.strictEqual(output.base_formula_operator, 'add');
+            assert.strictEqual(output.type, 'stun');
+        });
+
+        it("Parses actor imported strength-based damage with negative modifier", () => {
+            const output = actorWeaponParser.parseChummerDamage("({STR}-1)P", "4P")!;
+
+            assert.strictEqual(output.damage, -1);
+            assert.strictEqual(output.attribute, 'strength');
+            assert.strictEqual(output.base_formula_operator, 'add');
+            assert.strictEqual(output.type, 'physical');
+        });
+
+        it("Parses Chummer attribute formulas using the Chummer attribute table", () => {
+            for (const [chummerAttribute, systemAttribute] of Object.entries(Constants.attributeTable)) {
+                const output = actorWeaponParser.parseAttributeFormula(`{${chummerAttribute}}+2`);
+                if (!output) throw new Error(`Could not parse ${chummerAttribute} formula`);
+
+                assert.strictEqual(output.base, 2, chummerAttribute);
+                assert.strictEqual(output.attribute, systemAttribute, chummerAttribute);
+                assert.strictEqual(output.base_formula_operator, 'add', chummerAttribute);
+            }
+        });
+
+        it("Parses actor imported multiplied attribute damage", () => {
+            const output = actorWeaponParser.parseChummerDamage("({MAG}*2)P", "12P")!;
+
+            assert.strictEqual(output.damage, 2);
+            assert.strictEqual(output.attribute, 'magic');
+            assert.strictEqual(output.base_formula_operator, 'multiply');
+            assert.strictEqual(output.type, 'physical');
+        });
+
+        it("Parses actor imported elemental flat damage", () => {
+            const output = actorWeaponParser.parseChummerDamage("8S(e)", "8S(e)")!;
+
+            assert.strictEqual(output.damage, 8);
+            assert.strictEqual(output.type, 'stun');
+            assert.strictEqual(output.element, 'electricity');
+        });
+
+        it("Parses actor imported blast damage", () => {
+            const output = actorWeaponParser.parseChummerDamage("16P (-2/m)", "16P (-2/m)")!;
+
+            assert.strictEqual(output.damage, 16);
+            assert.strictEqual(output.type, 'physical');
+            assert.strictEqual(output.dropoff, -2);
+            assert.strictEqual(output.radius, 8);
+        });
+
+        it("Falls back to damage_english when rawdamage cannot be translated", () => {
+            const output = actorWeaponParser.parseChummerDamage("Special", "5P")!;
+
+            assert.strictEqual(output.damage, 5);
+            assert.strictEqual(output.attribute, '');
+            assert.strictEqual(output.type, 'physical');
+        });
+
+        it("Returns null when rawdamage and damage_english cannot be translated", () => {
+            const output = actorWeaponParser.parseChummerDamage("Special", "Missile");
+
+            assert.strictEqual(output, null);
+        });
+
+        it("Parses actor imported attribute AP formula", () => {
+            const output = actorWeaponParser.parseChummerAP("-{MAG}*0.5", "-3")!;
+
+            assert.strictEqual(output.base, -0.5);
+            assert.strictEqual(output.attribute, 'magic');
+            assert.strictEqual(output.base_formula_operator, 'multiply');
+        });
+
+        it("Falls back to ap_english when rawap cannot be translated", () => {
+            const output = actorWeaponParser.parseChummerAP("Special", "-2")!;
+
+            assert.strictEqual(output.base, -2);
+            assert.strictEqual(output.attribute, '');
+            assert.strictEqual(output.base_formula_operator, 'add');
+        });
+
+        it("Returns null when rawap and ap_english cannot be translated", () => {
+            const output = actorWeaponParser.parseChummerAP("Special", "-");
+
+            assert.strictEqual(output, null);
         });
     })
 }


### PR DESCRIPTION
## Summary
- Fix Chummer weapon import so `rawdamage`/`rawap` (and their english fallbacks) are parsed correctly, including attribute-based formulas (`{STR}+2`), elemental types, and blast radius/dropoff — previously only a naive numeric regex was used.
- Extract the fixed damage/AP-code parsing into a public `WeaponParserBase.parseDamageData()` and reuse it in `AmmoParser` (weapon bonus damage/AP, including `damagereplace`/`apreplace` and acid damage type), `MetatypeParserBase` (natural weapon `DV`/`AP`/`REACH` select-text parsing), and `CritterPowerParser` (natural weapon critter powers), removing several duplicated/buggy ad-hoc parsers.
- Fix a greedy-regex bug in the damage-code pattern that caused multi-segment damage strings to be parsed incorrectly, and add support for the `acid` damage type.

Fixes #1980