### PR TITLE
[BUG] Actor sheet footer layout breaks in edit mode

### DIFF
--- a/src/module/actor/sheets/SR5BaseActorSheet.ts
+++ b/src/module/actor/sheets/SR5BaseActorSheet.ts
@@ -302,7 +302,7 @@ export class SR5BaseActorSheet<T extends SR5ActorSheetData = SR5ActorSheetData> 
     static override DEFAULT_OPTIONS: DeepPartial<SR5ApplicationMixinTypes.Configuration> = {
         classes: ['actor', 'named-sheet'],
         position: {
-            width: 700,
+            width: 770,
             height: 600,
         },
         actions: {


### PR DESCRIPTION
Fixes #2031

### Overview

Footer elements worked in play mode but not in edit mode, due to the armor total value added a version back, causing edit mode input elements to wrap with the limited space of 700 px width.

Raised all sheet sizes to a minium of 770 px instead.