### PR TITLE
[BUG] Light theme issues in settings

### DIFF
--- a/src/css/settings.scss
+++ b/src/css/settings.scss
@@ -3,15 +3,15 @@
  */
 @use "config/variables";
 
-.settings-separator {
+#sr5-compendia-settings .settings-separator {
     margin: 1.5em 0 1em 0;
     border: none;
-    border-top: 2px solid variables.$light;
+    border-top: 2px solid var(--color-border-light-primary, variables.$dark);
 }
 
-.settings-section-header {
+#sr5-compendia-settings .settings-section-header {
     margin: 0.5em 0 1em 0;
-    color: variables.$light;
+    color: var(--color-text-primary, variables.$dark2);
     font-weight: bold;
     font-size: 1.1em;
 }


### PR DESCRIPTION
Fixes #2030

### Overview

CSS styling was using out dated assumptions about classic one mode theming instead of using light / dark primary colors.