### PR TITLE
[Code] Share skill compendium reads across actor creation to speed up bulk imports

### DIFF
--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -161,7 +161,7 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         // Abort if a skillset was already assigned (e.g. during Chummer import)
         if (foundry.utils.getProperty(data, 'system.skillset')) return;
         // Abort when the creation request opted out of default skills
-        if ((options as SR5ActorCreateOptions).skipDefaultSkills) return;
+        if ((options as SR5ActorCreateOptions | undefined)?.skipDefaultSkills) return;
         await CreateActorFlow.addDefaultActorSkillset(this, data);
     }
 

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -51,6 +51,7 @@ import { ActorOwnershipFlow } from '@/module/actor/flows/ActorOwnershipFlow';
 import { LinksHelpers } from '@/module/utils/links';
 import type { InitiativeModeOptions } from '../combat/SR5Combatant';
 import { CreateActorFlow } from './flows/CreateActorFlow';
+import type { SR5ActorCreateOptions } from './flows/CreateActorFlow';
 import { SkillNamingFlow } from '@/module/flows/SkillNamingFlow';
 import { SkillFieldType } from '../types/template/Skills';
 import { IconAssign } from 'src/module/apps/iconAssigner/IconAssign';
@@ -144,13 +145,15 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
      * @param user The User requesting the document creation
      */
     override async _preCreate(...args: Parameters<Actor<SubType>['_preCreate']>) {
-        const [data] = args;
+        const [data, options] = args;
         await super._preCreate(...args);
 
         // Abort skill creation data injection when duplicating
         if (foundry.utils.getProperty(data, '_stats.duplicateSource')) return;
         // Abort if a skillset was already assigned (e.g. during Chummer import)
         if (foundry.utils.getProperty(data, 'system.skillset')) return;
+        // Abort when the creation request opted out of default skills
+        if ((options as SR5ActorCreateOptions).skipDefaultSkills) return;
         await CreateActorFlow.addDefaultActorSkillset(this, data);
     }
 

--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -135,6 +135,14 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         return { img: assignedImage, texture: { src: assignedImage } };
     }
 
+    /** Share skill pack reads across a creation. */
+    static override async createDocuments<Temporary extends boolean | undefined = undefined>(
+        data: Actor.CreateInput[],
+        operation?: Actor.Database.CreateDocumentsOperation<Temporary>,
+    ) {
+        return PackItemFlow.withSkillPackCache(async () => await super.createDocuments(data, operation));
+    }
+
     /**
      * Lifecycle hook called before an actor document is created.
      *

--- a/src/module/actor/flows/CreateActorFlow.ts
+++ b/src/module/actor/flows/CreateActorFlow.ts
@@ -1,13 +1,6 @@
 import { PackItemFlow } from '@/module/item/flows/PackItemFlow';
-import { SkillItemFlow } from '@/module/item/flows/SkillItemFlow';
 import { SR5Actor } from '../SR5Actor';
 import { SkillSetFlow } from './SkillSetFlow';
-import type { PreparedSkillSetItems } from './SkillSetFlow';
-
-interface PreparedDefaultSkillSet {
-    uuid: string;
-    items: PreparedSkillSetItems;
-}
 
 /**
  * SR5 specific options understood while an actor document is created.
@@ -61,36 +54,5 @@ export const CreateActorFlow = {
         }
 
         return skillSet;
-    },
-
-    /** Add each actor type's default skill set to its creation sources. */
-    async addDefaultSkillsetsToSources(actorSources: Actor.CreateData[]) {
-        // Cache misses as null to avoid repeat lookups.
-        const skillSetsByActorType = new Map<string, PreparedDefaultSkillSet | null>();
-
-        for (const source of actorSources) {
-            // Preserve skill sets assigned by import data.
-            if (foundry.utils.getProperty(source, 'system.skillset')) continue;
-
-            let skillSetData = skillSetsByActorType.get(source.type);
-            if (skillSetData === undefined) {
-                const skillSet = await this.getDefaultSkillSet(source.type);
-                skillSetData = skillSet?.uuid
-                    ? { uuid: skillSet.uuid, items: await SkillSetFlow.prepareSkillSetItems(skillSet) }
-                    : null;
-
-                skillSetsByActorType.set(source.type, skillSetData);
-            }
-
-            if (!skillSetData) continue;
-
-            // Normalize keyed and list item sources.
-            const existingItems = Object.values(source.items ?? {}) as Item.CreateData[];
-            const items = SkillSetFlow.selectMissingSkillSetItems(skillSetData.items, SkillItemFlow.skillKeys(existingItems));
-
-            // Prepared items are shared by actor type.
-            source.items = [...existingItems, ...foundry.utils.deepClone(items)];
-            foundry.utils.setProperty(source, 'system.skillset', skillSetData.uuid);
-        }
     }
 };

