### PR TITLE
[Bug] Fix item sheet field labels showing blank instead of English in Portuguese and French

### DIFF
--- a/public/locale/fr/config.json
+++ b/public/locale/fr/config.json
@@ -76,28 +76,52 @@
             "FIELDS": {
                 "armor": {
                     "accessory": {
-                        "hint": "If this Armor is an Accessory (adds its value to the actor's base Armor)",
-                        "label": "Accessory"
+                        "hint": "Si cette Armure est un Accessoire (ajoute sa valeur au Blindage de base de l'acteur)",
+                        "label": "Accessoire"
+                    },
+                    "acid": {
+                        "hint": "Blindage supplémentaire contre les attaques à l'Acide",
+                        "label": "Résistance à l'acide"
+                    },
+                    "cold": {
+                        "hint": "Blindage supplémentaire contre les attaques de Froid",
+                        "label": "Isolation"
+                    },
+                    "electricity": {
+                        "hint": "Blindage supplémentaire contre les attaques d'Électricité",
+                        "label": "Non-conductivité"
+                    },
+                    "fire": {
+                        "hint": "Blindage supplémentaire contre les attaques de Feu",
+                        "label": "Résistance au feu"
                     },
                     "hardened": {
-                        "hint": "Si cette armure est renforcee",
-                        "label": "Armure renforcee"
-                    },
-                    "is_hardened": {
-                        "hint": "Si cette armure accorde une protection renforcee",
-                        "label": "Renforcee active"
+                        "hint": "Si cette armure est renforcée",
+                        "label": "Armure renforcée"
                     },
                     "immunities": {
-                        "hint": "Damage sources this armor grants Immunity against",
-                        "label": "Immunities"
+                        "hint": "Sources de dégâts contre lesquelles cette armure accorde l'Immunité",
+                        "label": "Immunités"
+                    },
+                    "is_hardened": {
+                        "hint": "Si cette armure accorde une protection renforcée",
+                        "label": "Renforcée active"
                     },
                     "pollutant": {
-                        "hint": "Extra Armor against attacks with Pollutant",
-                        "label": "Chemical Protection"
+                        "hint": "Blindage supplémentaire contre les attaques de Polluants",
+                        "label": "Protection chimique"
+                    },
+                    "radiation": {
+                        "hint": "Blindage supplémentaire contre les attaques de Radiations",
+                        "label": "Résistance aux radiations"
+                    },
+                    "value": {
+                        "hint": "Quantité de Blindage que cet objet fournit",
+                        "label": "Valeur Blindage"
                     },
                     "water": {
-                        "hint": "Extra Armor against attacks with Water",
-                        "label": "Water Protection"
+                        "hint": "Blindage supplémentaire contre les attaques d'Eau",
+                        "label": "Protection contre l'eau"
                     }
                 }
             },
@@ -112,6 +136,7 @@
         "ArmorValue": "Valeur Blindage",
         "AstralDice": "Dés init. Astral",
         "AstralInit": "Init. Astral",
+        "Attack": "Attaque",
         "AttackerHits": "Succès de l'attaquant",
         "AttrAgility": "Agilité",
         "AttrBody": "Constitution",
