### PR TITLE
[Bug] Fixes visual issues for the extend test and time control applications 

### DIFF
--- a/src/css/extended-test-manager.scss
+++ b/src/css/extended-test-manager.scss
@@ -21,6 +21,22 @@
     --etm-table-alt: var(--sr5v2-bg-subtle);
 }
 
+.sr5v2.extended-test-manager {
+    .window-header {
+        background: var(--sr5v2-app-header-bg);
+        background-repeat: repeat;
+        background-size: 100% 20px auto;
+        border-bottom: 1px solid var(--sr5v2-border);
+        color: var(--sr5v2-text-primary);
+    }
+
+    .window-content {
+        background: var(--sr5v2-option-bg);
+        background-image: none;
+        color: var(--sr5v2-text-primary);
+    }
+}
+
 .sr5.extended-test-manager {
     // Below this the toolbar wraps and the row value tracks start colliding with the
     // name column. ApplicationV2._updatePosition clamps dragging to the computed value.
@@ -37,9 +53,14 @@
             flex-flow: row nowrap;
             align-items: center;
             justify-content: space-between;
+            width: calc(100% + 0.5rem);
+            margin: 0 -0.25rem;
             gap: 0.5em;
             padding: 0.25em 0.5em;
             border-bottom: 1px solid var(--etm-border-strong);
+            background: var(--sr5v2-app-header-bg);
+            background-repeat: repeat;
+            background-size: 100% 20px auto;
 
             .etm-time-current {
                 font-weight: bold;

--- a/src/css/extended-test-manager.scss
+++ b/src/css/extended-test-manager.scss
@@ -225,7 +225,7 @@
                 .etm-row-values {
                     display: grid;
                     grid-template-columns: 7.5em 8em 3.5em;
-                    align-items: center;
+                    align-items: baseline;
                     gap: 0.6em;
                     white-space: nowrap;
                     font-size: var(--font-size-12);

--- a/src/css/extended-test-manager.scss
+++ b/src/css/extended-test-manager.scss
@@ -1,6 +1,26 @@
 @use 'config/variables';
 @use 'config/mixins';
 
+.sr5v2.extended-test-manager,
+.sr5v2.extended-test-config {
+    --etm-text: var(--sr5v2-text-primary);
+    --etm-text-secondary: var(--sr5v2-text-secondary);
+    --etm-text-muted: var(--sr5v2-text-muted);
+    --etm-label: var(--sr5v2-label);
+    --etm-border: var(--sr5v2-border);
+    --etm-border-strong: var(--sr5v2-border-strong);
+    --etm-row-bg: var(--sr5v2-bg-subtle);
+    --etm-surface: var(--sr5v2-control-bg);
+    --etm-surface-strong: var(--sr5v2-control-bg-strong);
+    --etm-input-text: var(--sr5v2-control-text);
+    --etm-input-bg: var(--sr5v2-control-bg-strong);
+    --etm-hover-bg: var(--sr5v2-button-hover-bg);
+    --etm-hover-text: var(--sr5v2-button-hover-text);
+    --etm-positive: var(--sr5v2-positive);
+    --etm-negative: var(--sr5v2-negative);
+    --etm-table-alt: var(--sr5v2-bg-subtle);
+}
+
 .sr5.extended-test-manager {
     // Below this the toolbar wraps and the row value tracks start colliding with the
     // name column. ApplicationV2._updatePosition clamps dragging to the computed value.
@@ -10,7 +30,7 @@
         display: flex;
         flex-flow: column nowrap;
         height: 100%;
-        color: variables.$white;
+        color: var(--etm-text);
 
         .etm-time-strip {
             display: flex;
@@ -19,11 +39,11 @@
             justify-content: space-between;
             gap: 0.5em;
             padding: 0.25em 0.5em;
-            border-bottom: 1px solid variables.$yellow;
+            border-bottom: 1px solid var(--etm-border-strong);
 
             .etm-time-current {
                 font-weight: bold;
-                color: variables.$yellow;
+                color: var(--etm-label);
                 white-space: nowrap;
             }
 
@@ -78,7 +98,9 @@
                 min-width: 12em;
                 height: 1.8em;
                 font-size: var(--font-size-12);
-                color: variables.$white;
+                color: var(--etm-input-text);
+                background: var(--etm-input-bg);
+                border: 1px solid var(--etm-border);
             }
 
             .etm-mine-filter {
@@ -86,6 +108,7 @@
                 align-items: center;
                 gap: 0.2em;
                 white-space: nowrap;
+                color: var(--etm-text-secondary);
             }
 
             button {
@@ -102,8 +125,8 @@
 
             // Flag a filter hidden behind the collapsed summary.
             .etm-filter-count {
-                background: variables.$yellow;
-                color: variables.$black;
+                background: var(--etm-label);
+                color: var(--sr5v2-text-inverse);
                 border-radius: 1em;
                 padding: 0 0.45em;
                 font-size: var(--font-size-12);
@@ -117,7 +140,7 @@
                 label {
                     display: flex;
                     flex-flow: column nowrap;
-                    color: variables.$grey;
+                    color: var(--etm-text-secondary);
                 }
 
                 select {
@@ -133,22 +156,22 @@
 
             .etm-empty {
                 text-align: center;
-                color: variables.$grey;
+                color: var(--etm-text-muted);
                 margin-top: 2em;
             }
 
             .etm-row {
-                border: variables.$groove;
+                border: 1px solid var(--etm-border);
                 border-radius: 0.3em;
                 margin-bottom: 0.35em;
                 padding: 0.35em 0.5em;
-                background: rgba(variables.$white, 0.03);
+                background: var(--etm-row-bg);
 
-                &.status-completed { border-left: 3px solid green; }
-                &.status-failed { border-left: 3px solid variables.$crimson; }
-                &.status-paused { border-left: 3px solid variables.$grey; }
-                &.status-cancelled { border-left: 3px solid variables.$grey; opacity: 0.7; }
-                &.status-active { border-left: 3px solid variables.$yellow; }
+                &.status-completed { border-left: 3px solid var(--etm-positive); }
+                &.status-failed { border-left: 3px solid var(--etm-negative); }
+                &.status-paused { border-left: 3px solid var(--etm-text-muted); }
+                &.status-cancelled { border-left: 3px solid var(--etm-text-muted); opacity: 0.7; }
+                &.status-active { border-left: 3px solid var(--etm-label); }
 
                 // Fixed tracks, so values and actions line up across rows of differing content.
                 .etm-row-main {
@@ -173,7 +196,7 @@
                         flex-flow: row wrap;
                         gap: 0.75em;
                         font-size: var(--font-size-12);
-                        color: variables.$grey;
+                        color: var(--etm-text-muted);
 
                         a {
                             @include mixins.rollable;
@@ -185,15 +208,15 @@
                     text-transform: uppercase;
                     font-weight: bold;
 
-                    &.etm-status-active { color: variables.$yellow; }
-                    &.etm-status-completed { color: green; }
-                    &.etm-status-failed { color: variables.$crimson; }
-                    &.etm-status-paused { color: variables.$grey; }
-                    &.etm-status-cancelled { color: variables.$grey; }
+                    &.etm-status-active { color: var(--etm-label); }
+                    &.etm-status-completed { color: var(--etm-positive); }
+                    &.etm-status-failed { color: var(--etm-negative); }
+                    &.etm-status-paused { color: var(--etm-text-muted); }
+                    &.etm-status-cancelled { color: var(--etm-text-muted); }
                 }
 
                 .etm-due {
-                    color: variables.$crimson;
+                    color: var(--etm-negative);
                     font-weight: bold;
                 }
 
@@ -269,7 +292,7 @@
                 }
 
                 .etm-row-details {
-                    border-top: 1px solid rgba(variables.$white, 0.15);
+                    border-top: 1px solid var(--etm-border);
                     margin-top: 0.35em;
                     padding-top: 0.35em;
                     font-size: var(--font-size-12);
@@ -278,7 +301,7 @@
                         display: flex;
                         flex-flow: row wrap;
                         gap: 1.5em;
-                        color: variables.$grey;
+                        color: var(--etm-text-muted);
                         margin-bottom: 0.3em;
                     }
 
@@ -299,12 +322,12 @@
                     .etm-log {
                         @include mixins.collapsible;
 
-                        color: variables.$grey;
+                        color: var(--etm-text-muted);
                         font-size: var(--font-size-12);
 
                         // The entry count stands in for the body while collapsed.
                         .etm-log-count {
-                            border: variables.$groove;
+                            border: 1px solid var(--etm-border);
                             border-radius: 1em;
                             padding: 0 0.45em;
                         }
@@ -321,6 +344,113 @@
                 }
             }
         }
+    }
+}
+
+body.theme-light .sr5v2.extended-test-manager:not(.theme-dark),
+.sr5v2.extended-test-manager.theme-light {
+    color-scheme: light;
+
+    .window-header {
+        background: var(--sr5v2-app-header-bg);
+        border-bottom: 1px solid var(--sr5v2-border);
+        color: var(--sr5v2-text-primary);
+
+        .window-title,
+        .header-control,
+        i,
+        button {
+            color: var(--sr5v2-text-primary);
+        }
+    }
+
+    .window-content {
+        background: var(--sr5v2-content-bg);
+        background-repeat: repeat;
+        background-size: 100% 20px auto;
+        color: var(--sr5v2-text-primary);
+    }
+
+    button,
+    input,
+    select,
+    textarea,
+    progress,
+    summary,
+    label,
+    .etm-row-name,
+    .etm-row-meta,
+    .etm-row-meta a,
+    .etm-row-meta span,
+    .etm-status,
+    .etm-due,
+    .etm-progress-text,
+    .etm-value,
+    .etm-value-number,
+    .etm-value-unit,
+    .etm-detail-meta,
+    .etm-log,
+    .etm-log-entry,
+    .etm-empty,
+    .etm-action-disabled,
+    .etm-action-empty,
+    .etm-row-actions a,
+    .etm-row-actions span,
+    .etm-row-actions i,
+    .etm-roll-history,
+    .etm-roll-history th,
+    .etm-roll-history td,
+    .etm-row-info a,
+    .etm-row-info span,
+    .etm-mine-filter,
+    .etm-time-current,
+    .etm-time-presets button,
+    .etm-advanced-filter-fields label,
+    .etm-config-form label,
+    .etm-config-form input,
+    .etm-config-form select,
+    .etm-config-form textarea,
+    .etm-config-form legend,
+    .etm-config-form .hint {
+        color: var(--sr5v2-text-primary);
+    }
+
+    i,
+    svg,
+    .fa,
+    .fas,
+    .far,
+    .fab {
+        color: var(--sr5v2-text-primary);
+    }
+
+    .etm-filter-count {
+        color: var(--sr5v2-text-inverse);
+    }
+
+    button,
+    input,
+    select,
+    textarea,
+    progress,
+    summary {
+        color-scheme: light;
+    }
+
+    select,
+    input[type='search'],
+    input[type='text'],
+    input[type='number'],
+    textarea {
+        color: var(--sr5v2-control-text);
+        background: var(--sr5v2-control-bg-strong);
+        border-color: var(--sr5v2-control-border);
+    }
+
+    button {
+        color: var(--sr5v2-button-text);
+        background: var(--sr5v2-button-bg);
+        border-color: var(--sr5v2-button-border);
     }
 }
 
@@ -343,12 +473,12 @@
         flex-flow: column nowrap;
         gap: 0.6em;
         padding: 0.5em;
-        color: variables.$white;
+        color: var(--etm-text);
 
         // Section heading, shared by the fieldset legends and the collapsible summary.
         @mixin section-heading {
             font-weight: bold;
-            color: variables.$yellow;
+            color: var(--etm-label);
             text-transform: uppercase;
             font-size: var(--font-size-12);
             letter-spacing: 0.05em;
@@ -367,7 +497,7 @@
         }
 
         .etm-config-section {
-            border: variables.$groove;
+            border: 1px solid var(--etm-border);
             border-radius: 0.3em;
             padding: 0.5em 0.6em 0.6em;
             margin: 0;
@@ -407,7 +537,9 @@
             }
 
             input, select, textarea {
-                color: variables.$white;
+                color: var(--etm-input-text);
+                background: var(--etm-input-bg);
+                border: 1px solid var(--etm-border);
                 min-width: 0;
             }
 
@@ -463,7 +595,7 @@
 
         .hint {
             font-size: var(--font-size-12);
-            color: variables.$grey;
+            color: var(--etm-text-muted);
             margin: 0;
         }
 
@@ -479,7 +611,7 @@
 
                 th {
                     font-size: var(--font-size-12);
-                    color: variables.$grey;
+                    color: var(--etm-text-muted);
                     text-transform: uppercase;
                 }
 
@@ -488,7 +620,7 @@
                 }
 
                 tbody tr:nth-child(odd) {
-                    background: rgba(variables.$white, 0.04);
+                    background: var(--etm-table-alt);
                 }
             }
         }
@@ -506,7 +638,7 @@
 
             .etm-config-submit {
                 font-weight: bold;
-                border-color: variables.$yellow;
+                border-color: var(--etm-label);
             }
         }
     }

