### PR TITLE
[LAYOUT] Light mode doesn't show edit mode icon

### DIFF
--- a/src/css/bundle-v2.scss
+++ b/src/css/bundle-v2.scss
@@ -301,6 +301,33 @@ body.theme-light,
                         -1px -1px 1px var(--sr5v2-link-hover),
                         -1px 1px 1px var(--sr5v2-link-hover);
         }
+        > button.header-control.icon.fa-stack {
+            padding: 0;
+            position: relative;
+            width: 1.75rem;
+            flex-basis: 1.75rem;
+            overflow: visible;
+            font-size: 0.8rem;
+
+            > .fa-toggle-large-on,
+            > .fa-toggle-large-off {
+                left: 50%;
+                top: 50%;
+                width: 3.25em;
+                transform: translate(-50%, -90%);
+                z-index: 0;
+            }
+
+            > .edit-wrench-icon {
+                left: calc(50% - 0.25rem);
+                top: 50%;
+                width: auto;
+                margin: 0;
+                font-size: 0.6rem;
+                transform: translate(-60%, -50%) rotate(270deg);
+                z-index: 1;
+            }
+        }
     }
 
     &.named-sheet {
@@ -987,6 +1014,12 @@ body.theme-light .sr5v2:not(.theme-dark),
     --sr5v2-negative-bg: rgba(140, 61, 61, 0.16);
     --sr5v2-list-selected-bg: radial-gradient(rgba(7, 145, 35, 0.22), rgba(7, 145, 35, 0.03));
     --sr5v2-icon-filter: none;
+}
+
+body.theme-light .sr5v2:not(.theme-dark) .window-header > button.header-control.icon.fa-stack > .edit-wrench-icon,
+.sr5v2.theme-light .window-header > button.header-control.icon.fa-stack > .edit-wrench-icon {
+    color: #fff;
+    text-shadow: none;
 }
 
 body.theme-light .sr5v2:not(.theme-dark) .toggle-fresh-import img[src$='.svg'],

--- a/src/module/handlebars/SR5ApplicationMixin.ts
+++ b/src/module/handlebars/SR5ApplicationMixin.ts
@@ -459,7 +459,6 @@ export function SR5ApplicationMixin<BaseClass extends Identity<typeof AnyApplica
             if (this.isEditable) {
                 const button = document.createElement('button');
                 button.className = 'header-control icon fa-stack';
-                button.style.fontSize = '.6rem';
                 button.dataset.tooltip = 'SR5.Tooltips.ToggleEditMode';
                 button.dataset.action = 'toggleEditMode';
 


### PR DESCRIPTION
Fixes #1925

<img width="1714" height="291" alt="image" src="https://github.com/user-attachments/assets/cb2a8e0c-4426-4c00-a5a3-00c40705974c" />
<img width="1755" height="232" alt="image" src="https://github.com/user-attachments/assets/51595c62-6b6b-423f-a9ae-ed4f98903f36" />