@@ -414,15 +439,165 @@
         "Item": {
             "FIELDS": {
                 "action": {
+                    "armor": {
+                        "hint": "Si le Blindage de l'acteur doit être ajouté au test",
+                        "label": "Blindage"
+                    },
+                    "attribute": {
+                        "hint": "L'Attribut utilisé par le test",
+                        "label": "Attribut"
+                    },
+                    "attribute2": {
+                        "hint": "L'Autre Attribut utilisé par ce test",
+                        "label": "Autre Attribut"
+                    },
+                    "categories": {
+                        "hint": "Catégories d'Action que ce test intègre. Ces actions peuvent être ciblées par des Effets Actifs",
+                        "label": "Catégories"
+                    },
                     "damage": {
+                        "ap": {
+                            "attribute": {
+                                "hint": "Attribut à utiliser dans le calcul de la PA",
+                                "label": "Attribut de PA"
+                            },
+                            "base": {
+                                "hint": "Pénétration d'Armure des Dégâts",
+                                "label": "PA"
+                            },
+                            "base_formula_operator": {
+                                "hint": "Comment la valeur de base de PA doit affecter l'Attribut",
+                                "label": "Opérateur"
+                            }
+                        },
+                        "attribute": {
+                            "hint": "Attribut à utiliser dans le calcul des Dégâts",
+                            "label": "Attribut de Dégâts"
+                        },
+                        "base": {
+                            "hint": "Le montant de base des Dégâts infligés par cette action",
+                            "label": "Dégâts de Base"
+                        },
+                        "base_formula_operator": {
+                            "hint": "Comment la valeur de base des Dégâts doit affecter l'Attribut",
+                            "label": "Opérateur"
+                        },
+                        "biofeedback": {
+                            "hint": "Si cette action inflige également des dégâts de Biofeedback. Ceci peut être ciblé par des Effets Actifs",
+                            "label": "Biofeedback"
+                        },
+                        "element": {
+                            "base": {
+                                "hint": "L'Élément du type de dégâts. Laisser vide pour aucun élément.",
+                                "label": "Élément"
+                            }
+                        },
                         "normal_weapon": {
-                            "hint": "If this damage is considered a normal (non-magical) weapon attack",
-                            "label": "Normal Weapon"
+                            "hint": "Si ces dégâts sont considérés comme une attaque d'arme normale (non magique)",
+                            "label": "Arme Normale"
+                        },
+                        "type": {
+                            "base": {
+                                "hint": "Type de Dégâts infligés par cette action",
+                                "label": "Type de Dégâts"
+                            }
                         }
+                    },
+                    "extended": {
+                        "hint": "S'il s'agit d'un Test étendu",
+                        "label": "Test étendu"
                     },
                     "initiative_mod": {
                         "hint": "Modificateur d'initiative appliqué lors de l'exécution de cette action",
                         "label": "Modificateur d'Initiative"
+                    },
+                    "limit": {
+                        "attribute": {
+                            "hint": "La Limite spécifique de l'Acteur utilisée pour le test.",
+                            "label": "Limite"
+                        },
+                        "base": {
+                            "hint": "Valeur de Limite utilisée pour le test. Elle est ajoutée si une limite spécifique est sélectionnée",
+                            "label": "Valeur de Limite"
+                        }
+                    },
+                    "mod": {
+                        "hint": "Tout modificateur appliqué au test",
+                        "label": "Modificateur"
+                    },
+                    "modifiers": {
+                        "hint": "Modificateurs d'Action qui affectent ce test.",
+                        "label": "Modificateurs"
+                    },
+                    "opposed": {
+                        "armor": {
+                            "hint": "Si le Blindage de l'acteur doit être ajouté au Test opposé",
+                            "label": "Blindage"
+                        },
+                        "attribute": {
+                            "hint": "L'Attribut utilisé par le Test opposé",
+                            "label": "Attribut"
+                        },
+                        "attribute2": {
+                            "hint": "L'Autre Attribut utilisé par ce Test opposé",
+                            "label": "Autre Attribut"
+                        },
+                        "mod": {
+                            "hint": "Tout modificateur appliqué au Test opposé",
+                            "label": "Modificateur"
+                        },
+                        "resist": {
+                            "armor": {
+                                "hint": "Si le Blindage de l'acteur doit être ajouté au Test de résistance",
+                                "label": "Blindage"
+                            },
+                            "attribute": {
+                                "hint": "L'Attribut utilisé par le Test de résistance",
+                                "label": "Attribut"
+                            },
+                            "attribute2": {
+                                "hint": "L'Autre Attribut utilisé par ce Test de résistance",
+                                "label": "Autre Attribut"
+                            },
+                            "test": {
+                                "hint": "Test que la cible effectue pour résister aux dégâts après le Test opposé",
+                                "label": "Test de résistance"
+                            }
+                        },
+                        "skill": {
+                            "hint": "Compétence utilisée par le Test opposé. Laisser vide si aucune compétence n'est utilisée",
+                            "label": "Compétence"
+                        },
+                        "test": {
+                            "hint": "Le Test que la cible de l'action doit effectuer",
+                            "label": "Test opposé"
+                        }
+                    },
+                    "roll_mode": {
+                        "hint": "Le Mode lancer de dés du test. Laisser vide pour utiliser le Mode lancer de dés sélectionné par l'utilisateur",
+                        "label": "Mode lancer de dés"
+                    },
+                    "skill": {
+                        "hint": "Compétence utilisée par cette action. Laisser vide si aucune compétence n'est utilisée",
+                        "label": "Compétence"
+                    },
+                    "spec": {
+                        "hint": "Si le modificateur de spécialisation de compétence (+2) doit être appliqué à ce test",
+                        "label": "Spécialisé"
+                    },
+                    "test": {
+                        "hint": "Type spécifique de test à utiliser pour cette Action",
+                        "label": "Type de Test"
+                    },
+                    "threshold": {
+                        "base": {
+                            "hint": "Le Seuil que le test doit atteindre",
+                            "label": "Valeur de Seuil"
+                        }
+                    },
+                    "type": {
+                        "hint": "Type d'action que cette compétence utilise",
+                        "label": "Type d'Action"
                     }
                 }
             }

--- a/public/locale/pt-BR/config.json
+++ b/public/locale/pt-BR/config.json
@@ -169,28 +169,52 @@
             "FIELDS": {
                 "armor": {
                     "accessory": {
-                        "hint": "If this Armor is an Accessory (adds its value to the actor's base Armor)",
-                        "label": "Accessory"
+                        "hint": "Se esta Armadura é um Acessório (soma seu valor à Armadura base do ator)",
+                        "label": "Acessório"
+                    },
+                    "acid": {
+                        "hint": "Armadura extra contra ataques com Ácido",
+                        "label": "Resistência a Ácido"
+                    },
+                    "cold": {
+                        "hint": "Armadura extra contra ataques com Frio",
+                        "label": "Isolamento"
+                    },
+                    "electricity": {
+                        "hint": "Armadura extra contra ataques com Eletricidade",
+                        "label": "Não Condutividade"
+                    },
+                    "fire": {
+                        "hint": "Armadura extra contra ataques com Fogo",
+                        "label": "Resistência a Fogo"
                     },
                     "hardened": {
-                        "hint": "Se esta armadura e endurecida",
+                        "hint": "Se esta armadura é endurecida",
                         "label": "Armadura Endurecida"
                     },
+                    "immunities": {
+                        "hint": "Fontes de dano contra as quais esta armadura concede Imunidade",
+                        "label": "Imunidades"
+                    },
                     "is_hardened": {
-                        "hint": "Se esta armadura concede protecao endurecida",
+                        "hint": "Se esta armadura concede proteção endurecida",
                         "label": "Endurecida Ativa"
                     },
-                    "immunities": {
-                        "hint": "Damage sources this armor grants Immunity against",
-                        "label": "Immunities"
-                    },
                     "pollutant": {
-                        "hint": "Extra Armor against attacks with Pollutant",
-                        "label": "Chemical Protection"
+                        "hint": "Armadura extra contra ataques com Poluentes",
+                        "label": "Proteção Química"
+                    },
+                    "radiation": {
+                        "hint": "Armadura extra contra ataques com Radiação",
+                        "label": "Resistência a Radiação"
+                    },
+                    "value": {
+                        "hint": "Quantidade de Armadura que este item fornece",
+                        "label": "Valor da Armadura"
                     },
                     "water": {
-                        "hint": "Extra Armor against attacks with Water",
-                        "label": "Water Protection"
+                        "hint": "Armadura extra contra ataques com Água",
+                        "label": "Proteção contra Água"
                     }
                 }
             },
@@ -203,6 +227,7 @@
         "ArmorHardenedFull": "Armadura Endurecida",
         "HardenedArmor": "Armadura Endurecida",
         "ArmorValue": "Valor da Armadura",
+        "Attack": "Ataque",
         "Attacker": "Atacante",
         "AttackerHits": "Acertos do Atacante",
         "AttackerNetHits": "Acertos Líquidos do Atacante",
@@ -656,15 +681,165 @@
         "Item": {
             "FIELDS": {
                 "action": {
+                    "armor": {
+                        "hint": "Se a Armadura do ator deve ser somada ao teste",
+                        "label": "Armadura"
+                    },
+                    "attribute": {
+                        "hint": "O Atributo usado pelo teste",
+                        "label": "Atributo"
+                    },
+                    "attribute2": {
+                        "hint": "O Outro Atributo usado por este teste",
+                        "label": "Outro Atributo"
+                    },
+                    "categories": {
+                        "hint": "Categorias de Ação que este teste incorpora. Essas ações podem ser alvo de Efeitos Ativos",
+                        "label": "Categorias"
+                    },
                     "damage": {
+                        "ap": {
+                            "attribute": {
+                                "hint": "Atributo a ser usado no cálculo da PA",
+                                "label": "Atributo de PA"
+                            },
+                            "base": {
+                                "hint": "Penetração de Armadura do Dano",
+                                "label": "PA"
+                            },
+                            "base_formula_operator": {
+                                "hint": "Como o valor base de PA deve afetar o Atributo",
+                                "label": "Operador"
+                            }
+                        },
+                        "attribute": {
+                            "hint": "Atributo a ser usado no cálculo do Dano",
+                            "label": "Atributo de Dano"
+                        },
+                        "base": {
+                            "hint": "A quantidade base de Dano que esta ação causa",
+                            "label": "Dano Base"
+                        },
+                        "base_formula_operator": {
+                            "hint": "Como o valor base de Dano deve afetar o Atributo",
+                            "label": "Operador"
+                        },
+                        "biofeedback": {
+                            "hint": "Se esta ação também causa dano de Biofeedback. Isso pode ser alvo de Efeitos Ativos",
+                            "label": "Biofeedback"
+                        },
+                        "element": {
+                            "base": {
+                                "hint": "O Elemento do tipo de dano. Deixe em branco para nenhum elemento.",
+                                "label": "Elemento"
+                            }
+                        },
                         "normal_weapon": {
-                            "hint": "If this damage is considered a normal (non-magical) weapon attack",
-                            "label": "Normal Weapon"
+                            "hint": "Se este dano é considerado um ataque de arma normal (não mágica)",
+                            "label": "Arma Normal"
+                        },
+                        "type": {
+                            "base": {
+                                "hint": "Tipo de Dano que esta ação causa",
+                                "label": "Tipo de Dano"
+                            }
                         }
+                    },
+                    "extended": {
+                        "hint": "Se este é um Teste Estendido",
+                        "label": "Teste Estendido"
                     },
                     "initiative_mod": {
                         "hint": "Modificador de iniciativa aplicado ao realizar esta ação",
                         "label": "Modificador de Iniciativa"
+                    },
+                    "limit": {
+                        "attribute": {
+                            "hint": "O Limite específico do Ator usado para o teste.",
+                            "label": "Limite"
+                        },
+                        "base": {
+                            "hint": "Valor de Limite usado para o teste. Este é somado se um limite específico for selecionado",
+                            "label": "Valor do Limite"
+                        }
+                    },
+                    "mod": {
+                        "hint": "Quaisquer modificadores aplicados ao teste",
+                        "label": "Modificador"
+                    },
+                    "modifiers": {
+                        "hint": "Modificadores de Ação que afetam este teste.",
+                        "label": "Modificadores"
+                    },
+                    "opposed": {
+                        "armor": {
+                            "hint": "Se a Armadura do ator deve ser somada ao Teste de Oposição",
+                            "label": "Armadura"
+                        },
+                        "attribute": {
+                            "hint": "O Atributo usado pelo Teste de Oposição",
+                            "label": "Atributo"
+                        },
+                        "attribute2": {
+                            "hint": "O Outro Atributo usado por este Teste de Oposição",
+                            "label": "Outro Atributo"
+                        },
+                        "mod": {
+                            "hint": "Quaisquer modificadores aplicados ao Teste de Oposição",
+                            "label": "Modificador"
+                        },
+                        "resist": {
+                            "armor": {
+                                "hint": "Se a Armadura do ator deve ser somada ao Teste de Resistência",
+                                "label": "Armadura"
+                            },
+                            "attribute": {
+                                "hint": "O Atributo usado pelo Teste de Resistência",
+                                "label": "Atributo"
+                            },
+                            "attribute2": {
+                                "hint": "O Outro Atributo usado por este Teste de Resistência",
+                                "label": "Outro Atributo"
+                            },
+                            "test": {
+                                "hint": "Teste que o alvo realiza para resistir ao dano após o Teste de Oposição",
+                                "label": "Teste de Resistência"
+                            }
+                        },
+                        "skill": {
+                            "hint": "Perícia usada pelo Teste de Oposição. Deixe em branco se nenhuma perícia for usada",
+                            "label": "Perícia"
+                        },
+                        "test": {
+                            "hint": "O Teste que o alvo da ação precisa realizar",
+                            "label": "Teste de Oposição"
+                        }
+                    },
+                    "roll_mode": {
+                        "hint": "O Modo de Rolagem do teste. Deixe em branco para usar o Modo de Rolagem selecionado pelo usuário",
+                        "label": "Modo de Rolagem"
+                    },
+                    "skill": {
+                        "hint": "Perícia usada por esta ação. Deixe em branco se nenhuma perícia for usada",
+                        "label": "Perícia"
+                    },
+                    "spec": {
+                        "hint": "Se o modificador de especialização da perícia (+2) deve ser aplicado a este teste",
+                        "label": "Especializado"
+                    },
+                    "test": {
+                        "hint": "Tipo específico de teste a ser usado para esta Ação",
+                        "label": "Tipo de Teste"
+                    },
+                    "threshold": {
+                        "base": {
+                            "hint": "O Limiar que o teste precisa alcançar",
+                            "label": "Valor do Limiar"
+                        }
+                    },
+                    "type": {
+                        "hint": "Tipo de ação que esta perícia utiliza",
+                        "label": "Tipo de Ação"
                     }
                 }
             }


### PR DESCRIPTION
## Problem

On Portuguese and French item sheets, most field labels in the Attack/Action block rendered as empty strings — Test Type, Action Type, Modifiers, Limit, Threshold and Roll Mode all showed a blank label. Armor sheets had the same problem on the resistance fields.

This was not a missing translation. Foundry falls back to English per key, so an untranslated key renders in English, never blank.

## Cause

Field labels are baked into the DataModel schema at startup by `Localization.localizeSchema`, which merges the English fallback with a **shallow** `Object.assign` over the top level of `<prefix>.FIELDS`:

```js
Object.assign(rules, getProperty(game.i18n._fallback, `${prefix}.FIELDS`));
Object.assign(rules, getProperty(game.i18n.translations, `${prefix}.FIELDS`));
```

`SR5.Item.FIELDS.action` was defined in pt-BR and fr with only 2 sub-keys, so it *replaced* the 72-leaf English group rather than extending it. The omitted leaves were absent from the lookup entirely, `label ||= ...` never fired, and the labels stayed `""`.

A `FIELDS` group must therefore be translated completely or omitted entirely — never partially.

## Scope

Audited all 24 `FIELDS` prefixes across all five locales. Exactly four partial groups existed:

| Locale | Group | Lost leaves |
|---|---|---|
| pt-BR | `SR5.Item.FIELDS.action` | 68 |
| pt-BR | `SR5.Armor.FIELDS.armor` | 12 |
| fr | `SR5.Item.FIELDS.action` | 68 |
| fr | `SR5.Armor.FIELDS.armor` | 12 |

`de` and `ko` translate both groups completely, which is why the bug never appeared there. Since `SR5.Item` is in `LOCALIZATION_PREFIXES` for nearly every item type, this affected almost every item sheet in both languages, not only weapons.

## Changes

- Completed both groups to full leaf parity in pt-BR and fr, reusing each file's existing terminology (Perícia/Compétence, Limiar/Seuil, PA, Modo de Rolagem/Mode lancer de dés).
- Added the missing `SR5.Attack` key, which is why the section header read "Attack" beside a translated "Dano"/"Dégâts".
- Corrected missing diacritics found inside the rewritten armor group (`endurecida`, `proteção`, `renforcée`).

The remaining untranslated keys in these files are unaffected — they fall back to English as intended.

## Testing

- All five locale files parse; zero partial `FIELDS` groups remain across every locale.
- `npm run locale:check` passes.
- Verified in the built `dist/locale` output that the previously blank rows now resolve (`Tipo de Teste`, `Tipo de Ação`, `Modificadores`, `Valor do Limite`, `Valor do Limiar`, `Modo de Rolagem`).
- No TypeScript touched; typecheck error count unchanged from base.