--- a/src/css/time-control.scss
+++ b/src/css/time-control.scss
@@ -1,13 +1,38 @@
-@use 'config/variables';
 @use 'config/mixins';
 
-.sr5.time-control {
+.sr5v2.time-control {
+    color-scheme: dark;
+    background: var(--sr5v2-surface-bg);
+    background-repeat: repeat;
+    background-size: 100% 20px auto;
+    color: var(--sr5v2-text-primary);
+
+    .window-header {
+        background: var(--sr5v2-app-header-bg);
+        border-bottom: 1px solid var(--sr5v2-border);
+        color: var(--sr5v2-text-primary);
+
+        .window-title,
+        .header-control,
+        i,
+        button {
+            color: var(--sr5v2-text-primary);
+        }
+    }
+
+    .window-content {
+        background: var(--sr5v2-content-bg);
+        background-repeat: repeat;
+        background-size: 100% 20px auto;
+        color: var(--sr5v2-text-primary);
+    }
+
     .time-control-app {
         display: flex;
         flex-flow: column nowrap;
         gap: 0.5em;
         padding: 0.5em;
-        color: variables.$white;
+        color: var(--sr5v2-text-primary);
 
         .time-control-current {
             display: flex;
@@ -16,16 +41,24 @@
             gap: 0.5em;
             font-size: var(--font-size-18);
             font-weight: bold;
-            color: variables.$yellow;
+            color: var(--sr5v2-label);
             padding: 0.25em;
         }
 
         .time-control-panel {
             @include mixins.collapsible;
 
-            border: variables.$groove;
+            border: 1px solid var(--sr5v2-border);
             border-radius: 0.3em;
             padding: 0.5em;
+
+            summary {
+                color: var(--sr5v2-text-primary);
+
+                i {
+                    color: var(--sr5v2-label);
+                }
+            }
         }
 
         .time-preset-grid {
@@ -45,7 +78,6 @@
 
             input {
                 width: 5em;
-                color: variables.$white;
             }
 
             select {
@@ -62,10 +94,6 @@
                 display: flex;
                 flex-flow: column nowrap;
                 font-size: var(--font-size-11);
-
-                input {
-                    color: variables.$white;
-                }
             }
         }
 
@@ -83,13 +111,45 @@
         .time-control-preview {
             margin-top: 0.4em;
             font-size: var(--font-size-12);
-            color: variables.$grey;
+            color: var(--sr5v2-text-muted);
 
             .time-shift-preview,
             .time-absolute-preview {
-                color: variables.$yellow;
+                color: var(--sr5v2-label);
                 font-weight: bold;
             }
         }
+
+        input,
+        select {
+            color: var(--sr5v2-control-text);
+            background: var(--sr5v2-control-bg);
+            border-color: var(--sr5v2-control-border);
+        }
+
+        select {
+            option,
+            optgroup {
+                color: var(--sr5v2-option-text);
+                background: var(--sr5v2-option-bg);
+            }
+        }
+
+        button {
+            color: var(--sr5v2-button-text);
+            border-color: var(--sr5v2-button-border);
+            background: var(--sr5v2-button-bg);
+
+            &:not(:disabled):hover {
+                color: var(--sr5v2-button-hover-text);
+                border-color: var(--sr5v2-button-hover-border);
+                background: var(--sr5v2-button-hover-bg);
+            }
+        }
     }
+}
+
+body.theme-light .sr5v2.time-control:not(.theme-dark),
+.sr5v2.time-control.theme-light {
+    color-scheme: light;
 }

--- a/src/css/time-control.scss
+++ b/src/css/time-control.scss
@@ -2,9 +2,8 @@
 
 .sr5v2.time-control {
     color-scheme: dark;
-    background: var(--sr5v2-surface-bg);
-    background-repeat: repeat;
-    background-size: 100% 20px auto;
+    background: var(--sr5v2-option-bg);
+    background-image: none;
     color: var(--sr5v2-text-primary);
 
     .window-header {
@@ -21,9 +20,8 @@
     }
 
     .window-content {
-        background: var(--sr5v2-content-bg);
-        background-repeat: repeat;
-        background-size: 100% 20px auto;
+        background: var(--sr5v2-option-bg);
+        background-image: none;
         color: var(--sr5v2-text-primary);
     }
 

--- a/src/module/apps/ExtendedTestManager.ts
+++ b/src/module/apps/ExtendedTestManager.ts
@@ -323,7 +323,7 @@ export class ExtendedTestManager extends HandlebarsApplicationMixin(ApplicationV
             intervalsElapsed: ExtendedTestRules.intervalsElapsed(record, worldTime),
             isDue: ExtendedTestRules.isDue(record, worldTime),
             createdGameTime: WorldTimeFlow.format(record.createdWorldTime),
-            updatedRealTime: new Date(record.updatedAt).toLocaleString(),
+            updatedRealTime: WorldTimeFlow.formatRealTime(record.updatedAt),
             canRoll,
             rollBlockedByInterval: mayRoll && canContinue && !intervalAllowsRoll,
             canEdit,
@@ -341,7 +341,7 @@ export class ExtendedTestManager extends HandlebarsApplicationMixin(ApplicationV
                 glitch: roll.glitch,
                 criticalGlitch: roll.criticalGlitch,
                 poolUsed: roll.poolUsed,
-                realTime: new Date(roll.timestamp).toLocaleString(),
+                realTime: WorldTimeFlow.formatRealTime(roll.timestamp),
                 gameTime: WorldTimeFlow.format(roll.worldTime),
                 messageUuid: roll.messageUuid,
                 userName: userName(roll.userId),
@@ -349,7 +349,7 @@ export class ExtendedTestManager extends HandlebarsApplicationMixin(ApplicationV
             log: expanded ? record.log.map(entry => ({
                 actionLabel: game.i18n.localize(`SR5.ExtendedTestManager.Log.${entry.action}` as Parameters<typeof game.i18n.localize>[0]),
                 detail: entry.detail,
-                realTime: new Date(entry.timestamp).toLocaleString(),
+                realTime: WorldTimeFlow.formatRealTime(entry.timestamp),
                 userName: userName(entry.userId),
             })) : [],
         };

--- a/src/module/apps/gmtools/TimeControlApplication.ts
+++ b/src/module/apps/gmtools/TimeControlApplication.ts
@@ -88,7 +88,7 @@ export class TimeControlApplication extends HandlebarsApplicationMixin(Applicati
             label: game.i18n.localize(preset.labelKey as Parameters<typeof game.i18n.localize>[0]),
         }));
 
-        const components = WorldTimeFlow.components();
+        const components = WorldTimeFlow.displayComponents();
         context.components = {
             year: components.year,
             // Display month and day of month as 1-based values.
@@ -139,7 +139,7 @@ export class TimeControlApplication extends HandlebarsApplicationMixin(Applicati
         const fields = this.element?.querySelector<HTMLElement>('.time-absolute-fields');
         if (!fields || fields.contains(document.activeElement)) return;
 
-        const components = WorldTimeFlow.components();
+        const components = WorldTimeFlow.displayComponents();
         const values: Record<string, number> = {
             year: components.year,
             // Month and day of month are displayed as 1-based values.

--- a/src/module/flows/WorldTimeFlow.ts
+++ b/src/module/flows/WorldTimeFlow.ts
@@ -89,6 +89,21 @@ export const WorldTimeFlow = {
     },
 
     /**
+     * Calendar components for display, with fractional seconds removed without changing
+     * the underlying world time.
+     */
+    displayComponents(worldTime: number = game.time.worldTime): foundry.data.CalendarData.TimeComponents {
+        return WorldTimeFlow.components(WorldTimeFlow.floorToSecond(worldTime));
+    },
+
+    /**
+     * Truncate a time value expressed in seconds to the start of its current second.
+     */
+    floorToSecond(seconds: number): number {
+        return Math.floor(seconds);
+    },
+
+    /**
      * Convert absolute calendar components, as displayed, into world time seconds.
      *
      * NOTE: CalendarData#componentsToTime ignores month and dayOfMonth, which would place
@@ -129,11 +144,19 @@ export const WorldTimeFlow = {
      * Mirrors CalendarData.formatTimestamp, which prints the unshifted year.
      */
     format(worldTime: number = game.time.worldTime): string {
-        const { year, month, dayOfMonth, hour, minute, second } = WorldTimeFlow.components(worldTime);
+        const { year, month, dayOfMonth, hour, minute, second } = WorldTimeFlow.displayComponents(worldTime);
         const ordinal = game.time.calendar.months?.values?.[month]?.ordinal ?? month + 1;
 
         const pad = (value: number, length = 2) => String(value).padStart(length, '0');
         return `${pad(year, 4)}-${pad(ordinal)}-${pad(dayOfMonth + 1)} ${pad(hour)}:${pad(minute)}:${pad(second)}`;
+    },
+
+    /**
+     * Format a real-time timestamp for display without showing milliseconds.
+     */
+    formatRealTime(timestamp: number = Date.now()): string {
+        const wholeSeconds = WorldTimeFlow.floorToSecond(timestamp / 1000);
+        return new Date(wholeSeconds * 1000).toLocaleString();
     },
 
     /**

--- a/src/module/flows/WorldTimeFlow.ts
+++ b/src/module/flows/WorldTimeFlow.ts
@@ -89,15 +89,15 @@ export const WorldTimeFlow = {
     },
 
     /**
-     * Calendar components for display, with fractional seconds removed without changing
-     * the underlying world time.
+     * Calendar components for display, with fractional seconds floored for formatting
+     * without modifying the stored world time.
      */
     displayComponents(worldTime: number = game.time.worldTime): foundry.data.CalendarData.TimeComponents {
         return WorldTimeFlow.components(WorldTimeFlow.floorToSecond(worldTime));
     },
 
     /**
-     * Truncate a time value expressed in seconds to the start of its current second.
+     * Floor a time value expressed in seconds to the start of its current second.
      */
     floorToSecond(seconds: number): number {
         return Math.floor(seconds);


### PR DESCRIPTION
## Overview of fixed issues as taken from discord

* [x] (tamif) Test and Time mangers both only have dark mode (Screenshot 1)
* [x] (tamif) Test manager uses noisy dark theme background for whole window instead of header section only, like other apps
* [x] (tamif) time stamps can render down to sub microseconds (at least for Game Time)
* [x] (tamif) Hits counter for an extended test in the manager is vertically offset to the other elements in its line (screenshot 2)

The only logic change was necessary for world time display of fractions of a second.

Note: CSS Changes are made by AI only.