### PR TITLE
[BUG] Deleting single mark for persona device doesn't delete mark

### DIFF
--- a/src/module/actor/sheets/SR5MatrixActorSheet.ts
+++ b/src/module/actor/sheets/SR5MatrixActorSheet.ts
@@ -676,15 +676,18 @@ export class SR5MatrixActorSheet<T extends MatrixActorSheetData = MatrixActorShe
             return;
         }
 
-        const uuid = SheetFlow.closestUuid(event.target);
-        if (!uuid) return;
+        // Only consider the stored mark id on the element when clearing a single mark.
+        const el = event.target.closest<HTMLElement>('[data-mark-id]');
+        if (!el) return;
+        const markId = el.dataset.markId;
+        if (!markId) return;
 
         const userConsented = await Helpers.confirmDeletion();
         if (!userConsented) return;
 
         // Change selection state before triggering an update caused re-render.
         this.toggleMatrixTargetSelection(undefined);
-        await this.actor.clearMark(uuid);
+        await this.actor.clearMark(markId);
     }
 
     static async #clearAllMarks(this: SR5MatrixActorSheet, event: PointerEvent) {

--- a/src/templates/v2/list-items/marked_icon/item.hbs
+++ b/src/templates/v2/list-items/marked_icon/item.hbs
@@ -1,6 +1,6 @@
 {{!--expects a MarkedDocument to be passed in as 'item' --}}
 <div class="list-item-container {{cssClass}}">
-    <div class="list-item {{#if item.selected}}list-item-selected{{/if}}" data-uuid="{{item.document.uuid}}">
+    <div class="list-item {{#if item.selected}}list-item-selected{{/if}}" data-uuid="{{item.document.uuid}}" data-mark-id="{{item.markId}}">
         <div class="list-item-start">
             {{> "systems/shadowrun5e/dist/templates/v2/list-items/matrix-icon-image.hbs" item.document }}
             <a data-action="openUuid">


### PR DESCRIPTION
Fixes #1985

The issues was, again, related to display vs actual marked device:

The actually marked device when marking a 'persona' is the persona device. However, when the marked icons are displayed, the persona actor is the main interaction point, but has a different mark.