--- a/src/module/actor/flows/CreateActorFlow.ts
+++ b/src/module/actor/flows/CreateActorFlow.ts
@@ -3,6 +3,18 @@ import { SR5Actor } from '../SR5Actor';
 import { SkillSetFlow } from './SkillSetFlow';
 
 /**
+ * SR5 specific options understood while an actor document is created.
+ *
+ * They're passed as part of the create operation and reach the document through
+ * its _preCreate options:
+ * `SR5Actor.create(data, { skipDefaultSkills: true })`
+ */
+export interface SR5ActorCreateOptions {
+    /** Skip applying the default skill set configured for the created actor type. */
+    skipDefaultSkills?: boolean;
+}
+
+/**
  * Handles actor initialization concerns that only apply during document creation.
  *
  * This flow is intentionally narrow: it prepares newly created actors with any
@@ -20,8 +32,6 @@ export const CreateActorFlow = {
      * @param data Creation data containing the actor type used for skill set selection.
      */
     async addDefaultActorSkillset(actor: SR5Actor, data: Actor.CreateData) {
-        if (window.doNotPopulateDefaultSkills) return console.warn(`Shadowrun 5e | Skipping default skill set application for actor ${actor.name} due to doNotPopulateDefaultSkills flag`);
-
         const skillSets = await PackItemFlow.getAllPackSkillSets();
         const skillSet = skillSets.find(skillSet => {
             if (!skillSet.system.set.default.type) return false;

--- a/src/module/actor/flows/CreateActorFlow.ts
+++ b/src/module/actor/flows/CreateActorFlow.ts
@@ -1,6 +1,13 @@
 import { PackItemFlow } from '@/module/item/flows/PackItemFlow';
+import { SkillItemFlow } from '@/module/item/flows/SkillItemFlow';
 import { SR5Actor } from '../SR5Actor';
 import { SkillSetFlow } from './SkillSetFlow';
+import type { PreparedSkillSetItems } from './SkillSetFlow';
+
+interface PreparedDefaultSkillSet {
+    uuid: string;
+    items: PreparedSkillSetItems;
+}
 
 /**
  * SR5 specific options understood while an actor document is created.
@@ -32,19 +39,58 @@ export const CreateActorFlow = {
      * @param data Creation data containing the actor type used for skill set selection.
      */
     async addDefaultActorSkillset(actor: SR5Actor, data: Actor.CreateData) {
-        const skillSets = await PackItemFlow.getAllPackSkillSets();
-        const skillSet = skillSets.find(skillSet => {
-            if (!skillSet.system.set.default.type) return false;
-            return skillSet.system.set.default.type === data.type;
-        });
-
-        if (!skillSet) {
-            console.debug(`Shadowrun 5e | No default skill set found for actor type ${data.type}, skipping default skill set application`);
-            return;
-        }
+        const skillSet = await this.getDefaultSkillSet(data.type);
+        if (!skillSet) return;
 
         await SkillSetFlow.applySkillSetToActor(actor, skillSet, { useSource: true });
 
         console.debug(`Shadowrun 5e | Added skill set ${skillSet.name} to actor source data`);
+    },
+
+    /** Get the default skill set for an actor type. */
+    async getDefaultSkillSet(actorType?: string) {
+        const skillSets = await PackItemFlow.getAllPackSkillSets();
+        const skillSet = skillSets.find(skillSet => {
+            if (!skillSet.system.set.default.type) return false;
+            return skillSet.system.set.default.type === actorType;
+        });
+
+        if (!skillSet) {
+            console.debug(`Shadowrun 5e | No default skill set found for actor type ${actorType}, skipping default skill set application`);
+            return;
+        }
+
+        return skillSet;
+    },
+
+    /** Add each actor type's default skill set to its creation sources. */
+    async addDefaultSkillsetsToSources(actorSources: Actor.CreateData[]) {
+        // Cache misses as null to avoid repeat lookups.
+        const skillSetsByActorType = new Map<string, PreparedDefaultSkillSet | null>();
+
+        for (const source of actorSources) {
+            // Preserve skill sets assigned by import data.
+            if (foundry.utils.getProperty(source, 'system.skillset')) continue;
+
+            let skillSetData = skillSetsByActorType.get(source.type);
+            if (skillSetData === undefined) {
+                const skillSet = await this.getDefaultSkillSet(source.type);
+                skillSetData = skillSet?.uuid
+                    ? { uuid: skillSet.uuid, items: await SkillSetFlow.prepareSkillSetItems(skillSet) }
+                    : null;
+
+                skillSetsByActorType.set(source.type, skillSetData);
+            }
+
+            if (!skillSetData) continue;
+
+            // Normalize keyed and list item sources.
+            const existingItems = Object.values(source.items ?? {}) as Item.CreateData[];
+            const items = SkillSetFlow.selectMissingSkillSetItems(skillSetData.items, SkillItemFlow.skillKeys(existingItems));
+
+            // Prepared items are shared by actor type.
+            source.items = [...existingItems, ...foundry.utils.deepClone(items)];
+            foundry.utils.setProperty(source, 'system.skillset', skillSetData.uuid);
+        }
     }
 };

--- a/src/module/actor/flows/SkillSetFlow.ts
+++ b/src/module/actor/flows/SkillSetFlow.ts
@@ -73,7 +73,8 @@ export const SkillSetFlow = {
 
         // Support document creation flow.
         if (options.useSource) {
-            actor.updateSource({ items, system: { skillset: skillSet.uuid } });
+            const existingItems = actor.items.map(item => item.toObject());
+            actor.updateSource({ items: [...existingItems, ...items], system: { skillset: skillSet.uuid } });
             return;
         }
 

--- a/src/module/actor/flows/SkillSetFlow.ts
+++ b/src/module/actor/flows/SkillSetFlow.ts
@@ -2,11 +2,15 @@ import { PackItemFlow } from '@/module/item/flows/PackItemFlow';
 import { SR5Actor } from '../SR5Actor';
 import { SR5Item } from '@/module/item/SR5Item';
 import { SkillItemFlow } from '@/module/item/flows/SkillItemFlow';
-import { ActorSkillFlow } from './ActorSkillFlow';
 import { Helpers } from '@/module/helpers';
 
 interface ReplaceSkillSetOptions {
     askForConfirmation?: boolean;
+}
+
+export interface PreparedSkillSetItems {
+    skills: Item.CreateData[];
+    groups: Item.CreateData[];
 }
 
 /**
@@ -64,24 +68,8 @@ export const SkillSetFlow = {
     async applySkillSetToActor(actor: SR5Actor, skillSet: SR5Item<'skill'>, options: { useSource?: boolean } = {}) {
         if (!skillSet.isType('skill') || skillSet.system.type !== 'set') return;
 
-        let skills = await PackItemFlow.prepareSkillsForSkillSet(skillSet);
-        const groups = await PackItemFlow.prepareSkillGroupsForSkillSet(skillSet) as Item.CreateData[];
-
-        const newSkillKeys = new Set<string>();
-        
-        skills = skills.filter(item => {
-            if (!item.name) return false;
-
-            const skillCategory = foundry.utils.getProperty(item, 'system.skill.category') as string;
-            const skillNameByCategoryKey = SkillItemFlow.skillNameByCategoryKey(item.name, skillCategory);
-            if (newSkillKeys.has(skillNameByCategoryKey) || ActorSkillFlow.hasSkillOfSameNameAndCategory(actor, item.name, skillCategory)) {
-                return false;
-            }
-            newSkillKeys.add(skillNameByCategoryKey);
-            return true;
-        });
-
-        const items = [...skills, ...groups];
+        const prepared = await this.prepareSkillSetItems(skillSet);
+        const items = this.selectMissingSkillSetItems(prepared, SkillItemFlow.skillKeys(actor.items));
 
         // Support document creation flow.
         if (options.useSource) {
@@ -92,6 +80,31 @@ export const SkillSetFlow = {
         // Support adding skillset onto existing actor flow.
         await actor.createEmbeddedDocuments('Item', items);
         await actor.update({ system: { skillset: skillSet.uuid } });
-        console.log(`Shadowrun 5e | Added ${skills.length} skills and ${groups.length} skill groups from pack to actor ${actor.name}`);
+        console.log(`Shadowrun 5e | Added ${items.length} skills and skill groups from pack to actor ${actor.name}`);
+    },
+
+    /** Prepare the items contributed by a skill set. */
+    async prepareSkillSetItems(skillSet: SR5Item<'skill'>): Promise<PreparedSkillSetItems> {
+        return {
+            skills: await PackItemFlow.prepareSkillsForSkillSet(skillSet),
+            groups: await PackItemFlow.prepareSkillGroupsForSkillSet(skillSet),
+        };
+    },
+
+    /** Exclude prepared skills already present; always include groups. */
+    selectMissingSkillSetItems(prepared: PreparedSkillSetItems, existingSkillKeys: Set<string>): Item.CreateData[] {
+        const skillKeys = new Set(existingSkillKeys);
+
+        const skills = prepared.skills.filter(item => {
+            if (!item.name) return false;
+
+            const skillNameByCategoryKey = SkillItemFlow.skillNameByCategoryKey(item.name, SkillItemFlow.getSkillCategory(item));
+            if (skillKeys.has(skillNameByCategoryKey)) return false;
+
+            skillKeys.add(skillNameByCategoryKey);
+            return true;
+        });
+
+        return [...skills, ...prepared.groups];
     },
 };

--- a/src/module/apps/itemImport/importer/DataImporter.ts
+++ b/src/module/apps/itemImport/importer/DataImporter.ts
@@ -138,9 +138,7 @@ export abstract class DataImporter {
         for (const [key, docs] of itemMap.entries()) {
             const compendium = Constants.MAP_COMPENDIUM_KEY[key];
             if (compendium.type === 'Actor') {
-                await SR5Actor.create(docs as Actor.CreateData[], {
-                    pack: `world.${compendium.pack}`, keepId: true,
-                });
+                await SR5Actor.create(docs as Actor.CreateData[], { pack: `world.${compendium.pack}`, keepId: true });
             } else {
                 await SR5Item.create(docs as Item.CreateData[], { pack: `world.${compendium.pack}`, keepId: true });
             }

--- a/src/module/apps/itemImport/importer/DataImporter.ts
+++ b/src/module/apps/itemImport/importer/DataImporter.ts
@@ -1,6 +1,8 @@
 import { Parser } from 'xml2js';
 import { SR5Item } from '@/module/item/SR5Item';
 import { SR5Actor } from '@/module/actor/SR5Actor';
+import { CreateActorFlow, type SR5ActorCreateOptions } from '@/module/actor/flows/CreateActorFlow';
+import { PackItemFlow } from '@/module/item/flows/PackItemFlow';
 import { ParseData, Schemas } from "../parser/Types";
 import { ImportHelper as IH } from '../helper/ImportHelper';
 import { ChummerFileXML, CompendiumKey, Constants } from './Constants';
@@ -138,7 +140,16 @@ export abstract class DataImporter {
         for (const [key, docs] of itemMap.entries()) {
             const compendium = Constants.MAP_COMPENDIUM_KEY[key];
             if (compendium.type === 'Actor') {
-                await SR5Actor.create(docs as Actor.CreateData[], { pack: `world.${compendium.pack}`, keepId: true });
+                // Prepare default skills once per actor type.
+                const actors = docs as Actor.CreateData[];
+                await PackItemFlow.withSkillPackCache(async () => {
+                    await CreateActorFlow.addDefaultSkillsetsToSources(actors);
+                });
+
+                const operation: Actor.Database.CreateDocumentsOperation & SR5ActorCreateOptions = {
+                    pack: `world.${compendium.pack}`, keepId: true, skipDefaultSkills: true,
+                };
+                await SR5Actor.create(actors, operation);
             } else {
                 await SR5Item.create(docs as Item.CreateData[], { pack: `world.${compendium.pack}`, keepId: true });
             }

--- a/src/module/apps/itemImport/importer/DataImporter.ts
+++ b/src/module/apps/itemImport/importer/DataImporter.ts
@@ -1,8 +1,6 @@
 import { Parser } from 'xml2js';
 import { SR5Item } from '@/module/item/SR5Item';
 import { SR5Actor } from '@/module/actor/SR5Actor';
-import { CreateActorFlow, type SR5ActorCreateOptions } from '@/module/actor/flows/CreateActorFlow';
-import { PackItemFlow } from '@/module/item/flows/PackItemFlow';
 import { ParseData, Schemas } from "../parser/Types";
 import { ImportHelper as IH } from '../helper/ImportHelper';
 import { ChummerFileXML, CompendiumKey, Constants } from './Constants';
@@ -140,16 +138,9 @@ export abstract class DataImporter {
         for (const [key, docs] of itemMap.entries()) {
             const compendium = Constants.MAP_COMPENDIUM_KEY[key];
             if (compendium.type === 'Actor') {
-                // Prepare default skills once per actor type.
-                const actors = docs as Actor.CreateData[];
-                await PackItemFlow.withSkillPackCache(async () => {
-                    await CreateActorFlow.addDefaultSkillsetsToSources(actors);
+                await SR5Actor.create(docs as Actor.CreateData[], {
+                    pack: `world.${compendium.pack}`, keepId: true,
                 });
-
-                const operation: Actor.Database.CreateDocumentsOperation & SR5ActorCreateOptions = {
-                    pack: `world.${compendium.pack}`, keepId: true, skipDefaultSkills: true,
-                };
-                await SR5Actor.create(actors, operation);
             } else {
                 await SR5Item.create(docs as Item.CreateData[], { pack: `world.${compendium.pack}`, keepId: true });
             }

--- a/src/module/item/flows/PackItemFlow.ts
+++ b/src/module/item/flows/PackItemFlow.ts
@@ -5,12 +5,57 @@ import { FLAGS, SYSTEM_NAME } from "@/module/constants";
 import { SR5 } from "@/module/config";
 import { Helpers } from "@/module/helpers";
 
+type SkillPackCache = Map<string, Promise<SR5Item<'skill'>[]>>;
+
+let activeSkillPackCache: SkillPackCache | null = null;
+let activeSkillPackCacheScopes = 0;
+
+/**
+ * Cache skill-pack reads for the duration of an operation.
+ *
+ * Reads are frozen for the scope's lifetime, there is no invalidation, so a pack edited while a
+ * scope is open won't be seen by it. Keep scopes short, without user interaction or writes to the
+ * skill packs. Nested scopes share one cache and it's released once the outermost one ends.
+ */
+async function withSkillPackCache<T>(operation: () => Promise<T>): Promise<T> {
+    if (activeSkillPackCacheScopes === 0) activeSkillPackCache = new Map();
+    activeSkillPackCacheScopes++;
+
+    try {
+        return await operation();
+    } finally {
+        activeSkillPackCacheScopes--;
+        if (activeSkillPackCacheScopes === 0) activeSkillPackCache = null;
+    }
+}
+
+/** Read from the active skill-pack cache. */
+async function cachedSkillPackRead(
+    key: string,
+    read: () => Promise<SR5Item<'skill'>[]>,
+): Promise<SR5Item<'skill'>[]> {
+    const cache = activeSkillPackCache;
+    if (!cache) return await read();
+
+    let result = cache.get(key);
+    if (!result) {
+        result = read();
+        // Don't let a failed read poison the rest of the scope.
+        result.catch(() => cache.delete(key));
+        cache.set(key, result);
+    }
+
+    return await result;
+}
+
 /**
  * Handle interaction with the system packs for predefined items.
  * 
  * This includes all system item packs, including actions and skills.
  */
 export const PackItemFlow = {
+    withSkillPackCache,
+
     /**
      * A pack document retrieval helper for typed items.
      * @param pack The pack to retrieve documents from.
@@ -240,15 +285,17 @@ export const PackItemFlow = {
      */
     async getPackSkills(): Promise<SR5Item<'skill'>[]> {
         const packName = this.getSkillsPackName();
-        console.debug(`Shadowrun 5e | Trying to fetch all skills from pack ${packName}`);
-        const pack = game.packs.find(pack => pack.metadata.system === SYSTEM_NAME && pack.metadata.name === packName) as foundry.documents.collections.CompendiumCollection<'Item'> | undefined;
-        if (!pack) return [];
+        return cachedSkillPackRead(`skills:${packName}`, async () => {
+            console.debug(`Shadowrun 5e | Trying to fetch all skills from pack ${packName}`);
+            const pack = game.packs.find(pack => pack.metadata.system === SYSTEM_NAME && pack.metadata.name === packName) as foundry.documents.collections.CompendiumCollection<'Item'> | undefined;
+            if (!pack) return [];
 
-        const packEntryIds = pack.index.filter(data => data.type === 'skill').map(data => data._id);
-        const documents = await this.getPackDocuments<'skill'>(pack, packEntryIds);
+            const packEntryIds = pack.index.filter(data => data.type === 'skill').map(data => data._id);
+            const documents = await this.getPackDocuments<'skill'>(pack, packEntryIds);
 
-        console.debug(`Shadowrun5e | Fetched all skills from pack ${packName}`, documents);
-        return documents;
+            console.debug(`Shadowrun5e | Fetched all skills from pack ${packName}`, documents);
+            return documents;
+        });
     },
 
     /**
@@ -258,16 +305,18 @@ export const PackItemFlow = {
      */
     async getPackSkillgroups(): Promise<SR5Item<'skill'>[]> {
         const packName = this.getSkillGroupsPackName();
-        console.debug(`Shadowrun 5e | Trying to fetch all skill groups from pack ${packName}`);
-        const pack = game.packs.find(pack => pack.metadata.system === SYSTEM_NAME && pack.metadata.name === packName) as foundry.documents.collections.CompendiumCollection<'Item'> | undefined;
-        if (!pack) return [];
+        return cachedSkillPackRead(`groups:${packName}`, async () => {
+            console.debug(`Shadowrun 5e | Trying to fetch all skill groups from pack ${packName}`);
+            const pack = game.packs.find(pack => pack.metadata.system === SYSTEM_NAME && pack.metadata.name === packName) as foundry.documents.collections.CompendiumCollection<'Item'> | undefined;
+            if (!pack) return [];
 
-        const packEntryIds = pack.index.filter(data => data.type === 'skill').map(data => data._id);
-        const documents = await this.getPackDocuments<'skill'>(pack, packEntryIds);
-        const skillGroups = documents.filter(document => document.system.type === 'group');
+            const packEntryIds = pack.index.filter(data => data.type === 'skill').map(data => data._id);
+            const documents = await this.getPackDocuments<'skill'>(pack, packEntryIds);
+            const skillGroups = documents.filter(document => document.system.type === 'group');
 
-        console.debug(`Shadowrun5e | Fetched all skill groups from pack ${packName}`, skillGroups);
-        return skillGroups;
+            console.debug(`Shadowrun5e | Fetched all skill groups from pack ${packName}`, skillGroups);
+            return skillGroups;
+        });
     },
 
     /**
@@ -293,16 +342,18 @@ export const PackItemFlow = {
      */
     async getAllPackSkillSets(): Promise<SR5Item<'skill'>[]> {
         const packName = this.getSkillSetsPackName();
-        console.debug(`Shadowrun 5e | Trying to fetch all skill sets from pack ${packName}`);
-        const pack = game.packs.find(pack => pack.metadata.system === SYSTEM_NAME && pack.metadata.name === packName) as foundry.documents.collections.CompendiumCollection<'Item'> | undefined;
-        if (!pack) return [];
+        return cachedSkillPackRead(`sets:${packName}`, async () => {
+            console.debug(`Shadowrun 5e | Trying to fetch all skill sets from pack ${packName}`);
+            const pack = game.packs.find(pack => pack.metadata.system === SYSTEM_NAME && pack.metadata.name === packName) as foundry.documents.collections.CompendiumCollection<'Item'> | undefined;
+            if (!pack) return [];
 
-        const packEntryIds = pack.index.filter(data => data.type === 'skill').map(data => data._id);
-        const documents = await this.getPackDocuments<'skill'>(pack, packEntryIds);
-        const skillSets = documents.filter(document => document.system.type === 'set');
+            const packEntryIds = pack.index.filter(data => data.type === 'skill').map(data => data._id);
+            const documents = await this.getPackDocuments<'skill'>(pack, packEntryIds);
+            const skillSets = documents.filter(document => document.system.type === 'set');
 
-        console.debug(`Shadowrun5e | Fetched all skill sets from pack ${packName}`, skillSets);
-        return skillSets;
+            console.debug(`Shadowrun5e | Fetched all skill sets from pack ${packName}`, skillSets);
+            return skillSets;
+        });
     },
 
     /**

--- a/src/module/item/flows/SkillItemFlow.ts
+++ b/src/module/item/flows/SkillItemFlow.ts
@@ -47,7 +47,8 @@ export const SkillItemFlow = {
 
         for (const item of items) {
             if (!SkillItemFlow.isSkillItem(item)) continue;
-            keys.add(SkillItemFlow.skillNameByCategoryKey(item.name ?? '', SkillItemFlow.getSkillCategory(item)));
+            const key = SkillItemFlow.skillNameByCategoryKey(item.name ?? '', SkillItemFlow.getSkillCategory(item));
+            if (key) keys.add(key);
         }
 
         return keys;

--- a/src/module/item/flows/SkillItemFlow.ts
+++ b/src/module/item/flows/SkillItemFlow.ts
@@ -41,6 +41,18 @@ export const SkillItemFlow = {
         return actor.items.filter(item => SkillItemFlow.isSkillItem(item));
     },
 
+    /** Collect canonical keys from skill items or sources. */
+    skillKeys(items: Iterable<Partial<Item.CreateData>>) {
+        const keys = new Set<string>();
+
+        for (const item of items) {
+            if (!SkillItemFlow.isSkillItem(item)) continue;
+            keys.add(SkillItemFlow.skillNameByCategoryKey(item.name ?? '', SkillItemFlow.getSkillCategory(item)));
+        }
+
+        return keys;
+    },
+
     /**
      * Return a base name for a newly created skill item.
      *

--- a/src/module/types/global.ts
+++ b/src/module/types/global.ts
@@ -339,8 +339,4 @@ declare global {
             { [K in E[0]]: _NormalizeNever<Extract<E, readonly [K, unknown]>[1]> };
         fromEntries<K extends PropertyKey, V>(obj: Iterable<readonly [K, V]>): Record<K, V>;
     }
-
-    // IF set to true, will disable auto population of pack based skill items on actors.
-    // This is only necessary for qunech unit tests and shouldn't be used otherwise.
-    var doNotPopulateDefaultSkills: boolean | undefined;
 }

--- a/src/unittests/ItemSkill.spec.ts
+++ b/src/unittests/ItemSkill.spec.ts
@@ -1,7 +1,6 @@
 import { QuenchBatchContext } from '@ethaks/fvtt-quench';
 
 import { SR5Actor } from '@/module/actor/SR5Actor';
-import { CreateActorFlow } from '@/module/actor/flows/CreateActorFlow';
 import { SkillGroupFlow } from '@/module/actor/flows/SkillGroupFlow';
 import { SkillSetFlow } from '@/module/actor/flows/SkillSetFlow';
 import { DataDefaults } from '@/module/data/DataDefaults';
@@ -917,205 +916,6 @@ export const itemSkillTesting = (context: QuenchBatchContext) => {
         });
     });
 
-    describe('CreateActorFlow.addDefaultSkillsetsToSources', () => {
-        /** Mock skill sets and count item preparations. */
-        const withSkillSets = async (
-            sets: [string, string[]][],
-            body: (context: { skillSetUuids: Record<string, string>, buildCount: () => number }) => Promise<void>,
-        ) => {
-            const originalGetAllPackSkillSets = PackItemFlow.getAllPackSkillSets;
-            const originalPrepareSkills = PackItemFlow.prepareSkillsForSkillSet;
-            const originalPrepareGroups = PackItemFlow.prepareSkillGroupsForSkillSet;
-
-            const skillSetItems = new Map<string, string[]>();
-            const skillSetUuids: Record<string, string> = {};
-            const skillSets: SR5Item<'skill'>[] = [];
-            const skillTemplates = new Map<string, SR5Item<'skill'>>();
-            let builds = 0;
-
-            for (const [actorType, skillNames] of sets) {
-                const skillSet = await factory.createItem({
-                    type: 'skill',
-                    name: `${actorType} set`,
-                    system: {
-                        type: 'set',
-                        set: {
-                            skills: skillNames.map(name => ({ name, rating: 0 })),
-                            groups: [],
-                            default: { type: actorType as never },
-                        },
-                    },
-                });
-
-                skillSets.push(skillSet);
-                skillSetUuids[actorType] = skillSet.uuid!;
-                skillSetItems.set(skillSet.uuid!, skillNames);
-
-                for (const name of skillNames) {
-                    if (skillTemplates.has(name)) continue;
-                    skillTemplates.set(name, await factory.createItem({
-                        type: 'skill',
-                        name,
-                        system: { type: 'skill', skill: { category: 'active' } },
-                    }));
-                }
-            }
-
-            PackItemFlow.getAllPackSkillSets = async () => skillSets;
-            PackItemFlow.prepareSkillsForSkillSet = async (skillSet) => {
-                builds++;
-                return (skillSetItems.get(skillSet.uuid!) ?? []).map(name => {
-                    const source = skillTemplates.get(name)!.toObject();
-                    foundry.utils.setProperty(source, 'system.source.uuid', skillSet.uuid!);
-                    return source;
-                });
-            };
-            PackItemFlow.prepareSkillGroupsForSkillSet = async () => [];
-
-            try {
-                await body({ skillSetUuids, buildCount: () => builds });
-            } finally {
-                PackItemFlow.getAllPackSkillSets = originalGetAllPackSkillSets;
-                PackItemFlow.prepareSkillsForSkillSet = originalPrepareSkills;
-                PackItemFlow.prepareSkillGroupsForSkillSet = originalPrepareGroups;
-            }
-        };
-
-        const actorSource = (type: string, items: Item.CreateData[] = []) =>
-            ({ name: `#QUENCH ${type}`, type, system: {}, items } as unknown as Actor.CreateData);
-
-        const skillNames = (source: Actor.CreateData) =>
-            (source.items as Item.CreateData[]).filter(item => item.type === 'skill').map(item => item.name);
-
-        // Guards the bulk import optimization: one build per actor type, not per actor.
-        it('builds a type\'s skill set once and gives every actor of that type the full list', async () => {
-            await withSkillSets([['character', ['Pistols', 'Perception', 'Running']]], async ({ skillSetUuids, buildCount }) => {
-                const sources = [actorSource('character'), actorSource('character'), actorSource('character')];
-
-                await CreateActorFlow.addDefaultSkillsetsToSources(sources);
-
-                assert.strictEqual(buildCount(), 1);
-                for (const source of sources) {
-                    assert.sameMembers(skillNames(source), ['Pistols', 'Perception', 'Running']);
-                    assert.strictEqual(foundry.utils.getProperty(source, 'system.skillset'), skillSetUuids.character);
-                }
-            });
-        });
-
-        // Guards that each actor type keeps its own skill set, an ic gets far fewer skills.
-        it('gives each actor type its own skill set within a mixed batch', async () => {
-            const sets: [string, string[]][] = [
-                ['character', ['Pistols', 'Perception', 'Running']],
-                ['spirit', ['Assensing', 'Astral Combat']],
-                ['ic', ['Computer', 'Hacking']],
-            ];
-
-            await withSkillSets(sets, async ({ skillSetUuids, buildCount }) => {
-                const sources = [
-                    actorSource('character'), actorSource('spirit'), actorSource('ic'),
-                    actorSource('character'), actorSource('ic'),
-                ];
-
-                await CreateActorFlow.addDefaultSkillsetsToSources(sources);
-
-                // One build per distinct type, not per actor.
-                assert.strictEqual(buildCount(), 3);
-
-                assert.sameMembers(skillNames(sources[0]), ['Pistols', 'Perception', 'Running']);
-                assert.sameMembers(skillNames(sources[1]), ['Assensing', 'Astral Combat']);
-                assert.sameMembers(skillNames(sources[2]), ['Computer', 'Hacking']);
-                assert.sameMembers(skillNames(sources[4]), ['Computer', 'Hacking']);
-
-                assert.strictEqual(foundry.utils.getProperty(sources[2], 'system.skillset'), skillSetUuids.ic);
-                assert.notStrictEqual(foundry.utils.getProperty(sources[2], 'system.skillset'), skillSetUuids.character);
-            });
-        });
-
-        it('skips actor types without a default skill set without looking them up again', async () => {
-            await withSkillSets([['character', ['Pistols']]], async ({ buildCount }) => {
-                const sources = [actorSource('vehicle'), actorSource('vehicle'), actorSource('character')];
-
-                await CreateActorFlow.addDefaultSkillsetsToSources(sources);
-
-                assert.strictEqual(buildCount(), 1);
-                assert.lengthOf(skillNames(sources[0]), 0);
-                assert.isUndefined(foundry.utils.getProperty(sources[0], 'system.skillset'));
-                assert.sameMembers(skillNames(sources[2]), ['Pistols']);
-            });
-        });
-
-        // Guards the Chummer defined subset, whose ratings must survive the top up.
-        it('keeps an actor\'s own rated skill instead of the skill set duplicate', async () => {
-            await withSkillSets([['character', ['Pistols', 'Perception']]], async () => {
-                const ownPistols = {
-                    name: 'Pistols',
-                    type: 'skill' as const,
-                    system: DataDefaults.baseSystemData('skill', {
-                        type: 'skill',
-                        skill: { category: 'active', rating: 6 },
-                    }),
-                } as unknown as Item.CreateData;
-                const sources = [actorSource('character', [ownPistols])];
-
-                await CreateActorFlow.addDefaultSkillsetsToSources(sources);
-
-                const pistols = (sources[0].items as Item.CreateData[]).filter(item => item.name === 'Pistols');
-                assert.lengthOf(pistols, 1);
-                assert.strictEqual(foundry.utils.getProperty(pistols[0], 'system.skill.rating'), 6);
-                assert.isEmpty(foundry.utils.getProperty(pistols[0], 'system.source.uuid') ?? '');
-                assert.sameMembers(skillNames(sources[0]), ['Pistols', 'Perception']);
-            });
-        });
-
-        // The prepared items are shared by every actor of a type, so each needs its own copy.
-        it('gives each actor independent item data', async () => {
-            await withSkillSets([['character', ['Pistols']]], async () => {
-                const sources = [actorSource('character'), actorSource('character')];
-
-                await CreateActorFlow.addDefaultSkillsetsToSources(sources);
-
-                const [first] = sources[0].items as Item.CreateData[];
-                foundry.utils.setProperty(first, 'system.skill.rating', 12);
-                first.name = 'Mutated';
-
-                const [second] = sources[1].items as Item.CreateData[];
-                assert.strictEqual(second.name, 'Pistols');
-                assert.strictEqual(foundry.utils.getProperty(second, 'system.skill.rating'), 0);
-            });
-        });
-
-        it('leaves an already assigned skillset alone', async () => {
-            await withSkillSets([['character', ['Pistols']]], async () => {
-                const source = actorSource('character');
-                foundry.utils.setProperty(source, 'system.skillset', 'Compendium.some.other.Item.abcdef1234567890');
-
-                await CreateActorFlow.addDefaultSkillsetsToSources([source]);
-
-                assert.lengthOf(skillNames(source), 0);
-                assert.strictEqual(foundry.utils.getProperty(source, 'system.skillset'), 'Compendium.some.other.Item.abcdef1234567890');
-            });
-        });
-
-        // Guards that moving the work out of _preCreate did not change the resulting actor.
-        it('produces the same actor as the per document _preCreate flow', async () => {
-            await withSkillSets([['character', ['Pistols', 'Perception']]], async () => {
-                const source = actorSource('character');
-                await CreateActorFlow.addDefaultSkillsetsToSources([source]);
-
-                const fromSources = await factory.createActor(
-                    { ...source, type: 'character' } as Parameters<typeof factory.createActor>[0],
-                    { skipDefaultSkills: true },
-                );
-                // Opt back in to the _preCreate flow this batch's factory skips by default.
-                const fromPreCreate = await factory.createActor({ type: 'character' }, { skipDefaultSkills: false });
-
-                const names = (actor: SR5Actor) => actor.items.filter(item => item.type === 'skill').map(item => item.name);
-                assert.sameMembers(names(fromSources), names(fromPreCreate));
-                assert.strictEqual(fromSources.system.skillset, fromPreCreate.system.skillset);
-            });
-        });
-    });
-
     describe('PackItemFlow pack cache', () => {
         /**
          * Counts pack reads while running the given test body and always restores the original
@@ -1191,6 +991,50 @@ export const itemSkillTesting = (context: QuenchBatchContext) => {
 
                 await PackItemFlow.getPackSkills();
                 assert.strictEqual(reads(), 2);
+            });
+        });
+
+        // Guards SR5Actor.createDocuments, so any batch creation shares its reads, not just imports.
+        it('shares pack reads across actors created in one batch', async () => {
+            const folder = await factory.getOrCreateFolderId('Actor');
+            const importedSkill = {
+                name: 'Pistols',
+                type: 'skill',
+                system: DataDefaults.baseSystemData('skill', {
+                    type: 'skill', skill: { category: 'active', rating: 6 },
+                }),
+            } as Item.CreateData;
+
+            await withPackReadCounter(async (reads) => {
+                const created = await SR5Actor.create(
+                    [
+                        { name: '#QUENCH', folder, type: 'character', items: [importedSkill] },
+                        { name: '#QUENCH', folder, type: 'character' },
+                        { name: '#QUENCH', folder, type: 'spirit' },
+                    ],
+                );
+                factory.actors.push(...created);
+
+                assert.strictEqual(reads(), 3);
+                for (const actor of created) assert.isNotEmpty(actor.items.filter(item => item.type === 'skill'));
+
+                const pistols = created[0].items.filter(item => item.name === 'Pistols');
+                assert.lengthOf(pistols, 1);
+                assert.strictEqual(foundry.utils.getProperty(pistols[0], 'system.skill.rating'), 6);
+            });
+        });
+
+        // Each creation gets its own scope, so a pack edited between two of them is picked up.
+        it('does not share pack reads between separate creations', async () => {
+            await withPackReadCounter(async (reads) => {
+                await factory.createActor({ type: 'character' }, { skipDefaultSkills: false });
+                const single = reads();
+
+                await factory.createActor({ type: 'character' }, { skipDefaultSkills: false });
+
+                // Reads scale with the actor count, separate creations share nothing.
+                assert.isAbove(single, 0);
+                assert.strictEqual(reads(), single * 2);
             });
         });
     });

--- a/src/unittests/ItemSkill.spec.ts
+++ b/src/unittests/ItemSkill.spec.ts
@@ -11,17 +11,13 @@ import { SR5Item } from '@/module/item/SR5Item';
 import { SR5TestFactory } from './utils';
 
 export const itemSkillTesting = (context: QuenchBatchContext) => {
-    const factory = new SR5TestFactory();
-    const { describe, it, before, after } = context;
+    // These tests build their skill sets by hand, so actors must start without any default skills.
+    const factory = new SR5TestFactory({ skipDefaultSkills: true });
+    const { describe, it, after } = context;
     const assert: Chai.AssertStatic = context.assert;
-
-    before(async () => {
-        window.doNotPopulateDefaultSkills = true;
-    });
 
     after(async () => {
         await factory.destroy();
-        delete window.doNotPopulateDefaultSkills;
     });
 
     describe('SkillSetFlow.applySkillSetToActor', () => {

--- a/src/unittests/ItemSkill.spec.ts
+++ b/src/unittests/ItemSkill.spec.ts
@@ -1,8 +1,10 @@
 import { QuenchBatchContext } from '@ethaks/fvtt-quench';
 
 import { SR5Actor } from '@/module/actor/SR5Actor';
+import { CreateActorFlow } from '@/module/actor/flows/CreateActorFlow';
 import { SkillGroupFlow } from '@/module/actor/flows/SkillGroupFlow';
 import { SkillSetFlow } from '@/module/actor/flows/SkillSetFlow';
+import { DataDefaults } from '@/module/data/DataDefaults';
 import { SkillSelectionFlow } from '@/module/flows/SkillSelectionFlow';
 import { ActionFlow } from '@/module/item/flows/ActionFlow';
 import { PackItemFlow } from '@/module/item/flows/PackItemFlow';
@@ -912,6 +914,284 @@ export const itemSkillTesting = (context: QuenchBatchContext) => {
             assert.property(skills, 'heavy_weapons');
             assert.strictEqual(skills.heavy_weapons, 'Heavy Weapons');
             assert.notProperty(skills, 'Heavy Weapons');
+        });
+    });
+
+    describe('CreateActorFlow.addDefaultSkillsetsToSources', () => {
+        /** Mock skill sets and count item preparations. */
+        const withSkillSets = async (
+            sets: [string, string[]][],
+            body: (context: { skillSetUuids: Record<string, string>, buildCount: () => number }) => Promise<void>,
+        ) => {
+            const originalGetAllPackSkillSets = PackItemFlow.getAllPackSkillSets;
+            const originalPrepareSkills = PackItemFlow.prepareSkillsForSkillSet;
+            const originalPrepareGroups = PackItemFlow.prepareSkillGroupsForSkillSet;
+
+            const skillSetItems = new Map<string, string[]>();
+            const skillSetUuids: Record<string, string> = {};
+            const skillSets: SR5Item<'skill'>[] = [];
+            const skillTemplates = new Map<string, SR5Item<'skill'>>();
+            let builds = 0;
+
+            for (const [actorType, skillNames] of sets) {
+                const skillSet = await factory.createItem({
+                    type: 'skill',
+                    name: `${actorType} set`,
+                    system: {
+                        type: 'set',
+                        set: {
+                            skills: skillNames.map(name => ({ name, rating: 0 })),
+                            groups: [],
+                            default: { type: actorType as never },
+                        },
+                    },
+                });
+
+                skillSets.push(skillSet);
+                skillSetUuids[actorType] = skillSet.uuid!;
+                skillSetItems.set(skillSet.uuid!, skillNames);
+
+                for (const name of skillNames) {
+                    if (skillTemplates.has(name)) continue;
+                    skillTemplates.set(name, await factory.createItem({
+                        type: 'skill',
+                        name,
+                        system: { type: 'skill', skill: { category: 'active' } },
+                    }));
+                }
+            }
+
+            PackItemFlow.getAllPackSkillSets = async () => skillSets;
+            PackItemFlow.prepareSkillsForSkillSet = async (skillSet) => {
+                builds++;
+                return (skillSetItems.get(skillSet.uuid!) ?? []).map(name => {
+                    const source = skillTemplates.get(name)!.toObject();
+                    foundry.utils.setProperty(source, 'system.source.uuid', skillSet.uuid!);
+                    return source;
+                });
+            };
+            PackItemFlow.prepareSkillGroupsForSkillSet = async () => [];
+
+            try {
+                await body({ skillSetUuids, buildCount: () => builds });
+            } finally {
+                PackItemFlow.getAllPackSkillSets = originalGetAllPackSkillSets;
+                PackItemFlow.prepareSkillsForSkillSet = originalPrepareSkills;
+                PackItemFlow.prepareSkillGroupsForSkillSet = originalPrepareGroups;
+            }
+        };
+
+        const actorSource = (type: string, items: Item.CreateData[] = []) =>
+            ({ name: `#QUENCH ${type}`, type, system: {}, items } as unknown as Actor.CreateData);
+
+        const skillNames = (source: Actor.CreateData) =>
+            (source.items as Item.CreateData[]).filter(item => item.type === 'skill').map(item => item.name);
+
+        // Guards the bulk import optimization: one build per actor type, not per actor.
+        it('builds a type\'s skill set once and gives every actor of that type the full list', async () => {
+            await withSkillSets([['character', ['Pistols', 'Perception', 'Running']]], async ({ skillSetUuids, buildCount }) => {
+                const sources = [actorSource('character'), actorSource('character'), actorSource('character')];
+
+                await CreateActorFlow.addDefaultSkillsetsToSources(sources);
+
+                assert.strictEqual(buildCount(), 1);
+                for (const source of sources) {
+                    assert.sameMembers(skillNames(source), ['Pistols', 'Perception', 'Running']);
+                    assert.strictEqual(foundry.utils.getProperty(source, 'system.skillset'), skillSetUuids.character);
+                }
+            });
+        });
+
+        // Guards that each actor type keeps its own skill set, an ic gets far fewer skills.
+        it('gives each actor type its own skill set within a mixed batch', async () => {
+            const sets: [string, string[]][] = [
+                ['character', ['Pistols', 'Perception', 'Running']],
+                ['spirit', ['Assensing', 'Astral Combat']],
+                ['ic', ['Computer', 'Hacking']],
+            ];
+
+            await withSkillSets(sets, async ({ skillSetUuids, buildCount }) => {
+                const sources = [
+                    actorSource('character'), actorSource('spirit'), actorSource('ic'),
+                    actorSource('character'), actorSource('ic'),
+                ];
+
+                await CreateActorFlow.addDefaultSkillsetsToSources(sources);
+
+                // One build per distinct type, not per actor.
+                assert.strictEqual(buildCount(), 3);
+
+                assert.sameMembers(skillNames(sources[0]), ['Pistols', 'Perception', 'Running']);
+                assert.sameMembers(skillNames(sources[1]), ['Assensing', 'Astral Combat']);
+                assert.sameMembers(skillNames(sources[2]), ['Computer', 'Hacking']);
+                assert.sameMembers(skillNames(sources[4]), ['Computer', 'Hacking']);
+
+                assert.strictEqual(foundry.utils.getProperty(sources[2], 'system.skillset'), skillSetUuids.ic);
+                assert.notStrictEqual(foundry.utils.getProperty(sources[2], 'system.skillset'), skillSetUuids.character);
+            });
+        });
+
+        it('skips actor types without a default skill set without looking them up again', async () => {
+            await withSkillSets([['character', ['Pistols']]], async ({ buildCount }) => {
+                const sources = [actorSource('vehicle'), actorSource('vehicle'), actorSource('character')];
+
+                await CreateActorFlow.addDefaultSkillsetsToSources(sources);
+
+                assert.strictEqual(buildCount(), 1);
+                assert.lengthOf(skillNames(sources[0]), 0);
+                assert.isUndefined(foundry.utils.getProperty(sources[0], 'system.skillset'));
+                assert.sameMembers(skillNames(sources[2]), ['Pistols']);
+            });
+        });
+
+        // Guards the Chummer defined subset, whose ratings must survive the top up.
+        it('keeps an actor\'s own rated skill instead of the skill set duplicate', async () => {
+            await withSkillSets([['character', ['Pistols', 'Perception']]], async () => {
+                const ownPistols = {
+                    name: 'Pistols',
+                    type: 'skill' as const,
+                    system: DataDefaults.baseSystemData('skill', {
+                        type: 'skill',
+                        skill: { category: 'active', rating: 6 },
+                    }),
+                } as unknown as Item.CreateData;
+                const sources = [actorSource('character', [ownPistols])];
+
+                await CreateActorFlow.addDefaultSkillsetsToSources(sources);
+
+                const pistols = (sources[0].items as Item.CreateData[]).filter(item => item.name === 'Pistols');
+                assert.lengthOf(pistols, 1);
+                assert.strictEqual(foundry.utils.getProperty(pistols[0], 'system.skill.rating'), 6);
+                assert.isEmpty(foundry.utils.getProperty(pistols[0], 'system.source.uuid') ?? '');
+                assert.sameMembers(skillNames(sources[0]), ['Pistols', 'Perception']);
+            });
+        });
+
+        // The prepared items are shared by every actor of a type, so each needs its own copy.
+        it('gives each actor independent item data', async () => {
+            await withSkillSets([['character', ['Pistols']]], async () => {
+                const sources = [actorSource('character'), actorSource('character')];
+
+                await CreateActorFlow.addDefaultSkillsetsToSources(sources);
+
+                const [first] = sources[0].items as Item.CreateData[];
+                foundry.utils.setProperty(first, 'system.skill.rating', 12);
+                first.name = 'Mutated';
+
+                const [second] = sources[1].items as Item.CreateData[];
+                assert.strictEqual(second.name, 'Pistols');
+                assert.strictEqual(foundry.utils.getProperty(second, 'system.skill.rating'), 0);
+            });
+        });
+
+        it('leaves an already assigned skillset alone', async () => {
+            await withSkillSets([['character', ['Pistols']]], async () => {
+                const source = actorSource('character');
+                foundry.utils.setProperty(source, 'system.skillset', 'Compendium.some.other.Item.abcdef1234567890');
+
+                await CreateActorFlow.addDefaultSkillsetsToSources([source]);
+
+                assert.lengthOf(skillNames(source), 0);
+                assert.strictEqual(foundry.utils.getProperty(source, 'system.skillset'), 'Compendium.some.other.Item.abcdef1234567890');
+            });
+        });
+
+        // Guards that moving the work out of _preCreate did not change the resulting actor.
+        it('produces the same actor as the per document _preCreate flow', async () => {
+            await withSkillSets([['character', ['Pistols', 'Perception']]], async () => {
+                const source = actorSource('character');
+                await CreateActorFlow.addDefaultSkillsetsToSources([source]);
+
+                const fromSources = await factory.createActor(
+                    { ...source, type: 'character' } as Parameters<typeof factory.createActor>[0],
+                    { skipDefaultSkills: true },
+                );
+                // Opt back in to the _preCreate flow this batch's factory skips by default.
+                const fromPreCreate = await factory.createActor({ type: 'character' }, { skipDefaultSkills: false });
+
+                const names = (actor: SR5Actor) => actor.items.filter(item => item.type === 'skill').map(item => item.name);
+                assert.sameMembers(names(fromSources), names(fromPreCreate));
+                assert.strictEqual(fromSources.system.skillset, fromPreCreate.system.skillset);
+            });
+        });
+    });
+
+    describe('PackItemFlow pack cache', () => {
+        /**
+         * Counts pack reads while running the given test body and always restores the original
+         * retrieval helper and cache state.
+         */
+        const withPackReadCounter = async (body: (reads: () => number) => Promise<void>) => {
+            const originalGetPackDocuments = PackItemFlow.getPackDocuments;
+            let reads = 0;
+
+            PackItemFlow.getPackDocuments = (async (...args: Parameters<typeof originalGetPackDocuments>) => {
+                reads++;
+                return originalGetPackDocuments.apply(PackItemFlow, args);
+            }) as typeof PackItemFlow.getPackDocuments;
+
+            try {
+                await body(() => reads);
+            } finally {
+                PackItemFlow.getPackDocuments = originalGetPackDocuments;
+            }
+        };
+
+        // Guards the default behaviour, so pack edits during normal play are picked up immediately.
+        it('reads the pack on every call while the cache is disabled', async () => {
+            await withPackReadCounter(async (reads) => {
+                await PackItemFlow.getPackSkills();
+                await PackItemFlow.getPackSkills();
+
+                assert.strictEqual(reads(), 2);
+            });
+        });
+
+        // Guards the bulk import optimization, where hundreds of actors pull the same documents.
+        it('reads the pack once per document type within a cache scope', async () => {
+            await withPackReadCounter(async (reads) => {
+                await PackItemFlow.withSkillPackCache(async () => {
+                    const firstSkills = await PackItemFlow.getPackSkills();
+                    const secondSkills = await PackItemFlow.getPackSkills();
+
+                    assert.strictEqual(reads(), 1);
+                    assert.deepEqual(firstSkills, secondSkills);
+
+                    await PackItemFlow.getPackSkillgroups();
+                    await PackItemFlow.getPackSkillgroups();
+                    await PackItemFlow.getAllPackSkillSets();
+                    await PackItemFlow.getAllPackSkillSets();
+                });
+
+                assert.strictEqual(reads(), 3);
+            });
+        });
+
+        it('reads the pack again after the cache scope ends', async () => {
+            await withPackReadCounter(async (reads) => {
+                await PackItemFlow.withSkillPackCache(async () => {
+                    await PackItemFlow.getPackSkills();
+                });
+                await PackItemFlow.getPackSkills();
+
+                assert.strictEqual(reads(), 2);
+            });
+        });
+
+        it('releases the cache when a scoped operation fails', async () => {
+            await withPackReadCounter(async (reads) => {
+                try {
+                    await PackItemFlow.withSkillPackCache(async () => {
+                        await PackItemFlow.getPackSkills();
+                        throw new Error('Expected test failure');
+                    });
+                } catch (error) {
+                    assert.strictEqual((error as Error).message, 'Expected test failure');
+                }
+
+                await PackItemFlow.getPackSkills();
+                assert.strictEqual(reads(), 2);
+            });
         });
     });
 };

--- a/src/unittests/ItemSkill.spec.ts
+++ b/src/unittests/ItemSkill.spec.ts
@@ -21,6 +21,18 @@ export const itemSkillTesting = (context: QuenchBatchContext) => {
         await factory.destroy();
     });
 
+    describe('SkillItemFlow.skillKeys', () => {
+        it('ignores skills without a canonical name key', () => {
+            const keys = SkillItemFlow.skillKeys([
+                { name: '', type: 'skill', system: { type: 'skill', skill: { category: 'active' } } },
+                { type: 'skill', system: { type: 'skill', skill: { category: 'active' } } },
+                { name: 'Pistols', type: 'skill', system: { type: 'skill', skill: { category: 'active' } } },
+            ] as Item.CreateData[]);
+
+            assert.deepEqual([...keys], ['pistols:active']);
+        });
+    });
+
     describe('SkillSetFlow.applySkillSetToActor', () => {
         // Guards provenance tracking so imported skillset items can still be identified later.
         it('stores non-empty source UUIDs on created skills and groups', async () => {
@@ -919,7 +931,7 @@ export const itemSkillTesting = (context: QuenchBatchContext) => {
     describe('PackItemFlow pack cache', () => {
         /**
          * Counts pack reads while running the given test body and always restores the original
-         * retrieval helper and cache state.
+         * retrieval helper.
          */
         const withPackReadCounter = async (body: (reads: () => number) => Promise<void>) => {
             const originalGetPackDocuments = PackItemFlow.getPackDocuments;

--- a/src/unittests/sr5.ActiveEffect.spec.ts
+++ b/src/unittests/sr5.ActiveEffect.spec.ts
@@ -193,15 +193,12 @@ export const shadowrunSR5ActiveEffect = (context: QuenchBatchContext) => {
         });
 
         it('UPGRADE mode: should raise the value to a max', async () => {
-            window.doNotPopulateDefaultSkills = true;
-
             const actor = await factory.createActor({
                 type: 'character',
                 system: {
                     attributes: { body: { base: 2 } },
                 },
-            });
-            delete window.doNotPopulateDefaultSkills;
+            }, { skipDefaultSkills: true });
 
             await actor.createEmbeddedDocuments('Item', [{
                 type: 'skill',
@@ -237,11 +234,7 @@ export const shadowrunSR5ActiveEffect = (context: QuenchBatchContext) => {
         });
 
         it('UPGRADE mode: uses the highest value for multiple upgrade changes', async () => {
-            window.doNotPopulateDefaultSkills = true;
-
-            const actor = await factory.createActor({ type: 'character' });
-            //
-            delete window.doNotPopulateDefaultSkills;
+            const actor = await factory.createActor({ type: 'character' }, { skipDefaultSkills: true });
 
             await actor.createEmbeddedDocuments('Item', [{
                 type: 'skill',
@@ -273,14 +266,12 @@ export const shadowrunSR5ActiveEffect = (context: QuenchBatchContext) => {
         });
 
         it('DOWNGRADE mode: should reduce the value to a min', async () => {
-            window.doNotPopulateDefaultSkills = true;
             const actor = await factory.createActor({
                 type: 'character',
                 system: {
                     attributes: { body: { base: 5 } },
                 },
-            });
-            delete window.doNotPopulateDefaultSkills;
+            }, { skipDefaultSkills: true });
 
             await actor.createEmbeddedDocuments('Item', [{
                 type: 'skill',
@@ -316,9 +307,7 @@ export const shadowrunSR5ActiveEffect = (context: QuenchBatchContext) => {
         });
 
         it('DOWNGRADE mode: uses the lowest value for multiple downgrade changes', async () => {
-            window.doNotPopulateDefaultSkills = true;
-            const actor = await factory.createActor({ type: 'character' });
-            delete window.doNotPopulateDefaultSkills;
+            const actor = await factory.createActor({ type: 'character' }, { skipDefaultSkills: true });
 
             await actor.createEmbeddedDocuments('Item', [{
                 type: 'skill',
@@ -348,14 +337,12 @@ export const shadowrunSR5ActiveEffect = (context: QuenchBatchContext) => {
         });
 
         it('MULTIPLY mode: multiplies base values by the change value', async () => {
-            window.doNotPopulateDefaultSkills = true;
             const actor = await factory.createActor({
                 type: 'character',
                 system: {
                     attributes: { body: { base: 5 } },
                 },
-            });
-            delete window.doNotPopulateDefaultSkills;
+            }, { skipDefaultSkills: true });
 
             await actor.createEmbeddedDocuments('Item', [{
                 type: 'skill',
@@ -391,14 +378,12 @@ export const shadowrunSR5ActiveEffect = (context: QuenchBatchContext) => {
         });
 
         it('SUBTRACT mode: subtracts the change value from base values', async () => {
-            window.doNotPopulateDefaultSkills = true;
             const actor = await factory.createActor({
                 type: 'character',
                 system: {
                     attributes: { body: { base: 5 } },
                 },
-            });
-            delete window.doNotPopulateDefaultSkills;
+            }, { skipDefaultSkills: true });
 
             await actor.createEmbeddedDocuments('Item', [{
                 type: 'skill',

--- a/src/unittests/sr5.CharacterDataPrep.spec.ts
+++ b/src/unittests/sr5.CharacterDataPrep.spec.ts
@@ -388,11 +388,9 @@ export const shadowrunSR5CharacterDataPrep = (context: QuenchBatchContext) => {
         });
 
         it('skill calculation', async () => {
-            window.doNotPopulateDefaultSkills = true;
-
             const character = await factory.createActor({
                 type: 'character'
-            });
+            }, { skipDefaultSkills: true });
 
             // create a skill item to trigger SkillField preparation.
             await character.createEmbeddedDocuments('Item', [{
@@ -406,8 +404,6 @@ export const shadowrunSR5CharacterDataPrep = (context: QuenchBatchContext) => {
                     }
                 },
             }]);
-
-            delete window.doNotPopulateDefaultSkills;
 
             // FVTT types currently do not support the `TypedObjectField` type, so we need to cast it.
             assert.strictEqual(character.system.skills.active.test.value, 3);

--- a/src/unittests/sr5.SpiritDataPrep.spec.ts
+++ b/src/unittests/sr5.SpiritDataPrep.spec.ts
@@ -155,8 +155,6 @@ export const shadowrunSR5SpiritDataPrep = (context: QuenchBatchContext) => {
         });
 
         it('spirit skills are toggles where on equals force and off equals zero', async () => {
-            window.doNotPopulateDefaultSkills = true;
-
             const spirit = await factory.createActor({
                 type: 'spirit',
                 system: {
@@ -164,7 +162,7 @@ export const shadowrunSR5SpiritDataPrep = (context: QuenchBatchContext) => {
                         force: { base: 6 },
                     }
                 }
-            });
+            }, { skipDefaultSkills: true });
 
             await spirit.createEmbeddedDocuments('Item', [
                 {
@@ -205,16 +203,12 @@ export const shadowrunSR5SpiritDataPrep = (context: QuenchBatchContext) => {
                 },
             ]);
 
-            delete window.doNotPopulateDefaultSkills;
-
             assert.strictEqual(spirit.system.skills.active.assensing.value, 6);
             assert.strictEqual(spirit.system.skills.active.perception.value, 6);
             assert.strictEqual(spirit.system.skills.active.arcana.value, 0);
         });
 
         it('spirit half value skill mode applies ceil(force/2) to ON skills', async () => {
-            window.doNotPopulateDefaultSkills = true;
-
             const spirit = await factory.createActor({
                 type: 'spirit',
                 system: {
@@ -223,7 +217,7 @@ export const shadowrunSR5SpiritDataPrep = (context: QuenchBatchContext) => {
                         force: { base: 5 },
                     }
                 }
-            });
+            }, { skipDefaultSkills: true });
 
             await spirit.createEmbeddedDocuments('Item', [
                 {
@@ -251,8 +245,6 @@ export const shadowrunSR5SpiritDataPrep = (context: QuenchBatchContext) => {
                     }
                 },
             ]);
-
-            delete window.doNotPopulateDefaultSkills;
 
             assert.strictEqual(spirit.system.skills.active.assensing.value, 3);
             assert.strictEqual(spirit.system.skills.active.arcana.value, 0);

--- a/src/unittests/sr5.SpriteDataPrep.spec.ts
+++ b/src/unittests/sr5.SpriteDataPrep.spec.ts
@@ -80,14 +80,12 @@ export const shadowrunSR5SpriteDataPrep = (context: QuenchBatchContext) => {
         });
 
         it('sprite skill toggles apply to active, language, and knowledge skills', async () => {
-            window.doNotPopulateDefaultSkills = true;
-
             const sprite = await factory.createActor({
                 type: 'sprite',
                 system: {
                     attributes: { level: { base: 7 } },
                 }
-            });
+            }, { skipDefaultSkills: true });
 
             await sprite.createEmbeddedDocuments('Item', [
                 {
@@ -123,8 +121,6 @@ export const shadowrunSR5SpriteDataPrep = (context: QuenchBatchContext) => {
                     }
                 },
             ]);
-
-            delete window.doNotPopulateDefaultSkills;
 
             const languageSkill = Object.values(sprite.system.skills.language).find(skill => skill.name === 'Sperethiel');
             const knowledgeSkill = Object.values(sprite.system.skills.knowledge.academic).find(skill => skill.name === 'Matrix Hosts');

--- a/src/unittests/sr5.Testing.spec.ts
+++ b/src/unittests/sr5.Testing.spec.ts
@@ -17,8 +17,6 @@ export const shadowrunTesting = (context: QuenchBatchContext) => {
 
     describe('SuccessTest', () => {
         it('evaluate a roll from action data', async () => {
-            window.doNotPopulateDefaultSkills = true;
-
             const action = await factory.createItem({
                 type: 'action',
                 system: {
@@ -51,7 +49,7 @@ export const shadowrunTesting = (context: QuenchBatchContext) => {
                 system: {
                     attributes: { body: { base: 5 }, strength: { base: 1 }, reaction: { base: 1 } },
                 }
-            });
+            }, { skipDefaultSkills: true });
             await actor.createEmbeddedDocuments('Item', [
                 {
                     type: 'skill',
@@ -65,8 +63,6 @@ export const shadowrunTesting = (context: QuenchBatchContext) => {
                     }
                 }
             ]);
-            
-            delete window.doNotPopulateDefaultSkills;
 
             const test = await TestCreator.fromItem(action, actor, {showMessage: false, showDialog: false});
 
@@ -145,8 +141,6 @@ export const shadowrunTesting = (context: QuenchBatchContext) => {
         });
 
         it('stores code term traces for labeled pool and limit parts', async () => {
-            window.doNotPopulateDefaultSkills = true;
-
             const actor = await factory.createActor({
                 type: 'character',
                 system: {
@@ -157,7 +151,7 @@ export const shadowrunTesting = (context: QuenchBatchContext) => {
                         reaction: { base: 3 }
                     },
                 }
-            });
+            }, { skipDefaultSkills: true });
 
             await actor.createEmbeddedDocuments('Item', [
                 {
@@ -172,8 +166,6 @@ export const shadowrunTesting = (context: QuenchBatchContext) => {
                     }
                 }
             ]);
-            
-            delete window.doNotPopulateDefaultSkills;
 
             const action = DataDefaults.createData('action_roll', {
                 test: 'SuccessTest',

--- a/src/unittests/utils.ts
+++ b/src/unittests/utils.ts
@@ -1,5 +1,6 @@
 import { SR5Actor } from "src/module/actor/SR5Actor";
 import { SR5Item } from "src/module/item/SR5Item";
+import type { SR5ActorCreateOptions } from "src/module/actor/flows/CreateActorFlow";
 
 export class SR5TestFactory {
     static readonly folderName = '#Quench';
@@ -8,6 +9,12 @@ export class SR5TestFactory {
     readonly items: Item.Stored[] = [];
     readonly scenes: Scene.Stored[] = [];
     readonly createdFolder = new Map<string, string>();
+
+    /**
+     * @param actorCreateOptions SR5 create options applied to every actor this factory creates.
+     *                           Individual createActor calls can override them.
+     */
+    constructor(readonly actorCreateOptions: SR5ActorCreateOptions = {}) {}
 
     async getOrCreateFolderId(type: 'Actor' | 'Item' | 'Scene'): Promise<string> {
         if (this.createdFolder.has(type)) return this.createdFolder.get(type)!;
@@ -21,10 +28,13 @@ export class SR5TestFactory {
 
     async createActor<T extends Actor.ConfiguredSubType>(
         data: Omit<Actor.CreateData, "name"> & { name?: string, type: T },
-        context?: Actor.ConstructionContext
+        operation?: Actor.Database.CreateDocumentsOperation & SR5ActorCreateOptions
     ) {
         const folder = await this.getOrCreateFolderId('Actor');
-        const actor = await SR5Actor.create({ name: `#QUENCH`, folder: folder, ...data }, context) as Actor.Stored<T>;
+        const actor = await SR5Actor.create(
+            { name: `#QUENCH`, folder: folder, ...data },
+            { ...this.actorCreateOptions, ...operation }
+        ) as Actor.Stored<T>;
         this.actors.push(actor);
         return actor;
     }

--- a/src/unittests/utils.ts
+++ b/src/unittests/utils.ts
@@ -2,6 +2,8 @@ import { SR5Actor } from "src/module/actor/SR5Actor";
 import { SR5Item } from "src/module/item/SR5Item";
 import type { SR5ActorCreateOptions } from "src/module/actor/flows/CreateActorFlow";
 
+type ActorOptions = Actor.Database.CreateDocumentsOperation & SR5ActorCreateOptions;
+
 export class SR5TestFactory {
     static readonly folderName = '#Quench';
 
@@ -14,7 +16,7 @@ export class SR5TestFactory {
      * @param actorCreateOptions SR5 create options applied to every actor this factory creates.
      *                           Individual createActor calls can override them.
      */
-    constructor(readonly actorCreateOptions: SR5ActorCreateOptions = {}) {}
+    constructor(readonly actorCreateOptions: ActorOptions = {}) {}
 
     async getOrCreateFolderId(type: 'Actor' | 'Item' | 'Scene'): Promise<string> {
         if (this.createdFolder.has(type)) return this.createdFolder.get(type)!;
@@ -28,7 +30,7 @@ export class SR5TestFactory {
 
     async createActor<T extends Actor.ConfiguredSubType>(
         data: Omit<Actor.CreateData, "name"> & { name?: string, type: T },
-        operation?: Actor.Database.CreateDocumentsOperation & SR5ActorCreateOptions
+        operation?: ActorOptions
     ) {
         const folder = await this.getOrCreateFolderId('Actor');
         const actor = await SR5Actor.create(


### PR DESCRIPTION
## Summary

Actor creation reads the skill, skill group and skill set compendiums in `_preCreate` to apply the default skill set for the actor's type. Every actor did this independently, so creating N actors cost 4N compendium reads — a Chummer bulk import of ~715 critters and drones paid it 715 times. `SR5Actor.createDocuments` now wraps creation in a scoped skill pack cache so all `_preCreate` calls in one batch share a single set of reads.

## Measurements

100 actors, same single batch write, only the cache differing: **90.9 / 82.9 ms per actor and 3 pack reads** with the cache, versus **241.8 / 208.8 ms and 400 reads** without. ~2.6x faster, on any path that creates actors together rather than just the importer. A single actor gains too, since `prepareSkillsForSkillSet` reads the skill groups pack internally and again via `prepareSkillSetItems`, so the scope turns 4 reads into 3.

## Changes

- **`PackItemFlow`** — adds `withSkillPackCache(operation)`, a reference-counted scope memoising `getPackSkills` / `getPackSkillgroups` / `getAllPackSkillSets` for its lifetime. The scope is the invalidation: outside it every read hits the pack, so compendium edits between operations are picked up. There is deliberately no cross-scope cache.
- **`SR5Actor.createDocuments`** — opens that scope around creation. Chosen over `_preCreateOperation`, which Foundry runs after every `_preCreate` and so is too late.
- **`SkillSetFlow`** — splits `prepareSkillSetItems` (the expensive build) from `selectMissingSkillSetItems` (the dedupe filter) so a build can be reused across actors.
- **`SkillItemFlow.skillKeys`** — one name+category key builder shared by the document and source-data dedupe paths.
- **`doNotPopulateDefaultSkills` removed** in favour of a `skipDefaultSkills` option on the create operation, read in `_preCreate`, with `SR5TestFactory` taking it as a constructor default. Custom keys on a create operation survive to `_preCreate`, so no fvtt-types augmentation is needed.
