### PR TITLE
[System] Both Windows and Linux used tsgo instead of tsgo.js

### DIFF
--- a/gulp.tasks.js
+++ b/gulp.tasks.js
@@ -18,7 +18,7 @@ const destFolder = path.resolve(process.cwd(), distName);
 const jsBundle = 'bundle.js';
 const entryPoint = "./src/module/main.ts";
 const tsgoPackagePath = require.resolve('@typescript/native-preview/package.json');
-const tsgoScriptPath = path.join(path.dirname(tsgoPackagePath), 'bin', 'tsgo.js');
+const tsgoScriptPath = path.join(path.dirname(tsgoPackagePath), 'bin', 'tsgo');
 
 /**
  * CLEAN


### PR DESCRIPTION
Both on my linux and windows machine, tsgo.js isn't the right executable anymore. 

tsgo should've been in use since TypeScript 7.0, as far as a quick google search goes.

<img width="1023" height="468" alt="image" src="https://github.com/user-attachments/assets/8e20259a-393a-4056-8ce2-8a49b23650f7" />

@BM123499 Please double check if you have this issue on `master` as well.
