### PR TITLE
[BUG] Restarting the matrix device while having a marked target icon selected keeps target selection active

### DIFF
--- a/src/module/actor/sheets/SR5MatrixActorSheet.ts
+++ b/src/module/actor/sheets/SR5MatrixActorSheet.ts
@@ -313,6 +313,10 @@ export class SR5MatrixActorSheet<T extends MatrixActorSheetData = MatrixActorShe
      */
     static async #rebootPersonaDevice(this: SR5MatrixActorSheet) {
         await MatrixSheetFlow.promptRebootPersonaDevice(this.actor);
+        // Avoid stale target selection, mostly for marked icons. Will also remove non-marked selections.
+        this.toggleMatrixTargetSelection(undefined);
+
+        void this.render();
     }
 
     /**


### PR DESCRIPTION
Fixes #2032

### Overview

Restarting the matrix device removes marks. When a marked icon is selected, this selection stays as it is sheet local behavior, while removing marks is related to the actor and global storage instead.

This will remove all target selections when restarting, even if it wouldn't remove visibilty of a selection.