### PR TITLE
[Bug] Fix essence displaying rounded up instead of decimal for NPC characters

### DIFF
--- a/src/module/actor/prep/functions/NPCPrep.ts
+++ b/src/module/actor/prep/functions/NPCPrep.ts
@@ -23,10 +23,10 @@ export class NPCPrep {
         for (const [name, attribute] of Object.entries(attributes)) {
             // Apply NPC modifiers
             const modifyBy = metatypeModifier.attributes?.[name] as number | undefined;
-            if (modifyBy)
+            if (modifyBy) {
                 ModifiableValue.addUnique(attribute, METATYPEMODIFIER, modifyBy);
-
-            AttributesPrep.calculateAttribute(name, attribute);
+                AttributesPrep.calculateAttribute(name, attribute);
+            }
         }
     }
 }

--- a/src/unittests/sr5.CharacterDataPrep.spec.ts
+++ b/src/unittests/sr5.CharacterDataPrep.spec.ts
@@ -532,5 +532,19 @@ export const shadowrunSR5CharacterDataPrep = (context: QuenchBatchContext) => {
             assert.strictEqual(character.system.track.stun.disabled, true);
             assert.strictEqual(character.system.track.physical.disabled, false);
         });
+
+        it('NPC essence should keep decimal precision (GH#2009)', async () => {
+            const character = await factory.createActor({ type: 'character', system: { is_npc: true } });
+            await character.createEmbeddedDocuments('Item', [{
+                type: 'cyberware',
+                name: 'Cybereyes',
+                system: {
+                    essence: 0.75,
+                    technology: { equipped: true }
+                }
+            }]);
+
+            assert.strictEqual(character.system.attributes.essence.value, SR.attributes.defaults['essence'] - 0.75);
+        });
     });
 };


### PR DESCRIPTION
Fixes #2009.

When a character actor had "Is NPC" checked, essence was displayed rounded up to the next integer (e.g. 6.25 → 7) instead of keeping its decimal precision, unlike non-NPC characters.

**Root cause:** `NPCPrep.applyMetatypeModifiers` recalculated every attribute — including `essence` — via `AttributesPrep.calculateAttribute`, which rounds up (`Math.ceil`) unless explicitly told to preserve decimals. This overwrote the decimal essence value that `AttributesPrep.prepareEssence` had just correctly computed. This path only runs for NPCs, since `applyMetatypeModifiers` returns early for non-NPC characters.

**Fix:** only recalculate an attribute in `applyMetatypeModifiers` when a metatype modifier actually applies to it. Essence is never a metatype-modifier target, so it's no longer needlessly re-rounded and keeps its decimal value.

Added a regression test (`sr5.CharacterDataPrep.spec.ts`) covering an NPC character with a fractional essence cost from an equipped cyberware item. Verified via the full Quench `data_prep` suite (64 tests, all passing).
