### PR TITLE
[REGRESSION] Re-add armor total to display on actor footer

### DIFF
--- a/src/css/bundle-v2.scss
+++ b/src/css/bundle-v2.scss
@@ -437,6 +437,24 @@ body.theme-light,
             border-top: 1px solid var(--sr5v2-border-strong);
             flex-shrink: 0;
             vertical-align: bottom;
+
+            /* Make the inner list-item distribute its children across the footer
+               so the footer content fills the full width and the armor badge
+               stays pinned to the far right. */
+            .list-item {
+                width: 100%;
+                display: flex;
+                flex-flow: row nowrap;
+                align-items: center;
+                gap: .5rem;
+                /* Allow children to grow to fill space so items span the full width */
+            }
+
+            /* By default each immediate child should flex to take available space */
+            .list-item > * {
+                flex: 1 1 auto;
+                min-width: 0; /* prevent overflow from long labels */
+            }
         }
 
         &.standard-form, .standard-form {

--- a/src/templates/v2/actor/footer.hbs
+++ b/src/templates/v2/actor/footer.hbs
@@ -253,6 +253,12 @@
                 {{> 'systems/shadowrun5e/dist/templates/v2/actor/parts/movement.hbs' }}
             {{/unless}}
         {{/unless}}
+        {{#if (or (eq actor.type 'character') (eq actor.type 'spirit') (eq actor.type 'vehicle'))}}
+            <label class="sheet-footer-armor" data-tooltip="{{localize 'SR5.Armor.label'}}">
+                <i class="fas fa-shield"></i>
+                {{system.armor.rating.value}}
+            </label>
+        {{/if}}
         <div></div>
     </div>
 </footer>


### PR DESCRIPTION
Fixes #1713

Adds the Armor total using the already in use armor icon to all actor type sheets that can have armor.