### PR TITLE
[BUG] Hot Sim modifier still applies on matrix tests after switching initiative back to meatspace

### DIFF
--- a/src/module/actor/SR5Actor.ts
+++ b/src/module/actor/SR5Actor.ts
@@ -1570,7 +1570,9 @@ export class SR5Actor<SubType extends Actor.ConfiguredSubType = Actor.Configured
         const updateData = {
             system: {
                 initiative: { perception: isMatrixMode ? 'matrix' : mode },
-                ...(isMatrixMode && { matrix: { hot_sim: mode === 'hot_sim' } }),
+                // Setting hot-sim to false is necessary even if new ini mode is non-matrix.
+                // Otherwise matrix modifiers will still apply when in non-matrix mode.
+                ...(this.system.matrix && { matrix: { hot_sim: mode === 'hot_sim' } }),
             },
         } as const;
 

--- a/src/unittests/sr5.CharacterDataPrep.spec.ts
+++ b/src/unittests/sr5.CharacterDataPrep.spec.ts
@@ -327,6 +327,21 @@ export const shadowrunSR5CharacterDataPrep = (context: QuenchBatchContext) => {
             assert.strictEqual(character.system.initiative.matrix.dice.value, 3);
         });
 
+        it('clears hot-sim when switching to non-matrix initiative mode', async () => {
+            const character = await factory.createActor({
+                type: 'character',
+                system: {
+                    initiative: { perception: 'matrix' },
+                    matrix: { hot_sim: true },
+                },
+            });
+
+            await character.setInitiativeMode('meatspace');
+
+            assert.strictEqual(character.system.initiative.perception, 'meatspace');
+            assert.strictEqual(character.system.matrix.hot_sim, false);
+        });
+
         it('limit calculation', async () => {
             const character = await factory.createActor({
                 type: 'character',


### PR DESCRIPTION
Fixes #2033

### Overview

When setting a initiative and perception mode, the previous implementaiton only set `hot_sim` when the target mode was matrix based. As non-matrix modes (like meatspace) must still set it to `false`, as it might have been `true` before, the `hot_sim` property must always be set, so long as the actor in question is a matrix actor.

The bug came from the `...(a && b)` JavaScript object spread syntax resolving to `...false` when `a` is `false`, causing the object spread to abort quietly. Only when `a == true` does `b` evaluate and is used as the spread value of the returning sub expression.